### PR TITLE
feature/shadow on screen

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Materials.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0c85d29538800e45bd6798f451185cd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Materials/ShadowBoard.mat
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Materials/ShadowBoard.mat
@@ -1,0 +1,77 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ShadowBoard
+  m_Shader: {fileID: 4800000, guid: 044df1d3ff3d91a43815273fde94c8eb, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Materials/ShadowBoard.mat.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Materials/ShadowBoard.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d32d0e3d3dd69d843a3f109ba852af7b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -267,10 +267,9 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 148983026}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.22341412, y: 0.8723679, z: -1.3522048}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 2141451818}
   - {fileID: 749678941}
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -288,6 +287,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mainLight: {fileID: 2141451817}
+  mainLightLocalEulerAngle: {x: 50, y: -30, z: 0}
+  shadowLight: {fileID: 1971722878}
+  shadowLightLocalEulerAngle: {x: 15, y: -30, z: 0}
+  shadowBoardMotion: {fileID: 1057131357}
   postProcess: {fileID: 749678942}
   handler: {fileID: 1930233619}
 --- !u!1 &161296353
@@ -1004,7 +1007,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 148983027}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &749678942
 MonoBehaviour:
@@ -1313,6 +1316,112 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1057131352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1057131356}
+  - component: {fileID: 1057131355}
+  - component: {fileID: 1057131354}
+  - component: {fileID: 1057131353}
+  - component: {fileID: 1057131357}
+  m_Layer: 0
+  m_Name: ShadowBoard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &1057131353
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057131352}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1057131354
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057131352}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d32d0e3d3dd69d843a3f109ba852af7b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1057131355
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057131352}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1057131356
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057131352}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.5}
+  m_LocalScale: {x: 8, y: 8, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1629460662}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!114 &1057131357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057131352}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c576c1d95adf15e4798e96b11c05b941, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 1629460662}
 --- !u!1 &1134663115
 GameObject:
   m_ObjectHideFlags: 0
@@ -2135,7 +2244,10 @@ Transform:
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
   m_LocalPosition: {x: 0, y: 1, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 2141451818}
+  - {fileID: 1971722877}
+  - {fileID: 1057131356}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
@@ -3208,6 +3320,75 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 40, z: 0}
+--- !u!1 &1971722876
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1971722877}
+  - component: {fileID: 1971722878}
+  m_Layer: 0
+  m_Name: ShadowLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1971722877
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971722876}
+  m_LocalRotation: {x: 0.12607859, y: -0.2566048, z: 0.03378265, w: 0.9576622}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1629460662}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 15, y: -30, z: 0}
+--- !u!108 &1971722878
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971722876}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: 2
+    m_CustomResolution: -1
+    m_Strength: 0.6
+    m_Bias: 0.05
+    m_NormalBias: 0.2
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
 --- !u!1 &2059529784
 GameObject:
   m_ObjectHideFlags: 0
@@ -3309,7 +3490,7 @@ GameObject:
   - component: {fileID: 2141451818}
   - component: {fileID: 2141451817}
   m_Layer: 0
-  m_Name: Directional Light
+  m_Name: MainLight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3360,13 +3541,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2141451816}
-  m_LocalRotation: {x: -0.109381616, y: -0.8754262, z: 0.40821788, w: -0.23456965}
-  m_LocalPosition: {x: -0.22341412, y: 2.1276321, z: 1.3522048}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456976, z: 0.10938167, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 148983027}
+  m_Father: {fileID: 1629460662}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 50, y: -210, z: 0}
+  m_LocalEulerAnglesHint: {x: 50.000004, y: 150, z: 0}
 --- !u!1 &1516791124313086
 GameObject:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/LightingController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UniRx;
+﻿using UniRx;
 using UnityEngine;
 using UnityEngine.Rendering.PostProcessing;
 
@@ -11,15 +10,29 @@ namespace Baku.VMagicMirror
         private Light mainLight = null;
 
         [SerializeField]
+        private Vector3 mainLightLocalEulerAngle;
+
+        [SerializeField]
+        private Light shadowLight = null;
+
+        [SerializeField]
+        private Vector3 shadowLightLocalEulerAngle;
+
+        [SerializeField]
+        private ShadowBoardMotion shadowBoardMotion = null;
+
+        [SerializeField]
         private PostProcessVolume postProcess = null;
 
         [SerializeField]
         private ReceivedMessageHandler handler = null;
 
+
         private Bloom _bloom;
 
         private void Start()
         {
+
             _bloom = postProcess.profile.GetSetting<Bloom>();
 
             handler.Commands.Subscribe(message =>
@@ -32,6 +45,27 @@ namespace Baku.VMagicMirror
                     case MessageCommandNames.LightColor:
                         float[] lightRgb = message.ToColorFloats();
                         SetLightColor(lightRgb[0], lightRgb[1], lightRgb[2]);
+                        break;
+                    case MessageCommandNames.LightYaw:
+                        SetLightYaw(message.ToInt());
+                        break;
+                    case MessageCommandNames.LightPitch:
+                        SetLightPitch(message.ToInt());
+                        break;
+                    case MessageCommandNames.ShadowEnable:
+                        EnableShadow(message.ToBoolean());
+                        break;
+                    case MessageCommandNames.ShadowIntensity:
+                        SetShadowIntensity(message.ParseAsPercentage());
+                        break;
+                    case MessageCommandNames.ShadowYaw:
+                        SetShadowYaw(message.ToInt());
+                        break;
+                    case MessageCommandNames.ShadowPitch:
+                        SetShadowPitch(message.ToInt());
+                        break;
+                    case MessageCommandNames.ShadowDepthOffset:
+                        SetShadowDepthOffset(message.ParseAsCentimeter());
                         break;
                     case MessageCommandNames.BloomIntensity:
                         SetBloomIntensity(message.ParseAsPercentage());
@@ -54,6 +88,58 @@ namespace Baku.VMagicMirror
 
         private void SetLightIntensity(float intensity)
             => mainLight.intensity = intensity;
+
+        private void SetLightYaw(int yawDeg)
+        {
+            mainLightLocalEulerAngle = new Vector3(
+                mainLightLocalEulerAngle.x,
+                yawDeg,
+                mainLightLocalEulerAngle.z
+                );
+            mainLight.transform.localEulerAngles = mainLightLocalEulerAngle;
+        }
+
+        private void SetLightPitch(int pitchDeg)
+        {
+            mainLightLocalEulerAngle = new Vector3(
+                pitchDeg,
+                mainLightLocalEulerAngle.y,
+                mainLightLocalEulerAngle.z
+                );
+            mainLight.transform.localEulerAngles = mainLightLocalEulerAngle;
+        }
+
+        private void EnableShadow(bool enable)
+            => shadowLight.enabled = enable;
+
+        private void SetShadowIntensity(float shadowStrength)
+        {
+            shadowLight.shadowStrength = shadowStrength;
+        }
+
+        private void SetShadowYaw(int yawDeg)
+        {
+            shadowLightLocalEulerAngle = new Vector3(
+                shadowLightLocalEulerAngle.x,
+                yawDeg,
+                shadowLightLocalEulerAngle.z
+                );
+            shadowLight.transform.localEulerAngles = shadowLightLocalEulerAngle;
+        }
+
+        private void SetShadowPitch(int pitchDeg)
+        {
+            shadowLightLocalEulerAngle = new Vector3(
+                pitchDeg,
+                shadowLightLocalEulerAngle.y,
+                shadowLightLocalEulerAngle.z
+                );
+            shadowLight.transform.localEulerAngles = shadowLightLocalEulerAngle;
+        }
+
+        private void SetShadowDepthOffset(float depthOffset) 
+            => shadowBoardMotion.ShadowBoardWaistDepthOffset = depthOffset;
+
 
         private void SetBloomColor(float r, float g, float b)
             => _bloom.color.value = new Color(r, g, b);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/ShadowBoardMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/ShadowBoardMotion.cs
@@ -1,0 +1,26 @@
+﻿using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public class ShadowBoardMotion : MonoBehaviour
+    {
+        [SerializeField]
+        Transform cam = null;
+
+        public float ShadowBoardWaistDepthOffset { get; set; } = 0.4f;
+
+        void Update()
+        {
+            //コード通りだが、以下のうち奥側に影の影ポリが来るようにしたい
+            // - 腰よりちょっと奥 : 正面～浅く見下ろした角度ではコレを使いたい
+            // - 足元 : 深く見下ろした角度ではコレを使いたい
+            float depthByWaist = 
+                cam.transform.InverseTransformPoint(new Vector3(0, 1, 0)).z +
+                ShadowBoardWaistDepthOffset;
+
+            float depthByFoot = cam.transform.InverseTransformPoint(Vector3.zero).z;
+
+            transform.localPosition = Mathf.Max(depthByWaist, depthByFoot) * Vector3.forward;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/ShadowBoardMotion.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/ShadowBoardMotion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c576c1d95adf15e4798e96b11c05b941
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
@@ -104,6 +104,15 @@
         // Lighting 
         public const string LightIntensity = nameof(LightIntensity);
         public const string LightColor = nameof(LightColor);
+        public const string LightYaw = nameof(LightYaw);
+        public const string LightPitch = nameof(LightPitch);
+
+        public const string ShadowEnable = nameof(ShadowEnable);
+        public const string ShadowIntensity = nameof(ShadowIntensity);
+        public const string ShadowYaw = nameof(ShadowYaw);
+        public const string ShadowPitch = nameof(ShadowPitch);
+        public const string ShadowDepthOffset = nameof(ShadowDepthOffset);
+
         public const string BloomIntensity = nameof(BloomIntensity);
         public const string BloomThreshold = nameof(BloomThreshold);
         public const string BloomColor = nameof(BloomColor);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10101ac875d5667438165105df244e07
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/ShadowDrawer.shader
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/ShadowDrawer.shader
@@ -1,0 +1,96 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+Shader "Custom/ShadowDrawer"
+{
+    Properties
+    {
+        _Color ("Shadow Color", Color) = (0, 0, 0, 0.6)
+    }
+
+    CGINCLUDE
+
+    #include "UnityCG.cginc"
+    #include "AutoLight.cginc"
+
+    struct v2f_shadow {
+        float4 pos : SV_POSITION;
+        LIGHTING_COORDS(0, 1)
+    };
+
+    half4 _Color;
+
+    v2f_shadow vert_shadow(appdata_full v)
+    {
+        v2f_shadow o;
+        o.pos = UnityObjectToClipPos(v.vertex);
+        TRANSFER_VERTEX_TO_FRAGMENT(o);
+        return o;
+    }
+
+    half4 frag_shadow(v2f_shadow IN) : SV_Target
+    {
+        half atten = LIGHT_ATTENUATION(IN);
+        return half4(_Color.rgb, lerp(_Color.a, 0, atten));
+    }
+
+    ENDCG
+
+    SubShader
+    {
+        Tags { "Queue"="AlphaTest+49" }
+
+        // Depth fill pass
+        Pass
+        {
+            ColorMask 0
+
+            CGPROGRAM
+
+            #pragma vertex vert
+            #pragma fragment frag
+
+            struct v2f {
+                float4 pos : SV_POSITION;
+            };
+
+            v2f vert(appdata_full v)
+            {
+                v2f o;
+                o.pos = UnityObjectToClipPos (v.vertex);
+                return o;
+            }
+
+            half4 frag(v2f IN) : SV_Target
+            {
+                return (half4)0;
+            }
+
+            ENDCG
+        }
+
+        // Forward base pass
+        Pass
+        {
+            Tags { "LightMode" = "ForwardBase" }
+            Blend SrcAlpha OneMinusSrcAlpha
+            CGPROGRAM
+            #pragma vertex vert_shadow
+            #pragma fragment frag_shadow
+            #pragma multi_compile_fwdbase
+            ENDCG
+        }
+
+        // Forward add pass
+        Pass
+        {
+            Tags { "LightMode" = "ForwardAdd" }
+            Blend SrcAlpha OneMinusSrcAlpha
+            CGPROGRAM
+            #pragma vertex vert_shadow
+            #pragma fragment frag_shadow
+            #pragma multi_compile_fwdadd_fullshadows
+            ENDCG
+        }
+    }
+    FallBack "Mobile/VertexLit"
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/ShadowDrawer.shader.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/ShadowDrawer.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 044df1d3ff3d91a43815273fde94c8eb
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
影を追加。以下、おおまかな実装内容。

* [このブログ記事](https://www.baku-dreameater.net/entry/2019/05/29/214332)のうち影に関する部分を導入
* 影ライトと通常の照明ライトを作り、いずれもカメラに固定
* 影描画用の板ポリもカメラに固定するが、板ポリのローカルZ(奥行き)についてはカメラの角度によって以下いずれかを用いる。
    * キャラのやや背後にずらしておく(プレゼンモード、正面向きで有効)
    * 足元にほぼ一致させる(キャラを見下ろして全身を映してる場合に有効)
