### PR TITLE
プレゼン腕の伸び具合自動調整+ゲームコントローラIKの初期位置の修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/FaceControlManager.cs
@@ -97,12 +97,10 @@ namespace Baku.VMagicMirror
                     faceTracker.FaceDetectedAtLeastOnce
                     )
                 {
-                    Debug.Log("ImageBasedBlink");
                     imageBasedBlinkController.Apply(_proxy);
                 }
                 else
                 {
-                    Debug.Log("AutoBlink");
                     autoBlink.Apply(_proxy);
                 }
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/SmallGamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/SmallGamepadHandIKGenerator.cs
@@ -105,6 +105,13 @@ namespace Baku.VMagicMirror
             const float factor = 1.0f / 32768.0f;
             return new Vector2(v.x * factor, v.y * factor);
         }
+
+        private void Start()
+        {
+            //とりあえず初期位置までゲームコントローラIKの場所を持ち上げておく:
+            //やらないとIK位置が0,0,0のままになって良くない
+            ApplyStickPosition(Vector2.zero);   
+        }
         
         private void Update()
         {


### PR DESCRIPTION
#60 
→遠くを指さすとき、シグモイド関数ベースで腕の伸びを飽和させてゆっくり伸ばすようにした。

#102 
→VMagicMirrorの起動時に、(WPFの設定以前の)デフォルトの初期位置までIKを持ってくるようにした。実際にはWPFの設定が反映されないのでちょっとズレがあるが、それでも不自然さはかなり軽減するので、これで十分という事にする。