### PR TITLE
「動作後にブレンドシェイプを維持」オプションの追加

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/Models/MotionRequest.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/Models/MotionRequest.cs
@@ -27,6 +27,17 @@ namespace Baku.VMagicMirror
         /// </summary>
         public bool UseBlendShape;
 
+        /// <summary>
+        /// アニメーションの終了後にブレンドシェイプをそのままの状態にすべきか否か
+        /// </summary>
+        public bool HoldBlendShape;
+
+        /// <summary>
+        /// リップシンクに関係あるブレンドシェイプについて、リップシンクのブレンドシェイプ指定を優先するか否か
+        /// </summary>
+        /// <remarks>この設定を反映するには(Proxyではない本来の)ブレンドシェイプ解析が必要なことに注意</remarks>
+        public bool PreferLipSync;
+
         //NOTE: 辞書にしないでこのまま使う手も無くはないです
         [SerializeField] private BlendShapeValues BlendShapeValues = null;
 


### PR DESCRIPTION
表情を一時切り替えじゃなくて恒久切り替えにするためのオプションを追加した。

なお、あわせて`PreferLipSync`という表情よりリップシンクを優先させるプロパティも追加しているが、こちらは単にプロパティが増えているだけで実際には使っていない