### PR TITLE
Fix for issue #11 : Lip sync does not work in some cases

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMMotions/FingerAnimator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMMotions/FingerAnimator.cs
@@ -103,7 +103,10 @@ namespace Baku.VMagicMirror
                 float angle = (i < 5) ? defaultBendingAngle : -defaultBendingAngle;
                 for (int j = 0; j < _fingers[i].Length; j++)
                 {
-                    _fingers[i][j].localRotation = Quaternion.AngleAxis(angle, Vector3.forward);
+                    if (_fingers[i][j] != null)
+                    {
+                        _fingers[i][j].localRotation = Quaternion.AngleAxis(angle, Vector3.forward);
+                    }
                 }
             }
 
@@ -158,7 +161,10 @@ namespace Baku.VMagicMirror
 
                 foreach(var t in _fingers[i])
                 {
-                    t.localRotation = Quaternion.AngleAxis(angle, Vector3.forward);
+                    if (t != null)
+                    {
+                        t.localRotation = Quaternion.AngleAxis(angle, Vector3.forward);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #11 for the case of VRM without some of the finger bones.

## How it fixes the issue

Before this PR, VRM setup was aborted with `NullReferenceException`, by accessing not-existing finger bone's rotation. As a result, lip sync component setup was skipped.

This PR guards `NullReferenceException` to load lip sync component correctly.

## NOTE

VRM specification allows model without some of the finger bones, so this fix strictly obeys to the VRM specification itself.

[Specification](https://dwango.github.io/vrm/vrm_spec/#fn:notrequired)
