### PR TITLE
シーン上の依存関係をちょっと簡単化

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Windows 10環境でお使いいただけます。
 * [AniLipSync VRM](https://github.com/sh-akira/AniLipSync-VRM)
     + AniLipSyncが依存している[OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/)のインストールも必要です。
 * [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI)
+* Zenject (アセットストアからダウンロード可)
 
 ※v0.8.2時点ではビルド時に下記が必要でしたが、v0.8.3時点でビルド時の必須ライブラリから外しています。
 

--- a/README_en.md
+++ b/README_en.md
@@ -69,6 +69,7 @@ Set the folder as following.
 * [AniLipSync VRM](https://github.com/sh-akira/AniLipSync-VRM)
     + AniLipSync requires installation of [OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/).
 * [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI)
+* Zenject (from asset store)
 
 *note: until v0.8.2a following libraries are required, but from v0.8.3 you can build the app without them.
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -161,7 +161,6 @@ MonoBehaviour:
   shadowLightLocalEulerAngle: {x: 8, y: -20, z: 0}
   shadowBoardMotion: {fileID: 1057131357}
   postProcess: {fileID: 749678942}
-  handler: {fileID: 1930233619}
 --- !u!1 &161296353
 GameObject:
   m_ObjectHideFlags: 0
@@ -386,7 +385,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dcf6b464b4d783c44a19bdce46109df1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   sender: {fileID: 161296355}
   faceControlManager: {fileID: 1130871118}
 --- !u!114 &295217320
@@ -603,7 +601,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 81677ea49f21b6b4d986acc1d310bd8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   sender: {fileID: 161296355}
   blendShapeAssignReceiver: {fileID: 295217319}
   cam: {fileID: 1629460662}
@@ -912,6 +909,72 @@ Transform:
   m_Father: {fileID: 1674567171}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &708291027
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 708291029}
+  - component: {fileID: 708291028}
+  - component: {fileID: 708291030}
+  m_Layer: 0
+  m_Name: SceneContext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &708291028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 708291027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89715ad69b973a14899afa2c6730b30b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scriptableObjectInstallers: []
+  _monoInstallers:
+  - {fileID: 708291030}
+  _installerPrefabs: []
+  _autoRun: 1
+  _parentNewObjectsUnderSceneContext: 0
+  _contractNames: []
+  _parentContractNames: []
+--- !u!4 &708291029
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 708291027}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 20
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &708291030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 708291027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85437e04ea991b7489648a48de5da11f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  messageHandler: {fileID: 1930233619}
+  loadController: {fileID: 1787938567}
 --- !u!1 &749678940
 GameObject:
   m_ObjectHideFlags: 0
@@ -1328,7 +1391,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b883912af74d8df4ab86b0739678c879, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
 --- !u!1 &1134663115
 GameObject:
   m_ObjectHideFlags: 0
@@ -1488,7 +1550,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c43672cf46e1954cb280461a69ea74f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   keyboard: {fileID: 1169325487}
   touchpad: {fileID: 2059529786}
   gamepad: {fileID: 1798368043}
@@ -1561,7 +1622,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfd37789e02ac7843b7055662b478200, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _handler: {fileID: 1930233619}
 --- !u!1 &1281394291
 GameObject:
   m_ObjectHideFlags: 0
@@ -1738,7 +1798,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b3aee8e450bba3b4db544ed198ae226d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
 --- !u!114 &1335587173
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2125,7 +2184,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 402a480edc7368e4fab24434a0d83e5a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   cam: {fileID: 1629460661}
   transformController: {fileID: 1629460660}
 --- !u!114 &1629460664
@@ -2455,7 +2513,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2d0c8ece50ffcbc41b86f8994e837292, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
 --- !u!114 &1787938567
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2468,7 +2525,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 91cd6285b69da1e46a0a90d72eab7fc2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   loadSetting:
     bodyTarget: {fileID: 1134663116}
     leftHandTarget: {fileID: 1842530517}
@@ -2479,258 +2535,6 @@ MonoBehaviour:
   animatorController: {fileID: 9100000, guid: 8274142a1807f5848a5dd1166db7d615, type: 2}
   windowStyleController: {fileID: 1629460657}
   settingAdjuster: {fileID: 478567140}
-  vrmLoaded:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 2042410944}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 295217318}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1809547436}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1993346254}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 306547512}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1130871118}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 238267461}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 295217319}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1963776212}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2042410943}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 295217321}
-        m_MethodName: OnVrmLoaded
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: Baku.VMagicMirror.VRMLoadController+VrmLoadedEvent, Assembly-CSharp,
-      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  vrmDisposing:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 2042410944}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 295217318}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1809547436}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1993346254}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 306547512}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1130871118}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 238267461}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 295217319}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1963776212}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 2042410943}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 295217321}
-        m_MethodName: OnVrmDisposing
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &1798368041
 GameObject:
   m_ObjectHideFlags: 0
@@ -2847,7 +2651,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 22e0a61ea7cc8df41828ba8c224381ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
 --- !u!1 &1842530516
 GameObject:
   m_ObjectHideFlags: 0
@@ -3115,7 +2918,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8060a04e4473d34d867afecf5747f34, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   manager: {fileID: 1963776212}
 --- !u!4 &1963776214
 Transform:
@@ -3257,7 +3059,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9838934ad278ba4a92a84679291438b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
 --- !u!1 &2042410935
 GameObject:
   m_ObjectHideFlags: 0
@@ -3607,7 +3408,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 06fcbc682dad80141953923a215f8b28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   gamePadBasedBodyLean: {fileID: 2042410941}
   handIkIntegrator: {fileID: 2042410944}
   headIkIntegrator: {fileID: 2042410943}
@@ -3625,7 +3425,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e27dcaac7204d74cb9cf10b7ec999d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handler: {fileID: 1930233619}
   gamePad: {fileID: 953451441}
   handIkIntegrator: {fileID: 2042410944}
   headIkIntegrator: {fileID: 2042410943}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cc908d2165b0034a946d104967d1111
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    public class VMagicMirrorInstaller : MonoInstaller
+    {
+        [SerializeField] private ReceivedMessageHandler messageHandler = null;
+        [SerializeField] private VRMLoadController loadController = null;
+        
+        public override void InstallBindings()
+        {
+            //メッセージハンドラの依存はここで注入(偽レシーバを入れたい場合、interfaceを切って別インスタンスを捻じ込めばOK)
+            Container.BindInstance(messageHandler);
+
+            //VRMLoadControllerがIVRMLoadable(VRMのロード/破棄イベント送信元)の実装を提供する
+            Container
+                .Bind<IVRMLoadable>()
+                .FromInstance(loadController)
+                .AsSingle();
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85437e04ea991b7489648a48de5da11f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraController.cs
@@ -3,12 +3,13 @@ using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class CameraController : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
         [SerializeField] private Camera cam = null;
         [SerializeField] private CameraTransformController transformController = null;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/LightingController.cs
@@ -1,6 +1,7 @@
 ﻿using UniRx;
 using UnityEngine;
 using UnityEngine.Rendering.PostProcessing;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -14,7 +15,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private ShadowBoardMotion shadowBoardMotion = null;
 
         [SerializeField] private PostProcessVolume postProcess = null;
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
 
 
         private Bloom _bloom;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/BlendShapeAssignment/BlendShapeAssignReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/BlendShapeAssignment/BlendShapeAssignReceiver.cs
@@ -1,11 +1,12 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class BlendShapeAssignReceiver : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
         [SerializeField] private GrpcSender sender = null;
         [SerializeField] private FaceControlManager faceControlManager = null;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/EyeJitter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/EyeJitter.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using Zenject;
 
 //ref: https://gist.github.com/GOROman/51ee32887bd1d3248b7610f845904b30
 namespace Baku.VMagicMirror
@@ -20,6 +21,8 @@ namespace Baku.VMagicMirror
         [Tooltip("微細運動をスムージングする速度ファクタ")]
         [SerializeField] private float speedFactor = 11.0f;
 
+        [Inject] private IVRMLoadable _vrmLoadable = null;
+
         private Transform _rightEye = null;
         private Transform _leftEye = null;
         private bool _hasValidEyeBone = false;
@@ -28,20 +31,12 @@ namespace Baku.VMagicMirror
         private Quaternion _targetRotation;
         public Quaternion CurrentRotation { get; private set; }
         
-        public void OnVrmLoaded(VrmLoadedInfo info)
+        private void Start()
         {
-            _rightEye = info.animator.GetBoneTransform(HumanBodyBones.RightEye);
-            _leftEye = info.animator.GetBoneTransform(HumanBodyBones.LeftEye);
-            _hasValidEyeBone = (_rightEye != null && _leftEye != null);
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+            _vrmLoadable.VrmDisposing += OnVrmDisposing;
         }
-
-        public void OnVrmDisposing()
-        {
-            _rightEye = null;
-            _leftEye = null;
-            _hasValidEyeBone = false;
-        }
-
+        
         private void LateUpdate()
         {
             _count -= Time.deltaTime;
@@ -68,6 +63,20 @@ namespace Baku.VMagicMirror
                 _rightEye.localRotation *= CurrentRotation;
                 _leftEye.localRotation *= CurrentRotation;
             }
+        }
+        
+        private void OnVrmLoaded(VrmLoadedInfo info)
+        {
+            _rightEye = info.animator.GetBoneTransform(HumanBodyBones.RightEye);
+            _leftEye = info.animator.GetBoneTransform(HumanBodyBones.LeftEye);
+            _hasValidEyeBone = (_rightEye != null && _leftEye != null);
+        }
+
+        private void OnVrmDisposing()
+        {
+            _rightEye = null;
+            _leftEye = null;
+            _hasValidEyeBone = false;
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using VRM;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -17,6 +18,8 @@ namespace Baku.VMagicMirror
         [SerializeField] private AnimMorphEasedTarget animMorphEasedTarget = null;
         [SerializeField] private ImageBasedBlinkController imageBasedBlinkController = null;
         [SerializeField] private VRMAutoBlink autoBlink = null;
+
+        [Inject] private IVRMLoadable _vrmLoadable = null;
 
         /// <summary>
         /// VRMロード時の初期化が済んだら発火
@@ -44,28 +47,6 @@ namespace Baku.VMagicMirror
         public DefaultFunBlendShapeModifier DefaultBlendShape { get; } 
             = new DefaultFunBlendShapeModifier();
         
-        public void OnVrmLoaded(VrmLoadedInfo info)
-        {
-            _proxy = info.blendShape;
-            eyeDownController.OnVrmLoaded(info);
-            animMorphEasedTarget.OnVrmLoaded(info);
-            
-            BlendShapeStore.OnVrmLoaded(info);
-            EyebrowBlendShape.RefreshTarget(BlendShapeStore);
-
-            VrmInitialized?.Invoke();
-        }
-
-        public void OnVrmDisposing()
-        {
-            _proxy = null;
-            eyeDownController.OnVrmDisposing();
-            animMorphEasedTarget.OnVrmDisposing();
-            
-            BlendShapeStore.OnVrmDisposing();
-            EyebrowBlendShape.Reset();
-        }
-
         private bool _overrideByMotion = false;
         
         public bool OverrideByMotion
@@ -92,6 +73,12 @@ namespace Baku.VMagicMirror
                 }
             }
         }
+
+        private void Start()
+        {
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+            _vrmLoadable.VrmDisposing += OnVrmDisposing;
+        }
         
         private void Update()
         {
@@ -113,6 +100,22 @@ namespace Baku.VMagicMirror
                     autoBlink.Apply(_proxy);
                 }
             }
+        }
+                
+        private void OnVrmLoaded(VrmLoadedInfo info)
+        {
+            _proxy = info.blendShape;
+            BlendShapeStore.OnVrmLoaded(info);
+            EyebrowBlendShape.RefreshTarget(BlendShapeStore);
+
+            VrmInitialized?.Invoke();
+        }
+
+        private void OnVrmDisposing()
+        {
+            _proxy = null;
+            BlendShapeStore.OnVrmDisposing();
+            EyebrowBlendShape.Reset();
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManagerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManagerReceiver.cs
@@ -1,12 +1,13 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     [RequireComponent(typeof(FaceControlManager))]
     public class FaceControlManagerReceiver : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
 
         private FaceControlManager _faceControlManager;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTrackerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTrackerReceiver.cs
@@ -1,13 +1,14 @@
 ﻿using System.Linq;
 using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     [RequireComponent(typeof(FaceTracker))]
     public class FaceTrackerReceiver : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
 
         private FaceTracker _faceTracker;
         private bool _enableFaceTracking = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/HidTransformController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/HidTransformController.cs
@@ -1,13 +1,14 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class HidTransformController : MonoBehaviour
     {
         private const float TouchPadVerticalOffset = 0.01f;
-
-        [SerializeField]
+        
+        [Inject]
         private ReceivedMessageHandler handler = null;
 
         [SerializeField]

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/LipSync/AnimMorphEasedTarget.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/LipSync/AnimMorphEasedTarget.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using VRM;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -50,15 +51,7 @@ namespace Baku.VMagicMirror
         private OVRLipSync.Viseme _previousViseme = OVRLipSync.Viseme.sil;
         private float _transitionTimer = 0.0f;
 
-        public void OnVrmLoaded(VrmLoadedInfo info)
-        {
-            blendShapeProxy = info.blendShape;
-        }
-
-        public void OnVrmDisposing()
-        {
-            blendShapeProxy = null;
-        }
+        [Inject] private IVRMLoadable _loadable = null;
         
         private void Start()
         {
@@ -67,8 +60,10 @@ namespace Baku.VMagicMirror
             {
                 LogOutput.Instance.Write("同じGameObjectにOVRLipSyncContextBaseを継承したクラスが見つかりません。");
             }
-
             _context.Smoothing = smoothAmount;
+
+            _loadable.VrmLoaded += info => blendShapeProxy = info.blendShape;
+            _loadable.VrmDisposing += () => blendShapeProxy = null;
         }
 
         private void Update()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/LipSync/LipSyncReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/LipSync/LipSyncReceiver.cs
@@ -1,11 +1,12 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class LipSyncReceiver : MonoBehaviour
     {
-        [SerializeField]
+        [Inject]
         private ReceivedMessageHandler handler = null;
 
         private DeviceSelectableLipSyncContext _lipSyncContext;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/BodyMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/BodyMotionManager.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -12,31 +13,19 @@ namespace Baku.VMagicMirror
         [SerializeField] private ImageBasedBodyMotion imageBasedBodyMotion = null;
         [SerializeField] private WaitingBodyMotion waitingBodyMotion = null;
 
+        [Inject] private IVRMLoadable _vrmLoadable = null;
+
         public WaitingBodyMotion WaitingBodyMotion => waitingBodyMotion;
 
         private Transform _vrmRoot = null;
         private Vector3 _defaultBodyIkPosition;
         private bool _isVrmLoaded = false;
         
-        public void OnVrmLoaded(VrmLoadedInfo info)
+        private void Start()
         {
-            //NOTE: VRMLoadControllerがロード時点でbodyIkの位置をキャラのHipsあたりに調整しているので、それを貰う
-            _defaultBodyIkPosition = bodyIk.position;
-            imageBasedBodyMotion.OnVrmLoaded(info);
-            _vrmRoot = info.vrmRoot;
-
-            _isVrmLoaded = true;
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+            _vrmLoadable.VrmDisposing += OnVrmDisposing;
         }
-
-        public void OnVrmDisposing()
-        {
-            _isVrmLoaded = false;
-
-            _vrmRoot = null;
-            imageBasedBodyMotion.OnVrmDisposing();
-        }
-        
-        
 
         private void Update()
         {
@@ -52,6 +41,24 @@ namespace Baku.VMagicMirror
 
             //全体でズラさないと整合しなさそうなので…
             _vrmRoot.position = imageBasedBodyMotion.BodyIkOffset;
+        }
+        
+        private void OnVrmLoaded(VrmLoadedInfo info)
+        {
+            //NOTE: VRMLoadControllerがロード時点でbodyIkの位置をキャラのHipsあたりに調整しているので、それを貰う
+            _defaultBodyIkPosition = bodyIk.position;
+            imageBasedBodyMotion.OnVrmLoaded(info);
+            _vrmRoot = info.vrmRoot;
+
+            _isVrmLoaded = true;
+        }
+
+        private void OnVrmDisposing()
+        {
+            _isVrmLoaded = false;
+
+            _vrmRoot = null;
+            imageBasedBodyMotion.OnVrmDisposing();
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/BodyMotionManagerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/BodyMotionManagerReceiver.cs
@@ -1,11 +1,12 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class BodyMotionManagerReceiver : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
 
         [SerializeField] private BodyMotionManager bodyMotionManager = null;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/ElbowMotionModifyReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/ElbowMotionModifyReceiver.cs
@@ -1,12 +1,12 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class ElbowMotionModifyReceiver : MonoBehaviour
     {
-        [SerializeField]
-        private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
 
         public float WaistWidthHalf { get; private set; } = 0.15f;
         public float ElbowCloseStrength { get; private set; } = 0.30f;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/FaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/FaceAttitudeController.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -15,7 +16,9 @@ namespace Baku.VMagicMirror
 
         [SerializeField]
         [Range(0.05f, 1.0f)]
-        private float timeScaleFactor = 1.0f;        
+        private float timeScaleFactor = 1.0f;
+
+        [Inject] private IVRMLoadable _vrmLoadable = null;
 
         private const float HeadYawRateToDegFactor = 50.00f;
         private const float HeadTotalRotationLimitDeg = 40.0f;
@@ -48,6 +51,8 @@ namespace Baku.VMagicMirror
             faceTracker.FaceParts.Nose.NoseBaseHeightValue.Subscribe(
                 v => SetHeadPitchDeg(NoseBaseHeightToNeckPitchDeg(v))
                 );
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+            _vrmLoadable.VrmDisposing += OnVrmDisposing;
         }
 
         private void LateUpdate()
@@ -99,14 +104,14 @@ namespace Baku.VMagicMirror
             _prevRotationSpeedEuler = speed;
         }
 
-        public void OnVrmLoaded(VrmLoadedInfo info)
+        private void OnVrmLoaded(VrmLoadedInfo info)
         {
             var animator = info.animator;
             _vrmNeckTransform = animator.GetBoneTransform(HumanBodyBones.Neck);
             _vrmHeadTransform = animator.GetBoneTransform(HumanBodyBones.Head);
         }
 
-        public void OnVrmDisposing()
+        private void OnVrmDisposing()
         {
             _vrmNeckTransform = null;
             _vrmHeadTransform = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
@@ -1,6 +1,7 @@
 ﻿using RootMotion.FinalIK;
 using UnityEngine;
 using XinputGamePad;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -50,26 +51,12 @@ namespace Baku.VMagicMirror
         private HandTargetType _leftTargetType = HandTargetType.Keyboard;
         private HandTargetType _rightTargetType = HandTargetType.Keyboard;
 
+        [Inject] private IVRMLoadable _vrmLoadable = null;
+
         public bool EnablePresentationMode { get; set; }
 
 
         #region API
-
-        public void OnVrmLoaded(VrmLoadedInfo info)
-        {
-            fingerController.Initialize(info.animator);
-            presentation.Initialize(info.animator);
-
-            //ホームポジションを押させてIK位置を整える
-            PressKey("F");
-            PressKey("J");
-        }
-
-        public void OnVrmDisposing()
-        {
-            fingerController.Dispose();
-            presentation.Dispose();
-        }
 
         public void PressKey(string keyName)
         {
@@ -166,8 +153,27 @@ namespace Baku.VMagicMirror
             _currentLeftHand = Typing.LeftHand;
             _leftHandStateBlendCount = HandIkToggleDuration;
             _rightHandStateBlendCount = HandIkToggleDuration;
+
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+            _vrmLoadable.VrmDisposing += OnVrmDisposing;
+        }
+        
+        private void OnVrmLoaded(VrmLoadedInfo info)
+        {
+            fingerController.Initialize(info.animator);
+            presentation.Initialize(info.animator);
+
+            //ホームポジションを押させてIK位置を整える
+            PressKey("F");
+            PressKey("J");
         }
 
+        private void OnVrmDisposing()
+        {
+            fingerController.Dispose();
+            presentation.Dispose();
+        }
+        
         private void Update()
         {
             //ねらい: 前のステートと今のステートをブレンドしながら実際にIKターゲットの位置、姿勢を更新する

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HeadIkIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HeadIkIntegrator.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -16,6 +17,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private Transform cam = null;
         [SerializeField] private Transform lookAtTarget = null;
         [SerializeField] private float lookAtSpeedFactor = 6.0f;
+        [Inject] private IVRMLoadable _vrmLoadable = null;
         
         private readonly IKDataRecord _mouseBasedLookAt = new IKDataRecord();
         public IIKGenerator MouseBasedLookAt => _mouseBasedLookAt;
@@ -27,16 +29,6 @@ namespace Baku.VMagicMirror
 
         private LookAtStyles _lookAtStyle = LookAtStyles.MousePointer;
         private Transform _head = null;
-        
-        public void OnVrmLoaded(VrmLoadedInfo info)
-        {
-            _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
-        }
-
-        public void OnVrmDisposing()
-        {
-            _head = null;
-        }
         
         public void MoveMouse(int x, int y)
         {
@@ -61,6 +53,8 @@ namespace Baku.VMagicMirror
         private void Start()
         {
             _camBasedLookAt.Camera = cam;
+            _vrmLoadable.VrmLoaded += info => _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
+            _vrmLoadable.VrmDisposing += () =>  _head = null;
         }
 
         private void Update()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/HidInputReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/HidInputReceiver.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -10,7 +11,7 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class HidInputReceiver : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
         
         [SerializeField] private StatefulXinputGamePad gamePad = null;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
@@ -1,12 +1,13 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     /// <summary> モーション関係で、操作ではなく設定値を受け取るレシーバクラス </summary>
     public class MotionSettingReceiver : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
 
         [SerializeField] private GamepadBasedBodyLean gamePadBasedBodyLean = null;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Particle/ParticleControlReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Particle/ParticleControlReceiver.cs
@@ -1,5 +1,6 @@
 ﻿using UniRx;
 using UnityEngine;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -8,8 +9,7 @@ namespace Baku.VMagicMirror
     {
         private const int InvalidTypingEffectIndex = ParticleStore.InvalidTypingEffectIndex;
 
-        [SerializeField]
-        private ReceivedMessageHandler _handler = null;
+        [Inject] private ReceivedMessageHandler _handler = null;
 
         private ParticleStore _particleStore = null;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/SettingAdjust/SettingAutoAdjuster.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/SettingAdjust/SettingAutoAdjuster.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -12,7 +13,7 @@ namespace Baku.VMagicMirror
         //Hand (Wrist) to Middle Distal
         private const float ReferenceHandLength = 0.114f;
 
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
         [SerializeField] private GrpcSender sender = null;
         [SerializeField] private BlendShapeAssignReceiver blendShapeAssignReceiver = null;
         [SerializeField] private Transform cam = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/IVRMLoadable.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/IVRMLoadable.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary> VRMロード元が提供すべきイベントの定義 </summary>
+    public interface IVRMLoadable
+    {
+        event Action<VrmLoadedInfo> VrmLoaded;
+        event Action VrmDisposing;
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/IVRMLoadable.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/IVRMLoadable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2640aebd5a17d145be5e64cde0e589d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/VRMPreviewLanguage.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/VRMLoad/VRMPreviewLanguage.cs
@@ -1,11 +1,12 @@
 ﻿using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class VrmPreviewLanguage : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
 
         public string Language { get; private set; } = "Japanese";
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionManagerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionManagerReceiver.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -9,7 +10,7 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class WordToMotionManagerReceiver : MonoBehaviour
     {
-        [SerializeField] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler handler = null;
         [SerializeField] private WordToMotionManager manager = null;
 
         void Start()


### PR DESCRIPTION
#85 の解決用のPR。やった事は3つ。

* Zenjectを導入
* `ReceivedMessageHandler`はSerializeFieldでの代入ではなくInjectで入れる方式に変更
* `VRMLoadController`でVRMのロード/アンロードイベントをI/F化し、I/FをInjectされたクラスではStart時点でイベントハンドラを登録するよう変更

この変更で、シーン上の依存関係が2つ減った。

* `ReceiveMessageHandler`の参照を毎回設定しなくとも良くなった。
* `VRMLoadController`のキャラロード/アンロードのイベント参照を手作業で入れてたのが無くなった。

今回のPRでは`ReceivedMessageHandler`とか`VRMLoadController`のGameObject自体はシーン上に静的配置したままにした。いかにもZenjectらしい書き方だとこれらコンポーネント自体を動的生成できる(気がする)が、まずは変更抑えめでの導入ということで控え目な方針を取った。

ただ、この変更単体だとむしろ`static`おじさんに近寄った感がある。乱用注意。