### PR TITLE
自動まばたきが動かないことがある問題の修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManager.cs
@@ -31,8 +31,9 @@ namespace Baku.VMagicMirror
 
         private VRMBlendShapeProxy _proxy;
 
-        private bool _preferAutoBlink = false;
+        public bool IsFaceTrackingActive { get; set; }
 
+        private bool _preferAutoBlink = false;
         /// <summary> 顔トラッキング中であっても自動まばたきを優先するかどうか </summary>
         public bool PreferAutoBlink
         {
@@ -91,12 +92,17 @@ namespace Baku.VMagicMirror
             {
                 DefaultBlendShape.Apply(_proxy);
                 
-                if (!PreferAutoBlink && faceTracker.FaceDetectedAtLeastOnce)
+                if (IsFaceTrackingActive &&
+                    !PreferAutoBlink && 
+                    faceTracker.FaceDetectedAtLeastOnce
+                    )
                 {
+                    Debug.Log("ImageBasedBlink");
                     imageBasedBlinkController.Apply(_proxy);
                 }
                 else
                 {
+                    Debug.Log("AutoBlink");
                     autoBlink.Apply(_proxy);
                 }
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManagerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManagerReceiver.cs
@@ -18,6 +18,9 @@ namespace Baku.VMagicMirror
             {
                 switch (message.Command)
                 {
+                    case MessageCommandNames.EnableFaceTracking:
+                        _faceControlManager.IsFaceTrackingActive = message.ToBoolean();
+                        break;
                     case MessageCommandNames.AutoBlinkDuringFaceTracking:
                         _faceControlManager.PreferAutoBlink = message.ToBoolean();
                         break;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTracker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTracker.cs
@@ -331,6 +331,7 @@ namespace Baku.VMagicMirror
         {
             _isInitWaiting = false;
             HasInitDone = false;
+            FaceDetectedAtLeastOnce = false;
 
             if (_webCamTexture != null)
             {


### PR DESCRIPTION
#100 の修正。

直接原因は`FaceDetectedAtLeastOnce`フラグを顔トラッキングの停止時に折っていなかったことだが、本修正ではそれよりも意味的に素朴な「顔トラッキング中じゃなければ必ず自動瞬きの方を優先する」という判定を盛り込んで直した。