### PR TITLE
feature/rotate around character

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -208,74 +208,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetIpAddress: 127.0.0.1
   targetPort: 53242
---- !u!1 &161436640
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 161436643}
-  - component: {fileID: 161436642}
-  - component: {fileID: 161436641}
-  - component: {fileID: 161436644}
-  m_Layer: 9
-  m_Name: PresentationWall
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!64 &161436641
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 161436640}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!33 &161436642
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 161436640}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &161436643
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 161436640}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 5, y: 5, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &161436644
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 161436640}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3ff6fb558ada61d4a8e1a80ade7bdc8a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cam: {fileID: 1629460662}
 --- !u!1 &204388501
 GameObject:
   m_ObjectHideFlags: 0
@@ -353,7 +285,6 @@ GameObject:
   - component: {fileID: 402429507}
   - component: {fileID: 402429510}
   - component: {fileID: 402429509}
-  - component: {fileID: 402429508}
   m_Layer: 0
   m_Name: Up
   m_TagString: Untagged
@@ -375,20 +306,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &402429508
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 402429506}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &402429509
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -479,7 +396,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &500754460
 GameObject:
@@ -522,7 +439,6 @@ GameObject:
   - component: {fileID: 516414221}
   - component: {fileID: 516414224}
   - component: {fileID: 516414223}
-  - component: {fileID: 516414222}
   m_Layer: 0
   m_Name: Y
   m_TagString: Untagged
@@ -544,20 +460,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &516414222
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 516414220}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &516414223
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -614,7 +516,6 @@ GameObject:
   - component: {fileID: 525847741}
   - component: {fileID: 525847744}
   - component: {fileID: 525847743}
-  - component: {fileID: 525847742}
   m_Layer: 0
   m_Name: Right
   m_TagString: Untagged
@@ -636,20 +537,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &525847742
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 525847740}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &525847743
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -706,7 +593,6 @@ GameObject:
   - component: {fileID: 627282150}
   - component: {fileID: 627282153}
   - component: {fileID: 627282152}
-  - component: {fileID: 627282151}
   m_Layer: 0
   m_Name: B
   m_TagString: Untagged
@@ -728,20 +614,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &627282151
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 627282149}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &627282152
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -907,7 +779,6 @@ GameObject:
   - component: {fileID: 805620708}
   - component: {fileID: 805620711}
   - component: {fileID: 805620710}
-  - component: {fileID: 805620709}
   m_Layer: 0
   m_Name: LStick
   m_TagString: Untagged
@@ -929,20 +800,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &805620709
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 805620707}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &805620710
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1141,51 +998,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1010119728
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1010119730}
-  - component: {fileID: 1010119729}
-  m_Layer: 0
-  m_Name: PresentationBackgroundRoot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1010119729
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1010119728}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3ff6fb558ada61d4a8e1a80ade7bdc8a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cam: {fileID: 1629460662}
---- !u!4 &1010119730
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1010119728}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.05}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1843758875}
-  m_Father: {fileID: 0}
-  m_RootOrder: 17
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1057131352
 GameObject:
   m_ObjectHideFlags: 0
@@ -1197,7 +1009,6 @@ GameObject:
   - component: {fileID: 1057131356}
   - component: {fileID: 1057131355}
   - component: {fileID: 1057131354}
-  - component: {fileID: 1057131353}
   - component: {fileID: 1057131357}
   m_Layer: 0
   m_Name: ShadowBoard
@@ -1206,20 +1017,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!64 &1057131353
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1057131352}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &1057131354
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1514,7 +1311,6 @@ GameObject:
   - component: {fileID: 1374794598}
   - component: {fileID: 1374794601}
   - component: {fileID: 1374794600}
-  - component: {fileID: 1374794599}
   m_Layer: 0
   m_Name: A
   m_TagString: Untagged
@@ -1536,20 +1332,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &1374794599
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1374794597}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &1374794600
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1681,7 +1463,6 @@ GameObject:
   - component: {fileID: 1461652145}
   - component: {fileID: 1461652148}
   - component: {fileID: 1461652147}
-  - component: {fileID: 1461652146}
   m_Layer: 0
   m_Name: RStick
   m_TagString: Untagged
@@ -1703,20 +1484,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &1461652146
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1461652144}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &1461652147
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1847,7 +1614,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1534341280
 MonoBehaviour:
@@ -1912,7 +1679,6 @@ GameObject:
   - component: {fileID: 1581013137}
   - component: {fileID: 1581013140}
   - component: {fileID: 1581013139}
-  - component: {fileID: 1581013138}
   m_Layer: 0
   m_Name: X
   m_TagString: Untagged
@@ -1934,20 +1700,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &1581013138
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1581013136}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &1581013139
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -2258,7 +2010,6 @@ GameObject:
   - component: {fileID: 1687041056}
   - component: {fileID: 1687041059}
   - component: {fileID: 1687041058}
-  - component: {fileID: 1687041057}
   m_Layer: 0
   m_Name: Left
   m_TagString: Untagged
@@ -2280,20 +2031,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &1687041057
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687041055}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &1687041058
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -2350,7 +2087,6 @@ GameObject:
   - component: {fileID: 1708390758}
   - component: {fileID: 1708390761}
   - component: {fileID: 1708390760}
-  - component: {fileID: 1708390759}
   m_Layer: 0
   m_Name: Down
   m_TagString: Untagged
@@ -2372,20 +2108,6 @@ Transform:
   m_Father: {fileID: 1798368042}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!64 &1708390759
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1708390757}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!23 &1708390760
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -2732,97 +2454,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1674567171}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1843758871
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1843758875}
-  - component: {fileID: 1843758874}
-  - component: {fileID: 1843758873}
-  - component: {fileID: 1843758872}
-  m_Layer: 0
-  m_Name: PresentationBackground
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!65 &1843758872
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1843758871}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!23 &1843758873
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1843758871}
-  m_Enabled: 0
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1843758874
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1843758871}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &1843758875
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1843758871}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 10, z: 0.2}
-  m_Children: []
-  m_Father: {fileID: 1010119730}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1855229415
 GameObject:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RuntimeLayoutEdit/CameraTransformController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RuntimeLayoutEdit/CameraTransformController.cs
@@ -22,7 +22,14 @@ namespace Baku.VMagicMirror
         [SerializeField, Range(0.1f, 10f)]
         private float rotateSpeed = 0.3f;
 
+        private Camera _cam;
         private Vector3 preMousePos;
+        private Vector3 rotateCenterInThisAngleMove;
+
+        private void Start()
+        {
+            _cam = GetComponent<Camera>();
+        }
 
         private void Update()
         {
@@ -37,6 +44,11 @@ namespace Baku.VMagicMirror
                Input.GetMouseButtonDown(MiddleMouseButton))
             {
                 preMousePos = Input.mousePosition;
+            }
+
+            if (Input.GetMouseButtonDown(RightMouseButton))
+            {
+                rotateCenterInThisAngleMove = CheckRotateCenter(Input.mousePosition);
             }
 
             MouseDrag(Input.mousePosition);
@@ -59,16 +71,52 @@ namespace Baku.VMagicMirror
             }
             else if (Input.GetMouseButton(RightMouseButton))
             {
-                CameraRotate(new Vector2(-diff.y, diff.x) * rotateSpeed);
+                CameraRotateAround(
+                    new Vector2(-diff.y, diff.x) * rotateSpeed,
+                    rotateCenterInThisAngleMove
+                    );
             }
 
             preMousePos = mousePos;
         }
 
-        private void CameraRotate(Vector2 angle)
+        private void CameraRotateAround(Vector2 angle, Vector3 rotateCenter)
         {
-            transform.RotateAround(transform.position, transform.right, angle.x);
-            transform.RotateAround(transform.position, Vector3.up, angle.y);
+            transform.RotateAround(rotateCenter, transform.right, angle.x);
+            transform.RotateAround(rotateCenter, Vector3.up, angle.y);
+        }
+
+        private Vector3 CheckRotateCenter(Vector3 mousePosition)
+        {
+            //やりたいこと: 
+            // - マウス位置から求めたカメラレイと、Y軸の2直線間の最短距離になるようなカメラレイ上の点を求める
+            // - 求めた点をそのまんまカメラの回転中心にする
+            // - 結果として「Y軸にちかいところで頑張って回転してます」感が出ればOK
+            //ref: http://marupeke296.com/COL_3D_No19_LinesDistAndPos.html
+
+            var camRay = _cam.ScreenPointToRay(mousePosition);
+            var p1 = camRay.origin;
+            var v1 = camRay.direction;
+
+            var p2 = Vector3.zero;
+            var v2 = Vector3.up;
+
+            float d1 = Vector3.Dot(p2 - p1, v1);
+            float d2 = Vector3.Dot(p2 - p1, v2);
+            float dv = Vector3.Dot(v1, v2);
+
+            if (dv * dv > 0.999)
+            {
+                //ふたつのRayがほとんど平行: つまりカメラが真下か真上を向いているので、このときはその場回転でOK
+                return transform.position;
+            }
+            else
+            {
+                //note: 元記事では最短距離をつくる点を求めてるが、ここではq1(カメラレイ側の点)が分かったら十分
+                float t1 = (d1 - d2 * dv) / (1 - dv * dv);
+                return p1 + t1 * v1;
+            }
         }
     }
+
 }


### PR DESCRIPTION
カメラの回転について、なるべくキャラに注目したまま回すような挙動に改善。

また、(本来は別PRにすべきだったが)mainシーンの不要オブジェクトをいくつか削除。

以下、カメラの回転方法。フリーカメラモードが有効になっている状態で、

1. マウスで右クリックした時点で回転中心を求める。回転中心は、クリック位置から飛ばしたカメラレイ上で、Y軸にもっとも近い点を用いる。
2. 右クリックしている間、つまり一連の回転操作をする間は、つねに1で求めた回転中心を使い続ける 