### PR TITLE
v0.8.4 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Windows 10環境でお使いいただけます。
 
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
-* [UniVRM](https://github.com/vrm-c/UniVRM) v0.52.0
+* [UniVRM](https://github.com/vrm-c/UniVRM) v0.53.0
 * [UniRx](https://github.com/neuecc/UniRx)
 * [XinputGamepad](https://github.com/kaikikazu/XinputGamePad)
 * [gRPC](https://github.com/grpc/grpc)

--- a/README_en.md
+++ b/README_en.md
@@ -59,7 +59,7 @@ Set the folder as following.
 
 ### 4.2. Asset install
 
-* [UniVRM](https://dwango.github.io/vrm/) v0.52.0
+* [UniVRM](https://dwango.github.io/vrm/) v0.53.0
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
 * [UniVRM](https://dwango.github.io/vrm/)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -3008,7 +3008,7 @@ Light:
   serializedVersion: 8
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
-  m_Intensity: 0.55
+  m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
   m_CookieSize: 10


### PR DESCRIPTION
UniVRMの更新があり、髪などの表示修正で影響が大きかったため反映しなおした。

* UniVRMをv0.52.0からv0.53.0に上げたことで全体に白飛びしやすい問題が無くなったため、ライトのintensityのデフォルト値を`0.55`まで一旦下げていたのを本来v0.8.3で使っていた`1.0`に巻き戻し
* readmeを実態ベースで修正
