### PR TITLE
起動直後に首が下を向く+手がギュルンって動くやつの修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
@@ -19,9 +19,6 @@ namespace Baku.VMagicMirror
         [SerializeField] private TypingHandIKGenerator typing = null;
         public TypingHandIKGenerator Typing => typing;
 
-//        [SerializeField] private GamepadHandIKGenerator gamepadHand = null;
-//        public GamepadHandIKGenerator GamepadHand => gamepadHand;
-//
         [SerializeField] private SmallGamepadHandIKGenerator smallGamepadHand = null;
         public SmallGamepadHandIKGenerator SmallGamepadHand => smallGamepadHand;
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HeadIkIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HeadIkIntegrator.cs
@@ -55,6 +55,10 @@ namespace Baku.VMagicMirror
             _camBasedLookAt.Camera = cam;
             _vrmLoadable.VrmLoaded += info => _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
             _vrmLoadable.VrmDisposing += () =>  _head = null;
+
+            //起動後にマウスを動かさないとLookAtの先が原点になっちゃうので、それを防ぐためにやる
+            _mouseBasedLookAt.Position = cam.position;
+            lookAtTarget.localPosition = _camBasedLookAt.Position;
         }
 
         private void Update()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/MouseMoveHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/MouseMoveHandIKGenerator.cs
@@ -27,6 +27,14 @@ namespace Baku.VMagicMirror
 
         private Vector3 _targetPosition = Vector3.zero;
 
+        private void Start()
+        {
+            //NOTE: この値は初期値が大外れしていないことを保証するものなので、多少ズレていてもOK
+            _rightHand.Position = _touchPad.GetHandTipPosFromScreenPoint(0, 0) + YOffsetAlwaysVec;
+            _targetPosition = _rightHand.Position;
+        }
+            
+
         private void Update()
         {
             _rightHand.Position = Vector3.Lerp(

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/TypingHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/TypingHandIKGenerator.cs
@@ -66,6 +66,14 @@ namespace Baku.VMagicMirror
         //要るかなコレ。なくてもいいのでは？
         private Coroutine _leftHandMoveCoroutine = null;
         private Coroutine _rightHandMoveCoroutine = null;
+
+        private void Start()
+        {
+            //初期位置がゼロだとヘンな動きになるので、それを防ぐ
+            _leftHand.Position = keyboard.GetKeyTargetData("F").positionWithOffset;
+            _rightHand.Position = keyboard.GetKeyTargetData("J").positionWithOffset;
+        }
+        
         
         public (ReactedHand, Vector3) PressKey(string key, bool isLeftHandOnlyMode)
         {


### PR DESCRIPTION
#127 の修正。
推定の通りIK位置が原点初期化されていたのが原因だったため、初期設定のときの正解の値で初期化して症状を緩和した。