### PR TITLE
ゲームパッド操作時の見た目改善

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -112,6 +112,36 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &136507635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 136507636}
+  m_Layer: 0
+  m_Name: RightHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &136507636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 136507635}
+  m_LocalRotation: {x: -0.36868778, y: -0.6275069, z: -0.52654076, w: 0.43938503}
+  m_LocalPosition: {x: 0.12, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 908049630}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -80, y: -110, z: 0}
 --- !u!1 &148983026
 GameObject:
   m_ObjectHideFlags: 0
@@ -270,7 +300,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 20
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &238267459
 GameObject:
@@ -429,7 +459,6 @@ GameObject:
   - component: {fileID: 306547511}
   - component: {fileID: 306547510}
   - component: {fileID: 306547515}
-  - component: {fileID: 306547514}
   m_Layer: 0
   m_Name: BodyMotion
   m_TagString: Untagged
@@ -499,7 +528,6 @@ MonoBehaviour:
   gamepadBasedBodyLean: {fileID: 306547515}
   imageBasedBodyMotion: {fileID: 306547511}
   waitingBodyMotion: {fileID: 306547510}
-  gamePadBodyLeanSpeedFactor: 6
 --- !u!114 &306547513
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -513,18 +541,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   bodyMotionManager: {fileID: 306547512}
---- !u!114 &306547514
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 306547508}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e7721bdd88242aa439fa64a2e1a034a2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &306547515
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -537,83 +553,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5b64fe07c345fe0479dcf5ca013a19db, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &402429506
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 402429507}
-  - component: {fileID: 402429510}
-  - component: {fileID: 402429509}
-  m_Layer: 0
-  m_Name: Up
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &402429507
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 402429506}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.21, y: 0, z: 0.37}
-  m_LocalScale: {x: 0.02, y: 0.02, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &402429509
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 402429506}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &402429510
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 402429506}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+  bodyLeanMaxAngle: {x: 2, y: 2}
 --- !u!1 &478567139
 GameObject:
   m_ObjectHideFlags: 0
@@ -658,7 +598,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &500754460
 GameObject:
@@ -690,314 +630,6 @@ Transform:
   m_Father: {fileID: 1674567171}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &516414220
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 516414221}
-  - component: {fileID: 516414224}
-  - component: {fileID: 516414223}
-  m_Layer: 0
-  m_Name: Y
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &516414221
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 516414220}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.21, y: 0, z: 0.37}
-  m_LocalScale: {x: 0.02, y: 0.020000007, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &516414223
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 516414220}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &516414224
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 516414220}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &525847740
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 525847741}
-  - component: {fileID: 525847744}
-  - component: {fileID: 525847743}
-  m_Layer: 0
-  m_Name: Right
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &525847741
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 525847740}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.19, y: 0, z: 0.35}
-  m_LocalScale: {x: 0.02, y: 0.02, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &525847743
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 525847740}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &525847744
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 525847740}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &613294832
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 613294833}
-  - component: {fileID: 613294835}
-  - component: {fileID: 613294834}
-  m_Layer: 0
-  m_Name: LTrigger
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &613294833
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 613294832}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.23, y: 0, z: 0.39}
-  m_LocalScale: {x: 0, y: 0, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 11
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &613294834
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 613294832}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &613294835
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 613294832}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &627282149
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 627282150}
-  - component: {fileID: 627282153}
-  - component: {fileID: 627282152}
-  m_Layer: 0
-  m_Name: B
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &627282150
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 627282149}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.23, y: 0, z: 0.35}
-  m_LocalScale: {x: 0.02, y: 0.020000007, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &627282152
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 627282149}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &627282153
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 627282149}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &638373945
 GameObject:
   m_ObjectHideFlags: 0
@@ -1078,7 +710,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 21
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &708291030
 MonoBehaviour:
@@ -1142,83 +774,6 @@ MonoBehaviour:
   blendDistance: 0
   weight: 1
   priority: 0
---- !u!1 &805620707
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 805620708}
-  - component: {fileID: 805620711}
-  - component: {fileID: 805620710}
-  m_Layer: 0
-  m_Name: LStick
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &805620708
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 805620707}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.15, y: 0, z: 0.28}
-  m_LocalScale: {x: 0.04, y: 0.04, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &805620710
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 805620707}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a4f4c7f08d58d9c4389a0a569b2c0ad3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &805620711
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 805620707}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &819192695
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1232,7 +787,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 452380, guid: 4dd277bd9572488489906165e0931952, type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 452380, guid: 4dd277bd9572488489906165e0931952, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1248,83 +803,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4dd277bd9572488489906165e0931952, type: 3}
---- !u!1 &873970060
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 873970061}
-  - component: {fileID: 873970063}
-  - component: {fileID: 873970062}
-  m_Layer: 0
-  m_Name: LShoulder
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &873970061
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 873970060}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.19, y: 0, z: 0.39}
-  m_LocalScale: {x: 0, y: 0, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &873970062
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 873970060}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &873970063
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 873970060}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &908049629
 GameObject:
   m_ObjectHideFlags: 0
@@ -1348,13 +826,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 908049629}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0.13052624, y: 0, z: 0, w: 0.9914449}
   m_LocalPosition: {x: 0, y: 0, z: 0.3}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 136507636}
+  - {fileID: 2075937860}
   m_Father: {fileID: 1698725304}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: -15, y: 0, z: 0}
 --- !u!1 &935302417
 GameObject:
   m_ObjectHideFlags: 0
@@ -1428,7 +908,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1057131352
 GameObject:
@@ -1555,7 +1035,7 @@ Transform:
   - {fileID: 295217317}
   - {fileID: 4972949287635646}
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1130871116
 MonoBehaviour:
@@ -1648,83 +1128,6 @@ Transform:
   m_Father: {fileID: 1674567171}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1142378399
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1142378400}
-  - component: {fileID: 1142378402}
-  - component: {fileID: 1142378401}
-  m_Layer: 0
-  m_Name: RShoulder
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1142378400
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1142378399}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.19, y: 0, z: 0.39}
-  m_LocalScale: {x: 0, y: 0, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 12
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &1142378401
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1142378399}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1142378402
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1142378399}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1169325485
 GameObject:
   m_ObjectHideFlags: 0
@@ -1856,7 +1259,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   keyboard: {fileID: 1169325487}
   touchpad: {fileID: 2059529786}
-  gamepad: {fileID: 1798368043}
+  smallGamepad: {fileID: 1698725305}
   particleStore: {fileID: 1268007393}
 --- !u!1 &1268007391
 GameObject:
@@ -1888,7 +1291,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1268007393
 MonoBehaviour:
@@ -2071,7 +1474,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 15
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1335587171
 MonoBehaviour:
@@ -2115,237 +1518,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   messageSender: {fileID: 161296355}
---- !u!1 &1374794597
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1374794598}
-  - component: {fileID: 1374794601}
-  - component: {fileID: 1374794600}
-  m_Layer: 0
-  m_Name: A
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1374794598
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1374794597}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.21, y: 0, z: 0.33}
-  m_LocalScale: {x: 0.02, y: 0.020000007, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &1374794600
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1374794597}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1374794601
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1374794597}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1461652144
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1461652145}
-  - component: {fileID: 1461652148}
-  - component: {fileID: 1461652147}
-  m_Layer: 0
-  m_Name: RStick
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1461652145
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1461652144}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.15, y: 0, z: 0.28}
-  m_LocalScale: {x: 0.04, y: 0.04, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &1461652147
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1461652144}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a4f4c7f08d58d9c4389a0a569b2c0ad3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1461652148
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1461652144}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1581013136
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1581013137}
-  - component: {fileID: 1581013140}
-  - component: {fileID: 1581013139}
-  m_Layer: 0
-  m_Name: X
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1581013137
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1581013136}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.19, y: 0, z: 0.35}
-  m_LocalScale: {x: 0.02, y: 0.020000007, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &1581013139
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1581013136}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1581013140
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1581013136}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1629460656
 GameObject:
   m_ObjectHideFlags: 0
@@ -2583,85 +1755,8 @@ Transform:
   - {fileID: 1842530517}
   - {fileID: 638373946}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1687041055
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1687041056}
-  - component: {fileID: 1687041059}
-  - component: {fileID: 1687041058}
-  m_Layer: 0
-  m_Name: Left
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1687041056
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687041055}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.23, y: 0, z: 0.35}
-  m_LocalScale: {x: 0.02, y: 0.02, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &1687041058
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687041055}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1687041059
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687041055}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1698725303
 GameObject:
   m_ObjectHideFlags: 0
@@ -2671,6 +1766,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1698725304}
+  - component: {fileID: 1698725305}
   m_Layer: 0
   m_Name: SmallGamepadRoot
   m_TagString: Untagged
@@ -2693,160 +1789,23 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1706952127
-GameObject:
+--- !u!114 &1698725305
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1706952128}
-  - component: {fileID: 1706952130}
-  - component: {fileID: 1706952129}
-  m_Layer: 0
-  m_Name: RTrigger
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1706952128
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706952127}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.23, y: 0, z: 0.39}
-  m_LocalScale: {x: 0, y: 0, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 13
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &1706952129
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706952127}
+  m_GameObject: {fileID: 1698725303}
   m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1706952130
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706952127}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1708390757
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1708390758}
-  - component: {fileID: 1708390761}
-  - component: {fileID: 1708390760}
-  m_Layer: 0
-  m_Name: Down
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1708390758
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1708390757}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.21, y: 0, z: 0.33}
-  m_LocalScale: {x: 0.02, y: 0.02, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1798368042}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!23 &1708390760
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1708390757}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1708390761
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1708390757}
-  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db12dc8aed5453f43b65338140fcad7c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveRange: {x: 0.05, y: 0.05}
+  posToEulerAngle: {x: 20, y: 20}
+  gamepadCenter: {fileID: 908049630}
+  rightHand: {fileID: 136507636}
+  leftHand: {fileID: 2075937860}
 --- !u!1 &1735706651
 GameObject:
   m_ObjectHideFlags: 0
@@ -2879,7 +1838,7 @@ Transform:
   - {fileID: 306547509}
   - {fileID: 1993346253}
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1787938562
 GameObject:
@@ -2947,78 +1906,6 @@ MonoBehaviour:
   animatorController: {fileID: 9100000, guid: 8274142a1807f5848a5dd1166db7d615, type: 2}
   windowStyleController: {fileID: 1629460657}
   settingAdjuster: {fileID: 478567140}
---- !u!1 &1798368041
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1798368042}
-  - component: {fileID: 1798368043}
-  m_Layer: 0
-  m_Name: GamePadRoot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1798368042
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1798368041}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.9, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 627282150}
-  - {fileID: 1374794598}
-  - {fileID: 1581013137}
-  - {fileID: 516414221}
-  - {fileID: 525847741}
-  - {fileID: 1708390758}
-  - {fileID: 1687041056}
-  - {fileID: 402429507}
-  - {fileID: 805620708}
-  - {fileID: 1461652145}
-  - {fileID: 873970061}
-  - {fileID: 613294833}
-  - {fileID: 1142378400}
-  - {fileID: 1706952128}
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1798368043
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1798368041}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d405ac410ca1f6547ad14daa8917ba87, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  buttons:
-    B: {fileID: 627282150}
-    A: {fileID: 1374794598}
-    X: {fileID: 1581013137}
-    Y: {fileID: 516414221}
-    Right: {fileID: 525847741}
-    Down: {fileID: 1708390758}
-    Left: {fileID: 1687041056}
-    Up: {fileID: 402429507}
-    LeftShoulder: {fileID: 873970061}
-    RightShoulder: {fileID: 1142378400}
-    LeftTrigger: {fileID: 613294833}
-    RightTrigger: {fileID: 1706952128}
-  leftStick: {fileID: 805620708}
-  rightStick: {fileID: 1461652145}
 --- !u!114 &1809547436
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3189,7 +2076,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1943931266
 MonoBehaviour:
@@ -3233,7 +2120,7 @@ Transform:
   m_Children:
   - {fileID: 2059529785}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 40, z: 0}
 --- !u!1 &1963776207
 GameObject:
@@ -3351,7 +2238,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1971722876
 GameObject:
@@ -3466,7 +2353,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5d792dff3b9d00a46ba79e5cb27c3ac9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  receiver: {fileID: 1993346255}
+  handIkIntegrator: {fileID: 2042410944}
 --- !u!114 &1993346255
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3479,6 +2366,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f9838934ad278ba4a92a84679291438b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  modifier: {fileID: 1993346254}
 --- !u!1 &2042410935
 GameObject:
   m_ObjectHideFlags: 0
@@ -3492,11 +2380,13 @@ GameObject:
   - component: {fileID: 2042410945}
   - component: {fileID: 2042410944}
   - component: {fileID: 2042410943}
-  - component: {fileID: 2042410942}
-  - component: {fileID: 2042410939}
   - component: {fileID: 2042410940}
   - component: {fileID: 2042410938}
   - component: {fileID: 2042410937}
+  - component: {fileID: 2042410939}
+  - component: {fileID: 2042410941}
+  - component: {fileID: 2042410942}
+  - component: {fileID: 2042410947}
   m_Layer: 0
   m_Name: HandAndHeadIK
   m_TagString: Untagged
@@ -3558,7 +2448,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: faa499f972ed274418d736038a33962e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _gamePad: {fileID: 1798368043}
+  _gamePad: {fileID: 0}
   _horizontalApproachCurve:
     serializedVersion: 2
     m_Curve:
@@ -3755,6 +2645,20 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   keyboardMotionDuration: 0.25
+--- !u!114 &2042410941
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2042410935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b305eeb1911da1f4cae5b779b5c81287, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gamePad: {fileID: 1698725305}
+  speedFactor: 3
 --- !u!114 &2042410942
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3798,8 +2702,8 @@ MonoBehaviour:
   rightHandTarget: {fileID: 500754461}
   leftHandTarget: {fileID: 1842530517}
   typing: {fileID: 2042410940}
-  gamepadHand: {fileID: 0}
-  gamepadFinger: {fileID: 0}
+  smallGamepadHand: {fileID: 2042410941}
+  gamepadFinger: {fileID: 2042410947}
   mouseMove: {fileID: 2042410937}
   presentation: {fileID: 2042410938}
   fingerController: {fileID: 2042410942}
@@ -3817,6 +2721,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gamePadBasedBodyLean: {fileID: 306547515}
+  smallGamepadHandIk: {fileID: 2042410941}
   handIkIntegrator: {fileID: 2042410944}
   headIkIntegrator: {fileID: 2042410943}
   ikWeightCrossFade: {fileID: 1963776208}
@@ -3837,6 +2742,19 @@ MonoBehaviour:
   handIkIntegrator: {fileID: 2042410944}
   headIkIntegrator: {fileID: 2042410943}
   gamepadBasedBodyLean: {fileID: 306547515}
+--- !u!114 &2042410947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2042410935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbd6fafd68189eb42825229844eea4fe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fingerController: {fileID: 2042410942}
 --- !u!1 &2059529784
 GameObject:
   m_ObjectHideFlags: 0
@@ -3927,6 +2845,36 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2059529784}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2075937859
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2075937860}
+  m_Layer: 0
+  m_Name: LeftHand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2075937860
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2075937859}
+  m_LocalRotation: {x: -0.3686878, y: 0.6275069, z: 0.52654076, w: 0.4393851}
+  m_LocalPosition: {x: -0.12, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 908049630}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: -80, y: 110, z: 0}
 --- !u!1 &2141451816
 GameObject:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -270,7 +270,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &238267459
 GameObject:
@@ -658,7 +658,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &500754460
 GameObject:
@@ -844,6 +844,83 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 525847740}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &613294832
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 613294833}
+  - component: {fileID: 613294835}
+  - component: {fileID: 613294834}
+  m_Layer: 0
+  m_Name: LTrigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &613294833
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613294832}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0.23, y: 0, z: 0.39}
+  m_LocalScale: {x: 0, y: 0, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1798368042}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!23 &613294834
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613294832}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &613294835
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613294832}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &627282149
 GameObject:
   m_ObjectHideFlags: 0
@@ -1001,7 +1078,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 20
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &708291030
 MonoBehaviour:
@@ -1155,7 +1232,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 452380, guid: 4dd277bd9572488489906165e0931952, type: 3}
       propertyPath: m_RootOrder
-      value: 13
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 452380, guid: 4dd277bd9572488489906165e0931952, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1171,6 +1248,113 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4dd277bd9572488489906165e0931952, type: 3}
+--- !u!1 &873970060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 873970061}
+  - component: {fileID: 873970063}
+  - component: {fileID: 873970062}
+  m_Layer: 0
+  m_Name: LShoulder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &873970061
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 873970060}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0.19, y: 0, z: 0.39}
+  m_LocalScale: {x: 0, y: 0, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1798368042}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!23 &873970062
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 873970060}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &873970063
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 873970060}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &908049629
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 908049630}
+  m_Layer: 0
+  m_Name: SmallGamepad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &908049630
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908049629}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1698725304}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &935302417
 GameObject:
   m_ObjectHideFlags: 0
@@ -1230,6 +1414,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e8f7c07703c252243acd7f3b73b1ebc6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  TriggerDownThreshold: 30
   DeviceNumber: 0
 --- !u!4 &953451442
 Transform:
@@ -1243,7 +1428,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1057131352
 GameObject:
@@ -1370,7 +1555,7 @@ Transform:
   - {fileID: 295217317}
   - {fileID: 4972949287635646}
   m_Father: {fileID: 0}
-  m_RootOrder: 16
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1130871116
 MonoBehaviour:
@@ -1463,6 +1648,83 @@ Transform:
   m_Father: {fileID: 1674567171}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1142378399
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1142378400}
+  - component: {fileID: 1142378402}
+  - component: {fileID: 1142378401}
+  m_Layer: 0
+  m_Name: RShoulder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1142378400
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1142378399}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.19, y: 0, z: 0.39}
+  m_LocalScale: {x: 0, y: 0, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1798368042}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!23 &1142378401
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1142378399}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1142378402
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1142378399}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1169325485
 GameObject:
   m_ObjectHideFlags: 0
@@ -1626,7 +1888,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1268007393
 MonoBehaviour:
@@ -1809,7 +2071,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1335587171
 MonoBehaviour:
@@ -2321,7 +2583,7 @@ Transform:
   - {fileID: 1842530517}
   - {fileID: 638373946}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1687041055
 GameObject:
@@ -2399,6 +2661,114 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1687041055}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1698725303
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1698725304}
+  m_Layer: 0
+  m_Name: SmallGamepadRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1698725304
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1698725303}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.9, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 908049630}
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1706952127
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1706952128}
+  - component: {fileID: 1706952130}
+  - component: {fileID: 1706952129}
+  m_Layer: 0
+  m_Name: RTrigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1706952128
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1706952127}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.23, y: 0, z: 0.39}
+  m_LocalScale: {x: 0, y: 0, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1798368042}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!23 &1706952129
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1706952127}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8d164535b1e5cfb46abdc087216dc6fa, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1706952130
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1706952127}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1708390757
 GameObject:
@@ -2509,7 +2879,7 @@ Transform:
   - {fileID: 306547509}
   - {fileID: 1993346253}
   m_Father: {fileID: 0}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1787938562
 GameObject:
@@ -2615,8 +2985,12 @@ Transform:
   - {fileID: 402429507}
   - {fileID: 805620708}
   - {fileID: 1461652145}
+  - {fileID: 873970061}
+  - {fileID: 613294833}
+  - {fileID: 1142378400}
+  - {fileID: 1706952128}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1798368043
 MonoBehaviour:
@@ -2639,6 +3013,10 @@ MonoBehaviour:
     Down: {fileID: 1708390758}
     Left: {fileID: 1687041056}
     Up: {fileID: 402429507}
+    LeftShoulder: {fileID: 873970061}
+    RightShoulder: {fileID: 1142378400}
+    LeftTrigger: {fileID: 613294833}
+    RightTrigger: {fileID: 1706952128}
   leftStick: {fileID: 805620708}
   rightStick: {fileID: 1461652145}
 --- !u!114 &1809547436
@@ -2811,7 +3189,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1943931266
 MonoBehaviour:
@@ -2855,7 +3233,7 @@ Transform:
   m_Children:
   - {fileID: 2059529785}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 40, z: 0}
 --- !u!1 &1963776207
 GameObject:
@@ -2973,7 +3351,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1971722876
 GameObject:
@@ -3420,7 +3798,8 @@ MonoBehaviour:
   rightHandTarget: {fileID: 500754461}
   leftHandTarget: {fileID: 1842530517}
   typing: {fileID: 2042410940}
-  gamepad: {fileID: 2042410939}
+  gamepadHand: {fileID: 0}
+  gamepadFinger: {fileID: 0}
   mouseMove: {fileID: 2042410937}
   presentation: {fileID: 2042410938}
   fingerController: {fileID: 2042410942}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/GamepadProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/GamepadProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using UnityEngine;
-using XinputGamePad;
 
 namespace Baku.VMagicMirror
 {
@@ -20,16 +19,24 @@ namespace Baku.VMagicMirror
             public Transform Left;
             public Transform Up;
 
+            //NOTE: この二つは人差し指で押すボタン
+            public Transform LeftShoulder;
+            public Transform RightShoulder;
+
+            //連続値が拾えるトリガーだが、便宜的にボタンと同じ扱いにする
+            public Transform LeftTrigger;
+            public Transform RightTrigger;
+            
             public Transform[] GetTransforms() => new Transform[]
             {
-                B, A, X, Y, Right, Down, Left, Up
+                B, A, X, Y, Right, Down, Left, Up, 
             };
         }
 
         [SerializeField] private ButtonTransforms buttons;
         [SerializeField] private Transform leftStick = null;
         [SerializeField] private Transform rightStick = null;
-
+        
         private void Start()
         {
             var buttonMat = HIDMaterialUtil.Instance.GetButtonMaterial();
@@ -46,26 +53,34 @@ namespace Baku.VMagicMirror
             rightStick.GetComponent<MeshRenderer>().material = stickAreaMat;
         }
 
-        public Vector3 GetButtonPosition(XinputKey key)
+        public Vector3 GetButtonPosition(GamepadKey key)
         {
             switch (key)
             {
-                case XinputKey.B:
+                case GamepadKey.B:
                     return buttons.B.position;
-                case XinputKey.A:
+                case GamepadKey.A:
                     return buttons.A.position;
-                case XinputKey.X:
+                case GamepadKey.X:
                     return buttons.X.position;
-                case XinputKey.Y:
+                case GamepadKey.Y:
                     return buttons.Y.position;
-                case XinputKey.RIGHT:
+                case GamepadKey.RIGHT:
                     return buttons.Right.position;
-                case XinputKey.DOWN:
+                case GamepadKey.DOWN:
                     return buttons.Down.position;
-                case XinputKey.LEFT:
+                case GamepadKey.LEFT:
                     return buttons.Left.position;
-                case XinputKey.UP:
+                case GamepadKey.UP:
                     return buttons.Up.position;
+                case GamepadKey.RShoulder:
+                    return buttons.RightShoulder.position;
+                case GamepadKey.LShoulder:
+                    return buttons.LeftShoulder.position;
+                case GamepadKey.RTrigger:
+                    return buttons.RightTrigger.position;
+                case GamepadKey.LTrigger:
+                    return buttons.LeftTrigger.position;
                 default:
                     //来ないはず
                     return buttons.A.position;
@@ -73,36 +88,56 @@ namespace Baku.VMagicMirror
 
         }
 
-        public static bool IsLeftHandPreferred(XinputKey key)
+        public static bool IsLeftHandPreferred(GamepadKey key)
         {
             switch (key)
             {
-                case XinputKey.B:
-                case XinputKey.A:
-                case XinputKey.X:
-                case XinputKey.Y:
+                case GamepadKey.B:
+                case GamepadKey.A:
+                case GamepadKey.X:
+                case GamepadKey.Y:
+                case GamepadKey.RShoulder:
+                case GamepadKey.RTrigger:
                     return false;
                 default:
                     return true;
             }
         }
 
-        public static ReactedHand GetPreferredReactionHand(XinputKey key)
+        public static ReactedHand GetPreferredReactionHand(GamepadKey key)
         {
             switch (key)
             {
-                case XinputKey.B:
-                case XinputKey.A:
-                case XinputKey.X:
-                case XinputKey.Y:
+                case GamepadKey.B:
+                case GamepadKey.A:
+                case GamepadKey.X:
+                case GamepadKey.Y:
+                case GamepadKey.RShoulder:
+                case GamepadKey.RTrigger:
                     return ReactedHand.Right;
-                case XinputKey.UP:
-                case XinputKey.RIGHT:
-                case XinputKey.DOWN:
-                case XinputKey.LEFT:
+                case GamepadKey.UP:
+                case GamepadKey.RIGHT:
+                case GamepadKey.DOWN:
+                case GamepadKey.LEFT:
+                case GamepadKey.LShoulder:
+                case GamepadKey.LTrigger:
                     return ReactedHand.Left;
                 default:
                     return ReactedHand.None;
+            }
+        }
+
+        public static bool IsSideKey(GamepadKey key)
+        {
+            switch (key)
+            {
+                case GamepadKey.RShoulder:
+                case GamepadKey.RTrigger:
+                case GamepadKey.LShoulder:
+                case GamepadKey.LTrigger:
+                    return true;
+                default:
+                    return false;
             }
         }
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/HidTransformController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/HidTransformController.cs
@@ -16,16 +16,14 @@ namespace Baku.VMagicMirror
 
         [SerializeField]
         private TouchPadProvider touchpad = null;
-
-        [SerializeField]
-        private GamepadProvider gamepad = null;
+        
+        [SerializeField] private SmallGamepadProvider smallGamepad = null;
 
         [SerializeField]
         private ParticleStore particleStore = null;
 
         private Transform _keyboardRoot => keyboard.transform;
         private Transform _touchPadRoot => touchpad.transform.parent;
-        private Transform _gamepadRoot => gamepad.transform;
 
         void Start()
         {
@@ -43,15 +41,15 @@ namespace Baku.VMagicMirror
                         SetHidVisibility(message.ToBoolean());
                         break;
                     case MessageCommandNames.GamepadHeight:
-                        SetGamepadHeight(message.ParseAsCentimeter());
+                        smallGamepad.SetHeight(message.ParseAsCentimeter());
                         break;
                     case MessageCommandNames.GamepadHorizontalScale:
-                        SetGamepadHorizontalScale(message.ParseAsPercentage());
+                        smallGamepad.SetHorizontalScale(message.ParseAsPercentage());
                         break;
                     case MessageCommandNames.GamepadVisibility:
-                        SetGamepadVisibility(message.ToBoolean());
+                        //何もしない: ゲームパッドのメッシュが無くなったので
+//                        SetGamepadVisibility(message.ToBoolean());
                         break;
-
                     default:
                         break;
                 }
@@ -80,25 +78,6 @@ namespace Baku.VMagicMirror
         {
             keyboard.gameObject.SetActive(v);
             //touchpad.gameObject.SetActive(v);
-        }
-
-        private void SetGamepadHeight(float v)
-        {
-            var gamepadPos = _gamepadRoot.position;
-            _gamepadRoot.position = new Vector3(gamepadPos.x, v, gamepadPos.z);
-        }
-
-        private void SetGamepadHorizontalScale(float v)
-        {
-            _gamepadRoot.localScale = new Vector3(v, 1.0f, v);
-        }
-
-        private void SetGamepadVisibility(bool v)
-        {
-            foreach(var renderer in _gamepadRoot.GetComponentsInChildren<MeshRenderer>())
-            {
-                renderer.enabled = v;
-            }
         }
     }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/SmallGamepadProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/SmallGamepadProvider.cs
@@ -1,0 +1,60 @@
+﻿using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// 小さく、手で持って動かせるゲームパッドの位置と回転を表現するためのクラス
+    /// </summary>
+    public class SmallGamepadProvider : MonoBehaviour
+    {
+        //このx, zはスケーリングの影響を受けて、スケールが小さいと動きも小さくなる
+        [Tooltip("スティックを限界まで倒したときにゲームパッドが並進すべき距離(x, z)。")]
+        [SerializeField] private Vector2 moveRange = new Vector2(0.05f, 0.05f);
+         
+        [Tooltip("スティックを限界まで倒したときにゲームパッドが傾くべき角度")]
+        [SerializeField] private Vector2 posToEulerAngle = new Vector2(20f,20f);
+
+        [SerializeField] private Transform gamepadCenter = null;
+        [SerializeField] private Transform rightHand = null;
+        [SerializeField] private Transform leftHand = null;
+
+        private Vector3 _gamePadCenterInitialPosition;
+        
+        private void Start()
+        {
+            _gamePadCenterInitialPosition = gamepadCenter.localPosition;
+        }
+        
+        /// <summary>
+        /// [-1, 1]の範囲で表現されたスティック情報をもとにゲームパッドの位置を変更します。
+        /// </summary>
+        /// <param name="pos"></param>
+        public void SetHorizontalPosition(Vector2 pos)
+        {
+            gamepadCenter.localPosition =
+                _gamePadCenterInitialPosition +
+                new Vector3(
+                    moveRange.x * pos.x,
+                    0.0f,
+                    moveRange.y * pos.y
+                    );
+            
+            //並進に合わせて回転もする
+            gamepadCenter.localRotation = Quaternion.Euler(
+                pos.y * posToEulerAngle.y,
+                0,
+                -pos.x * posToEulerAngle.x
+                );
+        }
+        
+        public void SetHeight(float height) => transform.position = height * Vector3.up;
+        
+        //NOTE: yのスケールも必ず変える: 傾けたときにローカル座標が歪まないようにするため(いわゆるアフィン変換っぽいのをやりたい)
+        public void SetHorizontalScale(float scale) => transform.localScale = scale * Vector3.one;
+        
+        //ワールドのを渡す点に注意
+        public (Vector3, Quaternion) GetRightHand() => (rightHand.position, rightHand.rotation);
+        public (Vector3, Quaternion) GetLeftHand() => (leftHand.position, leftHand.rotation);
+
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/SmallGamepadProvider.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/SmallGamepadProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db12dc8aed5453f43b65338140fcad7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/XinputKeyData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/XinputKeyData.cs
@@ -2,22 +2,22 @@
 
 namespace Baku.VMagicMirror
 {
-    public struct XinputKeyData
+    public struct GamepadKeyData
     {
-        public XinputKeyData(XinputKey key, bool isPressed) : this()
+        public GamepadKeyData(GamepadKey key, bool isPressed) : this()
         {
             Key = key;
             IsPressed = isPressed;
         }
 
-        public readonly XinputKey Key;
+        public readonly GamepadKey Key;
         public readonly bool IsPressed;
 
         public bool IsArrowKey =>
-            Key == XinputKey.UP ||
-            Key == XinputKey.RIGHT ||
-            Key == XinputKey.DOWN ||
-            Key == XinputKey.LEFT;
+            Key == GamepadKey.UP ||
+            Key == GamepadKey.RIGHT ||
+            Key == GamepadKey.DOWN ||
+            Key == GamepadKey.LEFT;
     }
 }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/BodyMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/BodyMotionManager.cs
@@ -13,9 +13,6 @@ namespace Baku.VMagicMirror
         [SerializeField] private GamepadBasedBodyLean gamepadBasedBodyLean = null;
         [SerializeField] private ImageBasedBodyMotion imageBasedBodyMotion = null;
         [SerializeField] private WaitingBodyMotion waitingBodyMotion = null;
-
-        [SerializeField] private float gamePadBodyLeanSpeedFactor = 6.0f;
-
         [Inject] private IVRMLoadable _vrmLoadable = null;
 
         public WaitingBodyMotion WaitingBodyMotion => waitingBodyMotion;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/GamepadBasedBodyLean.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Body/GamepadBasedBodyLean.cs
@@ -8,8 +8,9 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class GamepadBasedBodyLean : MonoBehaviour
     {
-        private const float BodyLeanSpeedFactor = 6.0f;
-        private const float BodyLeanMaxAngleDegree = 5.0f;
+        private const float BodyLeanSpeedFactor = 3.0f;
+        
+        [SerializeField] private Vector2 bodyLeanMaxAngle = new Vector2(2.0f, 2.0f);
         
         public Quaternion BodyLeanSuggest { get; private set; } = Quaternion.identity;
         public bool ReverseGamepadStickLeanHorizontal { get; set; } = false;
@@ -78,9 +79,9 @@ namespace Baku.VMagicMirror
                 );
             
             _target = Quaternion.Euler(
-                pos.y * BodyLeanMaxAngleDegree,
+                pos.y * bodyLeanMaxAngle.y,
                 0,
-                -pos.x * BodyLeanMaxAngleDegree
+                -pos.x * bodyLeanMaxAngle.x
                 );
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/ElbowMotionModifyReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/ElbowMotionModifyReceiver.cs
@@ -7,10 +7,8 @@ namespace Baku.VMagicMirror
     public class ElbowMotionModifyReceiver : MonoBehaviour
     {
         [Inject] private ReceivedMessageHandler handler = null;
-
-        public float WaistWidthHalf { get; private set; } = 0.15f;
-        public float ElbowCloseStrength { get; private set; } = 0.30f;
-
+        [SerializeField] private ElbowMotionModifier modifier = null;
+        
         private void Start()
         {
             handler.Commands.Subscribe(message =>
@@ -18,16 +16,13 @@ namespace Baku.VMagicMirror
                 switch (message.Command)
                 {
                     case MessageCommandNames.SetWaistWidth:
-                        SetWaistWidth(message.ParseAsCentimeter());
+                        modifier.SetWaistWidth(message.ParseAsCentimeter());
                         break;
                     case MessageCommandNames.SetElbowCloseStrength:
-                        SetElbowCloseStrength(message.ParseAsPercentage());
+                        modifier.SetElbowCloseStrength(message.ParseAsPercentage());
                         break;
                 }
             });
         }
-
-        private void SetWaistWidth(float width) => WaistWidthHalf = width * 0.5f;
-        private void SetElbowCloseStrength(float strength) => ElbowCloseStrength = strength;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/FingerController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/FingerController.cs
@@ -19,7 +19,7 @@ namespace Baku.VMagicMirror
 
         private const float DefaultBendingAngle = 10.0f;
         private const float Duration = 0.25f;
-        private const float MaxBendingAngle = 25f;
+        private const float ThumbProximalMaxBendAngle = 30f;
         private const float HoldOperationSpeedFactor = 18.0f;
 
         //NOTE: 曲げ角度の符号に注意。左右で意味変わるのと、親指とそれ以外の差にも注意
@@ -57,6 +57,7 @@ namespace Baku.VMagicMirror
         private readonly bool[] _isAnimating = new bool[10];
         private readonly float[] _animationStartedTime = new float[10];
         private readonly bool[] _shouldHoldPressedMode = new bool[10];
+        private readonly float[] _holdAngles = new float[10];
         //「指を曲げっぱなしにする/離す」というオペレーションによって決まる値
         private readonly float[] _holdOperationBendingAngle = new float[10];
 
@@ -186,26 +187,29 @@ namespace Baku.VMagicMirror
         }
 
         /// <summary>
-        /// 特定の指を下げっぱなしにします。ゲームパッドの入力を表現するために使うのを想定しています。
+        /// 特定の指の曲げ角度を固定します。ゲームパッドの入力を表現するために使うのを想定しています。
         /// </summary>
         /// <param name="fingerNumber"></param>
-        public void PressAndHold(int fingerNumber)
+        /// <param name="angle"></param>
+        public void Hold(int fingerNumber, float angle)
         {
-            if (fingerNumber > 0 && fingerNumber < 11)
+            if (fingerNumber >= 0 && fingerNumber < _shouldHoldPressedMode.Length)
             {
-                _shouldHoldPressedMode[fingerNumber - 1] = true;
+                _shouldHoldPressedMode[fingerNumber] = true;
+                _holdAngles[fingerNumber] = angle;
             }
         }
 
         /// <summary>
-        /// <see cref="PressAndHold"/>で下げた指を上げます。
+        /// <see cref="Hold"/>で押していた指を解放します。
         /// </summary>
         /// <param name="fingerNumber"></param>
-        public void ReleaseHoldedFinger(int fingerNumber)
+        public void Release(int fingerNumber)
         {
-            if (fingerNumber > 0 && fingerNumber < 11)
+            if (fingerNumber >= 0 && fingerNumber < _shouldHoldPressedMode.Length)
             {
-                _shouldHoldPressedMode[fingerNumber - 1] = false;
+                _shouldHoldPressedMode[fingerNumber] = false;
+                _holdAngles[fingerNumber] = 0;
             }
         }
         
@@ -232,7 +236,7 @@ namespace Baku.VMagicMirror
 
                 _holdOperationBendingAngle[i] = Mathf.Lerp(
                     _holdOperationBendingAngle[i],
-                    _shouldHoldPressedMode[i] ? MaxBendingAngle : DefaultBendingAngle,
+                    _shouldHoldPressedMode[i] ? _holdAngles[i] : DefaultBendingAngle,
                     HoldOperationSpeedFactor * Time.deltaTime
                     );
                 
@@ -257,12 +261,16 @@ namespace Baku.VMagicMirror
                     angle = -angle;
                 }
 
-                foreach (var t in _fingers[i])
+                
+                for (int j = 0; j < _fingers[i].Length; j++)
                 {
-                    _holdOperationBendingAngle[i] = angle;
+                    var t = _fingers[i][j];
+                    //Holdのほうの値は正負考えずに入れるようになってるため、常にプラスで保存
+                    _holdOperationBendingAngle[i] = Mathf.Abs(angle);
+                    angle = LimitThumbBendAngle(angle, i, j);
                     if (t != null)
                     {
-                        t.localRotation = Quaternion.AngleAxis(angle, Vector3.forward);
+                        t.localRotation = Quaternion.AngleAxis(angle, GetRotationAxis(i, j));
                     }
                 }
             }
@@ -300,6 +308,36 @@ namespace Baku.VMagicMirror
 
                 targets[i].localRotation = Quaternion.AngleAxis(angles[i], axis);
             }
+        }
+
+        private static Vector3 GetRotationAxis(int fingerNumber, int jointIndex)
+        {
+            if ((fingerNumber == FingerConsts.LeftThumb || fingerNumber == FingerConsts.RightThumb) && 
+                jointIndex < 2
+                )
+            {
+                return Vector3.down;
+            }
+            else
+            {
+                return Vector3.forward;
+            }
+        }
+
+        private static float LimitThumbBendAngle(float angle, int fingerNumber, int jointIndex)
+        {
+            if (fingerNumber != FingerConsts.LeftThumb &&
+                fingerNumber != FingerConsts.RightThumb)
+            {
+                return angle;
+            }
+
+            if (jointIndex != 2)
+            {
+                return angle;
+            }
+
+            return Mathf.Clamp(angle, -ThumbProximalMaxBendAngle, ThumbProximalMaxBendAngle);
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/GamepadFingerController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/GamepadFingerController.cs
@@ -1,0 +1,68 @@
+﻿using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public class GamepadFingerController : MonoBehaviour
+    {
+        [SerializeField] private FingerController fingerController = null;
+
+        //どの指が何個のキーを押しているか、という値の一覧。親指の同時押しとかをちゃんとモニタリングするために使う
+        private readonly int[] _fingerPressButtonCounts = new int[10];
+        //NOTE: 親指のスティック操作に対して何が出来るか考えないといけないんですよね…
+
+        public void ButtonDown(GamepadKey key)
+        {
+            int fingerNumber = KeyToFingerNumber(key);
+            _fingerPressButtonCounts[fingerNumber - 1]++;
+            fingerController.PressAndHold(fingerNumber);
+        }
+
+        public void ButtonUp(GamepadKey key)
+        {
+            int fingerNumber = KeyToFingerNumber(key);
+            _fingerPressButtonCounts[fingerNumber - 1]--;
+            if (_fingerPressButtonCounts[fingerNumber - 1] == 0)
+            {
+                fingerController.ReleaseHoldedFinger(fingerNumber);
+            }
+        }
+
+        public void LeftStick(Vector2 stickPos)
+        {
+            //とりあえず何もしない: 親指のIKした方がいい可能性はある
+        }
+
+        public void RightStick(Vector2 stickPos)
+        {
+            //とりあえず何もしない: 親指のIKした方がいい可能性はある
+        }
+
+        private static int KeyToFingerNumber(GamepadKey key)
+        {
+            switch (key)
+            {
+                case GamepadKey.A:
+                case GamepadKey.B:
+                case GamepadKey.X:
+                case GamepadKey.Y:
+                    return FingerConsts.RightThumb;
+                case GamepadKey.UP:
+                case GamepadKey.RIGHT:
+                case GamepadKey.LEFT:
+                case GamepadKey.DOWN:
+                    return FingerConsts.LeftThumb;
+                case GamepadKey.RShoulder:
+                    return FingerConsts.RightIndex;
+                case GamepadKey.RTrigger:
+                    return FingerConsts.RightMiddle;
+                case GamepadKey.LShoulder:
+                    return FingerConsts.LeftIndex;
+                case GamepadKey.LTrigger:
+                    return FingerConsts.LeftMiddle;
+                default:
+                    return FingerConsts.RightThumb;
+            }
+        }
+        
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/GamepadFingerController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/GamepadFingerController.cs
@@ -13,18 +13,18 @@ namespace Baku.VMagicMirror
         public void ButtonDown(GamepadKey key)
         {
             int fingerNumber = KeyToFingerNumber(key);
-            _fingerPressButtonCounts[fingerNumber - 1]++;
-            fingerController.PressAndHold(fingerNumber);
+            _fingerPressButtonCounts[fingerNumber]++;
+            fingerController.Hold(fingerNumber, GetBendingAngle(fingerNumber, true));
         }
 
         public void ButtonUp(GamepadKey key)
         {
             int fingerNumber = KeyToFingerNumber(key);
-            _fingerPressButtonCounts[fingerNumber - 1]--;
-            if (_fingerPressButtonCounts[fingerNumber - 1] == 0)
-            {
-                fingerController.ReleaseHoldedFinger(fingerNumber);
-            }
+            _fingerPressButtonCounts[fingerNumber]--;
+            fingerController.Hold(
+                fingerNumber,
+                GetBendingAngle(fingerNumber, _fingerPressButtonCounts[fingerNumber] > 0)
+                );
         }
 
         public void LeftStick(Vector2 stickPos)
@@ -37,6 +37,64 @@ namespace Baku.VMagicMirror
             //とりあえず何もしない: 親指のIKした方がいい可能性はある
         }
 
+        /// <summary>右手でコントローラを握ります。</summary>
+        public void GripRightHand()
+        {
+            foreach (int fingerNumber in new[]
+            {
+                FingerConsts.RightThumb,
+                FingerConsts.RightIndex,
+                FingerConsts.RightMiddle,
+                FingerConsts.RightRing,
+                FingerConsts.RightLittle,
+            })
+            {
+                fingerController.Hold(
+                    fingerNumber,
+                    GetBendingAngle(fingerNumber, _fingerPressButtonCounts[fingerNumber] > 0)
+                );
+            }
+        }
+
+        /// <summary>左手でコントローラを握ります。</summary>
+        public void GripLeftHand()
+        {
+            foreach (int fingerNumber in new[]
+            {
+                FingerConsts.LeftThumb,
+                FingerConsts.LeftIndex,
+                FingerConsts.LeftMiddle,
+                FingerConsts.LeftRing,
+                FingerConsts.LeftLittle,
+            })
+            {
+                fingerController.Hold(
+                    fingerNumber,
+                    GetBendingAngle(fingerNumber, _fingerPressButtonCounts[fingerNumber] > 0)
+                );
+            }
+        }
+
+        /// <summary>右手をコントローラから離します。</summary>
+        public void ReleaseRightHand()
+        {
+            fingerController.Release(FingerConsts.RightThumb);
+            fingerController.Release(FingerConsts.RightIndex);
+            fingerController.Release(FingerConsts.RightMiddle);
+            fingerController.Release(FingerConsts.RightRing);
+            fingerController.Release(FingerConsts.RightLittle);
+        }
+
+        /// <summary>左手をコントローラから離します。</summary>
+        public void ReleaseLeftHand()
+        {
+            fingerController.Release(FingerConsts.LeftThumb);
+            fingerController.Release(FingerConsts.LeftIndex);
+            fingerController.Release(FingerConsts.LeftMiddle);
+            fingerController.Release(FingerConsts.LeftRing);
+            fingerController.Release(FingerConsts.LeftLittle);
+        }
+        
         private static int KeyToFingerNumber(GamepadKey key)
         {
             switch (key)
@@ -64,5 +122,36 @@ namespace Baku.VMagicMirror
             }
         }
         
+        /// <summary>
+        /// 指と、その指がボタンを押しているかどうかを用いて、指の望ましい曲げ角度を取得します。
+        /// </summary>
+        /// <param name="fingerNumber"></param>
+        /// <param name="isPressed"></param>
+        /// <returns></returns>
+        private static float GetBendingAngle(int fingerNumber, bool isPressed)
+        {
+            //必要な場合分け:
+            // - 親指, ひとさし-中指, 薬指-小指の区分
+            // - 押す/押さない
+
+            switch (fingerNumber)
+            {
+                case FingerConsts.LeftRing:
+                case FingerConsts.LeftLittle:
+                case FingerConsts.RightRing:
+                case FingerConsts.RightLittle:
+                    return 80f;
+                case FingerConsts.RightIndex:
+                case FingerConsts.RightMiddle:
+                case FingerConsts.LeftIndex:
+                case FingerConsts.LeftMiddle:
+                    return isPressed ? 45f : 30f;
+                case FingerConsts.LeftThumb:
+                case FingerConsts.RightThumb:
+                    return isPressed ? 45f: 30f;
+                default:
+                    return 25f;
+            }
+        }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/GamepadFingerController.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/GamepadFingerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbd6fafd68189eb42825229844eea4fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
@@ -1,6 +1,5 @@
 ﻿using RootMotion.FinalIK;
 using UnityEngine;
-using XinputGamePad;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -21,8 +20,10 @@ namespace Baku.VMagicMirror
         [SerializeField] private TypingHandIKGenerator typing = null;
         public TypingHandIKGenerator Typing => typing;
 
-        [SerializeField] private GamepadHandIKGenerator gamepad = null;
-        public GamepadHandIKGenerator Gamepad => gamepad;
+        [SerializeField] private GamepadHandIKGenerator gamepadHand = null;
+        public GamepadHandIKGenerator GamepadHand => gamepadHand;
+
+        [SerializeField] private GamepadFingerController gamepadFinger = null;
 
         [SerializeField] private MouseMoveHandIKGenerator mouseMove = null;
         public MouseMoveHandIKGenerator MouseMove => mouseMove;
@@ -99,19 +100,21 @@ namespace Baku.VMagicMirror
 
         public void MoveLeftGamepadStick(Vector2 v)
         {
-            gamepad.LeftStick(v);
+            gamepadHand.LeftStick(v);
+            gamepadHand.LeftStick(v);
             SetLeftHandIk(HandTargetType.Gamepad);
         }
 
         public void MoveRightGamepadStick(Vector2 v)
         {
-            gamepad.RightStick(v);
+            gamepadHand.RightStick(v);
+            gamepadFinger.RightStick(v);
             SetRightHandIk(HandTargetType.Gamepad);
         }
 
-        public void GamepadButtonDown(XinputKey key)
+        public void GamepadButtonDown(GamepadKey key)
         {
-            var hand = gamepad.ButtonDown(key);
+            var hand = gamepadHand.ButtonDown(key);
             if (hand == ReactedHand.Left)
             {
                 SetLeftHandIk(HandTargetType.Gamepad);
@@ -120,11 +123,13 @@ namespace Baku.VMagicMirror
             {
                 SetRightHandIk(HandTargetType.Gamepad);
             }
+            
+            gamepadFinger.ButtonDown(key);
         }
 
-        public void GamepadButtonUp(XinputKey key)
+        public void GamepadButtonUp(GamepadKey key)
         {
-            var hand = gamepad.ButtonUp(key);
+            var hand = gamepadHand.ButtonUp(key);
             if (hand == ReactedHand.Left)
             {
                 SetLeftHandIk(HandTargetType.Gamepad);
@@ -133,6 +138,8 @@ namespace Baku.VMagicMirror
             {
                 SetRightHandIk(HandTargetType.Gamepad);
             }
+
+            gamepadFinger.ButtonUp(key);
         }
 
         /// <summary> 既定の秒数をかけて手のIKを無効化します。 </summary>
@@ -251,7 +258,7 @@ namespace Baku.VMagicMirror
 
             var ik =
                 (targetType == HandTargetType.Keyboard) ? Typing.LeftHand :
-                (targetType == HandTargetType.Gamepad) ? Gamepad.LeftHand :
+                (targetType == HandTargetType.Gamepad) ? GamepadHand.LeftHand :
                 Typing.LeftHand;
 
             _prevLeftHand = _currentLeftHand;
@@ -271,7 +278,7 @@ namespace Baku.VMagicMirror
             var ik =
                 (targetType == HandTargetType.Mouse) ? MouseMove.RightHand :
                 (targetType == HandTargetType.Keyboard) ? Typing.RightHand :
-                (targetType == HandTargetType.Gamepad) ? Gamepad.RightHand :
+                (targetType == HandTargetType.Gamepad) ? GamepadHand.RightHand :
                 (targetType == HandTargetType.Presentation) ? Presentation.RightHand :
                 Typing.RightHand;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
@@ -1,5 +1,4 @@
-﻿using RootMotion.FinalIK;
-using UnityEngine;
+﻿using UnityEngine;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -20,8 +19,12 @@ namespace Baku.VMagicMirror
         [SerializeField] private TypingHandIKGenerator typing = null;
         public TypingHandIKGenerator Typing => typing;
 
-        [SerializeField] private GamepadHandIKGenerator gamepadHand = null;
-        public GamepadHandIKGenerator GamepadHand => gamepadHand;
+//        [SerializeField] private GamepadHandIKGenerator gamepadHand = null;
+//        public GamepadHandIKGenerator GamepadHand => gamepadHand;
+//
+        [SerializeField] private SmallGamepadHandIKGenerator smallGamepadHand = null;
+        public SmallGamepadHandIKGenerator SmallGamepadHand => smallGamepadHand;
+        
 
         [SerializeField] private GamepadFingerController gamepadFinger = null;
 
@@ -56,6 +59,8 @@ namespace Baku.VMagicMirror
 
         public bool EnablePresentationMode { get; set; }
 
+        public bool IsLeftHandGripGamepad => _leftTargetType == HandTargetType.Gamepad;
+        public bool IsRightHandGripGamepad => _rightTargetType == HandTargetType.Gamepad;
 
         #region API
 
@@ -100,21 +105,21 @@ namespace Baku.VMagicMirror
 
         public void MoveLeftGamepadStick(Vector2 v)
         {
-            gamepadHand.LeftStick(v);
-            gamepadHand.LeftStick(v);
+            smallGamepadHand.LeftStick(v);
+            gamepadFinger.LeftStick(v);
             SetLeftHandIk(HandTargetType.Gamepad);
         }
 
         public void MoveRightGamepadStick(Vector2 v)
         {
-            gamepadHand.RightStick(v);
+            smallGamepadHand.RightStick(v);
             gamepadFinger.RightStick(v);
             SetRightHandIk(HandTargetType.Gamepad);
         }
 
         public void GamepadButtonDown(GamepadKey key)
         {
-            var hand = gamepadHand.ButtonDown(key);
+            var hand = GamepadProvider.GetPreferredReactionHand(key);
             if (hand == ReactedHand.Left)
             {
                 SetLeftHandIk(HandTargetType.Gamepad);
@@ -123,13 +128,12 @@ namespace Baku.VMagicMirror
             {
                 SetRightHandIk(HandTargetType.Gamepad);
             }
-            
             gamepadFinger.ButtonDown(key);
         }
 
         public void GamepadButtonUp(GamepadKey key)
         {
-            var hand = gamepadHand.ButtonUp(key);
+            var hand = GamepadProvider.GetPreferredReactionHand(key);
             if (hand == ReactedHand.Left)
             {
                 SetLeftHandIk(HandTargetType.Gamepad);
@@ -138,10 +142,16 @@ namespace Baku.VMagicMirror
             {
                 SetRightHandIk(HandTargetType.Gamepad);
             }
-
             gamepadFinger.ButtonUp(key);
         }
 
+        public void ButtonStick(Vector2Int pos)
+        {
+            smallGamepadHand.ButtonStick(pos);
+            SetLeftHandIk(HandTargetType.Gamepad);
+        }
+        
+        
         /// <summary> 既定の秒数をかけて手のIKを無効化します。 </summary>
         public void DisableHandIk()
         {
@@ -254,16 +264,27 @@ namespace Baku.VMagicMirror
                 return;
             }
 
+            var prevType = _leftTargetType;
             _leftTargetType = targetType;
 
             var ik =
                 (targetType == HandTargetType.Keyboard) ? Typing.LeftHand :
-                (targetType == HandTargetType.Gamepad) ? GamepadHand.LeftHand :
+                (targetType == HandTargetType.Gamepad) ? SmallGamepadHand.LeftHand :
                 Typing.LeftHand;
 
             _prevLeftHand = _currentLeftHand;
             _currentLeftHand = ik;
             _leftHandStateBlendCount = 0f;
+
+            if (prevType == HandTargetType.Gamepad)
+            {
+                gamepadFinger.ReleaseLeftHand();
+            }
+            if (targetType == HandTargetType.Gamepad)
+            {
+                gamepadFinger.GripLeftHand();
+            }
+
         }
 
         private void SetRightHandIk(HandTargetType targetType)
@@ -273,12 +294,13 @@ namespace Baku.VMagicMirror
                 return;
             }
 
+            var prevType = _rightTargetType;
             _rightTargetType = targetType;
 
             var ik =
                 (targetType == HandTargetType.Mouse) ? MouseMove.RightHand :
                 (targetType == HandTargetType.Keyboard) ? Typing.RightHand :
-                (targetType == HandTargetType.Gamepad) ? GamepadHand.RightHand :
+                (targetType == HandTargetType.Gamepad) ? SmallGamepadHand.RightHand :
                 (targetType == HandTargetType.Presentation) ? Presentation.RightHand :
                 Typing.RightHand;
 
@@ -287,6 +309,15 @@ namespace Baku.VMagicMirror
             _rightHandStateBlendCount = 0f;
 
             fingerController.RightHandPresentationMode = (targetType == HandTargetType.Presentation);
+
+            if (prevType == HandTargetType.Gamepad)
+            {
+                gamepadFinger.ReleaseRightHand();
+            }
+            if (targetType == HandTargetType.Gamepad)
+            {
+                gamepadFinger.GripRightHand();
+            }
         }
 
         /// <summary>
@@ -304,5 +335,6 @@ namespace Baku.VMagicMirror
             Presentation,
             Gamepad,
         }
+
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/GamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/GamepadHandIKGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using UnityEngine;
-using XinputGamePad;
 
 namespace Baku.VMagicMirror
 {
@@ -83,12 +82,17 @@ namespace Baku.VMagicMirror
 
         #region API
 
-        public ReactedHand ButtonDown(XinputKey key)
+        public ReactedHand ButtonDown(GamepadKey key)
         {
             var hand = GamepadProvider.GetPreferredReactionHand(key);
             if (hand == ReactedHand.None)
             {
                 return hand;
+            }
+
+            if (GamepadProvider.IsSideKey(key))
+            {
+                return ReactedHand.None;
             }
             
             Vector3 targetPos = _gamePad.GetButtonPosition(key) + yOffsetAlwaysVec;
@@ -114,7 +118,7 @@ namespace Baku.VMagicMirror
             return hand;
         }
 
-        public ReactedHand ButtonUp(XinputKey key)
+        public ReactedHand ButtonUp(GamepadKey key)
         {
             var hand = GamepadProvider.GetPreferredReactionHand(key);
             if (hand == ReactedHand.None)
@@ -122,6 +126,11 @@ namespace Baku.VMagicMirror
                 return hand;
             }
 
+            if (GamepadProvider.IsSideKey(key))
+            {
+                return ReactedHand.None;
+            }
+            
             Vector3 targetPos = _gamePad.GetButtonPosition(key) + yOffsetAlwaysVec;
             targetPos -= HandToTipLength * new Vector3(targetPos.x, 0, targetPos.z).normalized;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/SmallGamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/SmallGamepadHandIKGenerator.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// ゲームパッドの入力状況に対して望ましい腕IKを指定するやつ。
+    /// 従来版と違い、小さなゲームパッドを握っている状態を再現する狙いで実装している
+    /// </summary>
+    public class SmallGamepadHandIKGenerator : MonoBehaviour
+    {
+        [SerializeField] private SmallGamepadProvider gamePad = null;
+        [SerializeField] private float speedFactor = 3.0f;
+        
+        private readonly IKDataRecord _leftHand = new IKDataRecord();
+        public IIKGenerator LeftHand => _leftHand;
+
+        private readonly IKDataRecord _rightHand = new IKDataRecord();
+        public IIKGenerator RightHand => _rightHand;
+
+        private const float ButtonDownAnimationY = 0.01f;
+        private const float ButtonDownAnimationDuration = 0.2f;
+        
+        private Coroutine _buttonDownIkMotionCoroutine = null;
+
+        private Vector3 _rawLeftPos = Vector3.zero;
+        private Quaternion _rawLeftRot = Quaternion.identity;
+        
+        private Vector3 _rawRightPos = Vector3.zero;
+        private Quaternion _rawRightRot = Quaternion.identity;
+
+        private float _offsetY = 0;
+        private GamepadLeanModes _leanMode = GamepadLeanModes.GamepadLeanLeftStick;
+
+        public bool ReverseGamepadStickLeanHorizontal { get; set; } = false;
+        public bool ReverseGamepadStickLeanVertical { get; set; } = false;
+
+        public void SetGamepadLeanMode(string leanModeName)
+        {
+            _leanMode =
+                Enum.TryParse<GamepadLeanModes>(leanModeName, out var result) ?
+                    result :
+                    GamepadLeanModes.GamepadLeanNone;
+
+            if (_leanMode == GamepadLeanModes.GamepadLeanNone)
+            {
+                ApplyStickPosition(Vector2Int.zero);
+            }
+        }
+        
+        public void ButtonDown(GamepadKey key)
+        {
+            if (GamepadProvider.IsSideKey(key))
+            {
+                return;
+            }
+            
+            //親指で押すボタンの場合、手をクイッてする動きとして反映
+            if (_buttonDownIkMotionCoroutine != null)
+            {
+                StopCoroutine(_buttonDownIkMotionCoroutine);
+            }
+            _buttonDownIkMotionCoroutine = StartCoroutine(ButtonDownRoutine());
+        }
+        
+        public void LeftStick(Vector2 stickPos)
+        {
+            if (_leanMode == GamepadLeanModes.GamepadLeanLeftStick)
+            {
+                ApplyStickPosition(stickPos);
+            }
+        }
+
+        public void RightStick(Vector2 stickPos)
+        {
+            if (_leanMode == GamepadLeanModes.GamepadLeanRightStick)
+            {
+                ApplyStickPosition(stickPos);
+            }
+        }
+
+        public void ButtonStick(Vector2Int buttonStickPos)
+        {
+            if (_leanMode == GamepadLeanModes.GamepadLeanLeftButtons)
+            {
+                ApplyStickPosition(NormalizedStickPos(buttonStickPos));
+            }
+        }
+        
+        private void ApplyStickPosition(Vector2 stickPos)
+        {
+            var pos = new Vector2(
+                stickPos.x * (ReverseGamepadStickLeanHorizontal ? -1f : 1f),
+                stickPos.y * (ReverseGamepadStickLeanVertical ? -1f : 1f)
+                );
+            
+            gamePad.SetHorizontalPosition(pos);
+            (_rawLeftPos, _rawLeftRot) = gamePad.GetLeftHand();
+            (_rawRightPos, _rawRightRot) = gamePad.GetRightHand();   
+        }
+
+        private static Vector2 NormalizedStickPos(Vector2Int v)
+        {
+            const float factor = 1.0f / 32768.0f;
+            return new Vector2(v.x * factor, v.y * factor);
+        }
+        
+        private void Update()
+        {
+            _leftHand.Position =
+                Vector3.Lerp(_leftHand.Position, _rawLeftPos, speedFactor * Time.deltaTime) +
+                Vector3.up * _offsetY;
+
+            _leftHand.Rotation = Quaternion.Slerp(
+                _leftHand.Rotation, _rawLeftRot, speedFactor * Time.deltaTime
+            );
+            
+            _rightHand.Position =
+                Vector3.Lerp(_rightHand.Position, _rawRightPos, speedFactor * Time.deltaTime) +
+                Vector3.up * _offsetY;
+
+            _rightHand.Rotation = Quaternion.Slerp(
+                _rightHand.Rotation, _rawRightRot, speedFactor * Time.deltaTime
+            );
+            
+        }
+        
+        private IEnumerator ButtonDownRoutine()
+        {
+            float startTime = Time.time;
+            while (Time.time - startTime < ButtonDownAnimationDuration)
+            {
+                float rate = (Time.time - startTime) / ButtonDownAnimationDuration;
+                _offsetY = -ButtonDownAnimationY * (1.0f - Mathf.Abs(1.0f - 2.0f * rate));
+                yield return null;
+            }
+            _offsetY = 0;
+        }
+        
+        /// <summary> どの入力をBodyLeanの値に反映するか考慮するやつ </summary>
+        private enum GamepadLeanModes
+        {
+            GamepadLeanNone,
+            GamepadLeanLeftButtons,
+            GamepadLeanLeftStick,
+            GamepadLeanRightStick,
+        }        
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/SmallGamepadHandIKGenerator.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/SmallGamepadHandIKGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b305eeb1911da1f4cae5b779b5c81287
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/HidInputReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/HidInputReceiver.cs
@@ -14,7 +14,7 @@ namespace Baku.VMagicMirror
         [Inject] private ReceivedMessageHandler handler = null;
         
         [SerializeField] private StatefulXinputGamePad gamePad = null;
-
+        
         [SerializeField] private HandIKIntegrator handIkIntegrator = null;
 
         [SerializeField] private HeadIkIntegrator headIkIntegrator = null;
@@ -60,6 +60,7 @@ namespace Baku.VMagicMirror
                 if (data.IsArrowKey)
                 {
                     gamepadBasedBodyLean.ButtonStick(gamePad.ArrowButtonsStickPosition);
+                    handIkIntegrator.ButtonStick(gamePad.ArrowButtonsStickPosition);
                 }
             });
             

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
@@ -10,6 +10,7 @@ namespace Baku.VMagicMirror
         [Inject] private ReceivedMessageHandler handler = null;
 
         [SerializeField] private GamepadBasedBodyLean gamePadBasedBodyLean = null;
+        [SerializeField] private SmallGamepadHandIKGenerator smallGamepadHandIk = null;
 
         [SerializeField] private HandIKIntegrator handIkIntegrator = null;
 
@@ -58,12 +59,15 @@ namespace Baku.VMagicMirror
                         break;
                     case MessageCommandNames.GamepadLeanMode:
                         gamePadBasedBodyLean.SetGamepadLeanMode(message.Content);
+                        smallGamepadHandIk.SetGamepadLeanMode(message.Content);
                         break;
                     case MessageCommandNames.GamepadLeanReverseHorizontal:
                         gamePadBasedBodyLean.ReverseGamepadStickLeanHorizontal = message.ToBoolean();
+                        smallGamepadHandIk.ReverseGamepadStickLeanHorizontal = message.ToBoolean();
                         break;
                     case MessageCommandNames.GamepadLeanReverseVertical:
                         gamePadBasedBodyLean.ReverseGamepadStickLeanVertical = message.ToBoolean();
+                        smallGamepadHandIk.ReverseGamepadStickLeanVertical = message.ToBoolean();
                         break;
                 }
 
@@ -75,26 +79,22 @@ namespace Baku.VMagicMirror
         private void SetLengthFromWristToTip(float v)
         {
             handIkIntegrator.Presentation.HandToTipLength = v;
-            handIkIntegrator.GamepadHand.HandToTipLength = v;
             handIkIntegrator.Typing.HandToTipLength = v;
         }
         
         private void SetLengthFromWristToPalm(float v)
         {
-            handIkIntegrator.GamepadHand.HandToPalmLength = v;
             handIkIntegrator.MouseMove.HandToPalmLength = v;
         }
         
         private void SetHandYOffsetBasic(float offset)
         {
-            handIkIntegrator.GamepadHand.YOffsetAlways = offset;
             handIkIntegrator.Typing.YOffsetAlways = offset;
             handIkIntegrator.MouseMove.YOffset = offset;
         }
 
         private void SetHandYOffsetAfterKeyDown(float offset)
         {
-            handIkIntegrator.GamepadHand.YOffsetAfterKeyDown = offset;
             handIkIntegrator.Typing.YOffsetAfterKeyDown = offset;
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
@@ -75,26 +75,26 @@ namespace Baku.VMagicMirror
         private void SetLengthFromWristToTip(float v)
         {
             handIkIntegrator.Presentation.HandToTipLength = v;
-            handIkIntegrator.Gamepad.HandToTipLength = v;
+            handIkIntegrator.GamepadHand.HandToTipLength = v;
             handIkIntegrator.Typing.HandToTipLength = v;
         }
         
         private void SetLengthFromWristToPalm(float v)
         {
-            handIkIntegrator.Gamepad.HandToPalmLength = v;
+            handIkIntegrator.GamepadHand.HandToPalmLength = v;
             handIkIntegrator.MouseMove.HandToPalmLength = v;
         }
         
         private void SetHandYOffsetBasic(float offset)
         {
-            handIkIntegrator.Gamepad.YOffsetAlways = offset;
+            handIkIntegrator.GamepadHand.YOffsetAlways = offset;
             handIkIntegrator.Typing.YOffsetAlways = offset;
             handIkIntegrator.MouseMove.YOffset = offset;
         }
 
         private void SetHandYOffsetAfterKeyDown(float offset)
         {
-            handIkIntegrator.Gamepad.YOffsetAfterKeyDown = offset;
+            handIkIntegrator.GamepadHand.YOffsetAfterKeyDown = offset;
             handIkIntegrator.Typing.YOffsetAfterKeyDown = offset;
         }
     }


### PR DESCRIPTION
ゲームパッド入力をモーションに反映する方法を色々と変更。

* 今までアーケードコントローラ的なでかい動きだったのを通常のゲームコントローラを想定したサイズまで縮小
* トリガーキーに対して人差し指、中指がちゃんと動くよう修正
* ボタンによる押し方の切り替えは廃止(親指はABXYのどれを押しても同じように動く)

以下、単純な改善とは言えない補足

* ゲームパッド操作中は肘を開き気味にするよう挙動を変更した。この変更を加えた理由は肘の食い込み防止のため。
    * 今までと異なり手首を内側に曲げてIKするので、キーボードタイピング時よりもゲームパッド操作時の方が肘が体に食い込みやすくなる。肘を開き気味にすることで食い込む動きを打ち消せる。
* デグレ対策( #89 )で追加した下半身のボーン角度固定スクリプトについて、体を傾ける処理と相性が悪かったため、上半身の見栄えを重視して削除している。
