### PR TITLE
起動時の挙動改善

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
@@ -452,9 +452,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   opaqueThreshold: 0.1
-  handler: {fileID: 0}
   windowPositionCheckInterval: 5
   cam: {fileID: 1574337991341618299}
+  cameraController: {fileID: 1574337991341618297}
 --- !u!114 &1574337991341618297
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraController.cs
@@ -9,7 +9,7 @@ namespace Baku.VMagicMirror
 {
     public class CameraController : MonoBehaviour
     {
-        [Inject] private ReceivedMessageHandler handler = null;
+        [Inject] private ReceivedMessageHandler _handler = null;
         [SerializeField] private Camera cam = null;
         [SerializeField] private CameraTransformController transformController = null;
 
@@ -29,7 +29,7 @@ namespace Baku.VMagicMirror
             _defaultCameraPosition = camTransform.position;
             _defaultCameraRotationEuler = camTransform.rotation.eulerAngles;
 
-            handler.Commands.Subscribe(message =>
+            _handler.Commands.Subscribe(message =>
             {
                 switch(message.Command)
                 {
@@ -51,7 +51,7 @@ namespace Baku.VMagicMirror
                         break;
                 }
             });
-            handler.QueryRequested += query =>
+            _handler.QueryRequested += query =>
             {
                 if (query.Command == MessageQueryNames.CurrentCameraPosition)
                 {
@@ -71,8 +71,9 @@ namespace Baku.VMagicMirror
             };
         }
 
-        private void SetCameraBackgroundColor(float a, float r, float g, float b)
+        public void SetCameraBackgroundColor(float a, float r, float g, float b)
         {
+            LogOutput.Instance.Write(nameof(SetCameraBackgroundColor) + $": {a:0.00},{r:0.00},{g:0.00},{b:0.00}");
             cam.backgroundColor = new Color(r, g, b, a);
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/DirectSettingFileReader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/DirectSettingFileReader.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// 直接UnityでWPF用の設定ファイルを読み込むクラス。
+    /// どうしても初期化で取得したい変数があるときだけ使う
+    /// </summary>
+    public class DirectSettingFileReader
+    {
+        public void Load()
+        {
+            try
+            {
+                LoadPropertiesFromSettingFile();
+            }
+            catch (Exception ex)
+            {
+                LogOutput.Instance.Write(ex);
+                TransparentBackground = false;
+            }
+        }
+        
+        public bool TransparentBackground { get; private set; }
+        
+        private void LoadPropertiesFromSettingFile()
+        {
+            if (!SettingFileExists())
+            {
+                return;
+            }
+
+            using (var sr = new StreamReader(GetSettingFilePath()))
+            {
+                var doc = XDocument.Load(sr);
+                var node = doc.XPathSelectElement("/SaveData/WindowSetting/IsTransparent");
+                TransparentBackground = 
+                    bool.TryParse(node.Value, out bool result) && result;
+            }
+        }
+        
+        //NOTE: ファイルパスはWPFのSpecialFilePathクラスでも使っているので合わせる必要あり
+        private const string AutoSaveSettingFileName = "_autosave";
+
+        //実行中のVMagicMirrorの設定が保存された設定ファイルのパスを取得します。
+        public static string GetSettingFilePath()
+            => Path.Combine(
+                Path.GetDirectoryName(Application.dataPath),
+                "ConfigApp",
+                AutoSaveSettingFileName
+            );
+
+        /// <summary>
+        /// <see cref="GetSettingFilePath"/>のパスに設定ファイルがあるかどうかを確認します。
+        /// </summary>
+        /// <returns></returns>
+        public static bool SettingFileExists() => File.Exists(GetSettingFilePath());
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/DirectSettingFileReader.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/DirectSettingFileReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ff0239b29aa06b4d9824b35a00caecd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/CommandArrayParser.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/CommandArrayParser.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public static class CommandArrayParser
+    {
+        public static IEnumerable<ReceivedCommand> ParseCommandArray(string content)
+        {
+            try
+            {
+                return JsonUtility.FromJson<MessageItemArray>(content)
+                    .items
+                    .Select(c => new ReceivedCommand(c.C, c.A));
+            }
+            catch (Exception ex)
+            {
+                LogOutput.Instance.Write(ex);
+                return Enumerable.Empty<ReceivedCommand>();
+            }
+        }
+    }
+    
+    [Serializable]
+    public class MessageItem
+    {
+        public string C;
+        public string A;
+    }
+    
+    [Serializable]
+    public class MessageItemArray
+    {
+        public MessageItem[] items;
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/CommandArrayParser.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/CommandArrayParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a980fc85daab9af4dbaa7effcbb34dfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
@@ -138,6 +138,8 @@
         public const string TakeScreenshot = nameof(TakeScreenshot);
         public const string OpenScreenshotFolder = nameof(OpenScreenshotFolder);
 
+        // Meta message
+        public const string CommandArray = nameof(CommandArray);
     }
 }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/ReceivedMessageHandler.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/ReceivedMessageHandler.cs
@@ -29,10 +29,23 @@ namespace Baku.VMagicMirror
                 ProcessQuery(query);
             }
         }
-
+        
         public void ReceiveCommand(ReceivedCommand command)
         {
-            _receivedCommands.Enqueue(command);
+            if (command.Command == MessageCommandNames.CommandArray)
+            {
+                //コマンドの一括送信を受け取ったとき: バラバラにしてキューに詰めておく
+                var commands = CommandArrayParser.ParseCommandArray(command.Content);
+                foreach (var c in commands)
+                {
+                    _receivedCommands.Enqueue(c);
+                }
+            }
+            else
+            {
+                //普通の受信
+                _receivedCommands.Enqueue(command);
+            }
         }
 
         public IObservable<string> ReceiveQuery(ReceivedQuery query)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/WpfStartAndQuit.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/WpfStartAndQuit.cs
@@ -35,8 +35,9 @@ namespace Baku.VMagicMirror
             string path = GetWpfPath();
             if (File.Exists(path))
             {
-                //Startが全部終わって落ち着いた状態でロードしたいので遅延つける
-                yield return new WaitForSeconds(0.5f);
+                //他スクリプトの初期化とUpdateが回ってからの方がよいので少しだけ遅らせる
+                yield return null;
+                yield return null;
 #if !UNITY_EDITOR
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
                 {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WindowStyle/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WindowStyle/WindowStyleController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using UnityEngine;
 using UniRx;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -25,17 +26,13 @@ namespace Baku.VMagicMirror
         const string InitialPositionXKey = "InitialPositionX";
         const string InitialPositionYKey = "InitialPositionY";
 
-        [SerializeField]
-        private float opaqueThreshold = 0.1f;
+        [SerializeField] private float opaqueThreshold = 0.1f;
+        [SerializeField] private float windowPositionCheckInterval = 5.0f;
+        [SerializeField] private Camera cam = null;
+        [SerializeField] private CameraController cameraController = null;
 
-        [SerializeField]
-        private ReceivedMessageHandler handler = null;
-
-        [SerializeField]
-        private float windowPositionCheckInterval = 5.0f;
-
-        [SerializeField]
-        private Camera cam = null;
+        [Inject]
+        private ReceivedMessageHandler _handler = null;
 
         private float _windowPositionCheckCount = 0;
         private Vector2Int _prevWindowPosition = Vector2Int.zero;
@@ -78,12 +75,14 @@ namespace Baku.VMagicMirror
             defaultExWindowStyle |= WS_EX_LAYERED;
             SetWindowLong(hWnd, GWL_EXSTYLE, defaultExWindowStyle);
 #endif
+            CheckSettingFileDirect();
+            InitializeWindowPositionCheckStatus();
         }
 
         private void Start()
         {
             _colorPickerTexture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
-            handler.Commands.Subscribe(message =>
+            _handler.Commands.Subscribe(message =>
             {
                 switch (message.Command)
                 {
@@ -132,7 +131,6 @@ namespace Baku.VMagicMirror
             //既定で最前面に表示
             SetTopMost(true);
 
-            InitializeWindowPositionCheckStatus();
             StartCoroutine(PickColorCoroutine());
         }
 
@@ -161,6 +159,24 @@ namespace Baku.VMagicMirror
         public void DisposeModelRenderers()
         {
             _renderers = new Renderer[0];
+        }
+
+        private void CheckSettingFileDirect()
+        {
+            var reader = new DirectSettingFileReader();
+            reader.Load();
+            if (reader.TransparentBackground)
+            {
+                LogOutput.Instance.Write("Set Transparency by direct setting file input");
+                //NOTE: このif文の中身には、WPF側で「背景を透過」にチェックを入れた時の挙動の一部を入れているが、
+                //見た目に関するものだけにしている(全部やるとクリックスルー設定が絡んで難しくなるので)
+                
+                //全部ではない(
+                //UI操作は1つでも処理がけっこう多いので要注意。
+                SetWindowTransparency(true);
+                SetWindowFrameVisibility(false);
+                cameraController.SetCameraBackgroundColor(0, 0, 0, 0);
+            }
         }
 
         private void UpdateClickThrough()
@@ -335,8 +351,6 @@ namespace Baku.VMagicMirror
         private void SetWindowFrameVisibility(bool isVisible)
         {
             _isWindowFrameHidden = !isVisible;
-
-            LogOutput.Instance.Write($"{nameof(SetWindowFrameVisibility)}:{isVisible}");
             var hwnd = GetUnityWindowHandle();
             uint windowStyle = isVisible ?
                 defaultWindowStyle :


### PR DESCRIPTION
#121 を直してみた。

パフォーマンス改善より、背景透過が指定されているとグリーンバックを経由しなくなったのが良い所かもしれない。

またv0.9.0と本PRの比較をすると以下の通り。

* 起動時間はほぼ同じまま
* 終了時間は手元環境で2.2秒→1.1秒くらいまで素早くなった

ただし、終了処理が速いのは本PRとは無関係である(gRPCからMemoryMappedFileに乗り換えて例外ロバストにしたのが主要因のため)。
