### PR TITLE
whole window transparency control

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
@@ -27,6 +27,8 @@
         public const string WindowDraggable = nameof(WindowDraggable);
         public const string MoveWindow = nameof(MoveWindow);
         public const string ResetWindowSize = nameof(ResetWindowSize);
+        public const string SetWholeWindowTransparencyLevel = nameof(SetWholeWindowTransparencyLevel);
+        public const string SetAlphaValueOnTransparent = nameof(SetAlphaValueOnTransparent);
 
         // Motion
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WindowStyle/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WindowStyle/NativeMethods.cs
@@ -123,6 +123,17 @@ namespace Baku.VMagicMirror
         public const uint WS_EX_LAYERED = 0x00080000;
         public const uint WS_EX_TRANSPARENT = 0x00000020;
 
+        [DllImport("user32.dll")]
+        public static extern bool SetLayeredWindowAttributes(IntPtr hWnd, uint crKey, byte bAlpha, uint dwFlags);
+
+        private const int LWA_COLORKEY = 0x0001;
+        private const int LWA_ALPHA = 0x0002;
+
+        public static void SetWindowAlpha(byte alpha)
+        {
+            SetLayeredWindowAttributes(GetUnityWindowHandle(), 0, alpha, LWA_ALPHA);
+        }
+
 
         public delegate bool EnumWindowsDelegate(IntPtr hWnd, IntPtr lparam);
 


### PR DESCRIPTION
#59 のための更新。

キャラを半透明にする条件を5段階に区切って実装している。すべて、背景が透明時のみ動作し、背景が不透明(単色背景が見える)の場合は透過処理はしない。

* Level 0: つねに不透明 = v0.8.5までの挙動
* Level 1: ドラッグ不許可でキャラにマウスが乗ったとき半透明
* Level 2: とにかくキャラにマウスが乗ったら半透明
* Level 3: ドラッグ不許可時はつねに半透明
* Level 4: つねに半透明

Levelが上がるほど半透明になりやすく、作業の邪魔にはなりにくい、という思想。