### PR TITLE
Feature/hit test improvement

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -1780,9 +1780,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8fac3e0a69c22e347ab8a8e7135c3cae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  opaqueThreshold: 0.1
   handler: {fileID: 1930233619}
-  sender: {fileID: 0}
   windowPositionCheckInterval: 5
+  cam: {fileID: 1629460661}
 --- !u!81 &1629460658
 AudioListener:
   m_ObjectHideFlags: 0
@@ -1838,7 +1839,7 @@ Camera:
     height: 1
   near clip plane: 0.05
   far clip plane: 100
-  field of view: 60
+  field of view: 40
   orthographic: 0
   orthographic size: 5
   m_Depth: -1
@@ -1864,7 +1865,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1629460656}
   m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
-  m_LocalPosition: {x: 0, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 1.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2141451818}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -2845,13 +2845,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1971722876}
-  m_LocalRotation: {x: 0.12607859, y: -0.2566048, z: 0.03378265, w: 0.9576622}
+  m_LocalRotation: {x: 0.06869671, y: -0.17322525, z: 0.012113088, w: 0.9824088}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1629460662}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 15, y: -30, z: 0}
+  m_LocalEulerAnglesHint: {x: 8, y: -20, z: 0}
 --- !u!108 &1971722878
 Light:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/SettingAutoAdjuster.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/SettingAutoAdjuster.cs
@@ -190,7 +190,7 @@ namespace Baku.VMagicMirror
         private void AdjustCameraPosition(Animator animator)
         {
             var head = animator.GetBoneTransform(HumanBodyBones.Neck);
-            cam.position = new Vector3(0, head.position.y, 1);
+            cam.position = new Vector3(0, head.position.y, 1.3f);
             cam.rotation = Quaternion.Euler(0, 180, 0);
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WindowStyle/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WindowStyle/NativeMethods.cs
@@ -51,6 +51,9 @@ namespace Baku.VMagicMirror
         public static extern IntPtr GetActiveWindow();
 
         [DllImport("user32.dll")]
+        public static extern IntPtr SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
         public static extern IntPtr FindWindow(string className, string windowName);
         public static IntPtr CurrentWindowHandle = IntPtr.Zero;
         public static IntPtr GetUnityWindowHandle() => CurrentWindowHandle == IntPtr.Zero ? CurrentWindowHandle = FindWindow(null, Application.productName) : CurrentWindowHandle;
@@ -99,6 +102,7 @@ namespace Baku.VMagicMirror
             return new Vector2Int(rect.left, rect.top);
         }
 
+        public static void SetUnityWindowActive() => SetForegroundWindow(GetUnityWindowHandle());
         public static void SetUnityWindowPosition(int x, int y) => SetWindowPos(GetUnityWindowHandle(), IntPtr.Zero, x, y, 0, 0, SetWindowPosFlags.IgnoreResize);
         public static void SetUnityWindowSize(int width, int height) => SetWindowPos(GetUnityWindowHandle(), IntPtr.Zero, 0, 0, width, height, SetWindowPosFlags.IgnoreMove);
         public static void SetUnityWindowTopMost(bool enable) => SetWindowPos(GetUnityWindowHandle(), enable ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0, SetWindowPosFlags.IgnoreMoveAndResize);


### PR DESCRIPTION
## 概要

#35 のfix。背景透過だけど触れる状態のウィンドウについて、透過部分は触れないように修正した。

また、本PRに含めない方が良かったが、ついでにライトとカメラのデフォルトパラメータが何か所か変だったので

## 補足

実装がヘンテコに見える部分はタッチスクリーンで挙動を破綻させないために頑張った結果。

* ウィンドウが透過な状態で左クリックを検出しようとすると`Input.MouseButtonDown(0)`が使えない事
* 透過の判定には諸事情で1-2frameかかる

などが理由で、WPF側のグローバルフックを使ったりディレイがかかった処理が入れ込んである。

※本当はUnity自身がUnityRawInput(の拡張)でこの処理をやってくれると嬉しい…。
