### PR TITLE
ゲームパッドモーション+キーボードの数値キーで表情制御する組み合わせのサポート

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/WordToMotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/WordToMotionController.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 7427902273662735819}
   - component: {fileID: 7427902273662735818}
   - component: {fileID: 7427902273662735821}
+  - component: {fileID: 4195983317812337395}
   m_Layer: 0
   m_Name: WordToMotionController
   m_TagString: Untagged
@@ -63,6 +64,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gamepad: {fileID: 7427902273662735821}
+  keyboard: {fileID: 4195983317812337395}
   forgetTime: 1
   ikFadeDuration: 0.5
   defaultAnimation: {fileID: 7400000, guid: 66fb8f57b49136c42ab6f7b5b9f1f6dc, type: 2}
@@ -136,4 +138,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gamepadInput: {fileID: 0}
+  cooldownTime: 0
+--- !u!114 &4195983317812337395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7427902273662735829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a27d6ae3a3e79845940da8cc571003b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
   cooldownTime: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
@@ -132,7 +132,8 @@
         public const string EnableWordToMotionPreview = nameof(EnableWordToMotionPreview);
         public const string SendWordToMotionPreviewInfo = nameof(SendWordToMotionPreviewInfo);
 
-        public const string UseGamepadToStartWordToMotion = nameof(UseGamepadToStartWordToMotion);
+        public const string SetDeviceTypeToStartWordToMotion = nameof(SetDeviceTypeToStartWordToMotion);
+        
 
         // Screenshot
         public const string TakeScreenshot = nameof(TakeScreenshot);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
@@ -70,7 +70,7 @@ namespace Baku.VMagicMirror
         
         public void PressKey(string keyName)
         {
-            if (!UseKeyboardForWordToMotion)
+            if (UseKeyboardForWordToMotion)
             {
                 return;
             }
@@ -98,7 +98,7 @@ namespace Baku.VMagicMirror
 
         public void MoveMouse(Vector3 mousePosition)
         {
-            if (!UseKeyboardForWordToMotion)
+            if (UseKeyboardForWordToMotion)
             {
                 return;
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
@@ -42,6 +42,9 @@ namespace Baku.VMagicMirror
 
         public bool UseGamepadForWordToMotion { get; set; } = false;
         
+        //NOTE: このフラグではキーボードのみならずマウス入力も無視することに注意
+        public bool UseKeyboardForWordToMotion { get; set; } = false;
+        
         public bool EnablePresentationMode { get; set; }
 
         public bool IsLeftHandGripGamepad => _leftTargetType == HandTargetType.Gamepad;
@@ -63,8 +66,15 @@ namespace Baku.VMagicMirror
         
         #region API
 
+        #region Keyboard and Mouse
+        
         public void PressKey(string keyName)
         {
+            if (!UseKeyboardForWordToMotion)
+            {
+                return;
+            }
+            
             var (hand, pos) = typing.PressKey(keyName, EnablePresentationMode);
             if (hand == ReactedHand.Left)
             {
@@ -88,6 +98,11 @@ namespace Baku.VMagicMirror
 
         public void MoveMouse(Vector3 mousePosition)
         {
+            if (!UseKeyboardForWordToMotion)
+            {
+                return;
+            }
+            
             mouseMove.MoveMouse(mousePosition);
             presentation.MoveMouse(mousePosition);
             SetRightHandIk(EnablePresentationMode ? HandTargetType.Presentation : HandTargetType.Mouse);
@@ -95,13 +110,15 @@ namespace Baku.VMagicMirror
 
         public void ClickMouse(string button)
         {
-            if (!EnablePresentationMode && EnableHidArmMotion)
+            if (!EnablePresentationMode && EnableHidArmMotion && !UseKeyboardForWordToMotion)
             {
                 fingerController.StartClickMotion(button);
                 SetRightHandIk(HandTargetType.Mouse);   
             }
         }
 
+        #endregion
+        
         #region Gamepad
         
         //NOTE: 表情コントロール用にゲームパッドを使っている間は入力を無視する

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/Receiver/MotionSettingReceiver.cs
@@ -7,7 +7,12 @@ namespace Baku.VMagicMirror
     /// <summary> モーション関係で、操作ではなく設定値を受け取るレシーバクラス </summary>
     public class MotionSettingReceiver : MonoBehaviour
     {
-        [Inject] private ReceivedMessageHandler handler = null;
+        //Word to Motionの専用入力に使うデバイスを指定する定数値
+        private const int DeviceTypeNone = 0;
+        private const int DeviceTypeGamepad = 1;
+        private const int DeviceTypeKeyboard = 2;
+
+        [Inject] private ReceivedMessageHandler _handler = null;
 
         [SerializeField] private GamepadBasedBodyLean gamePadBasedBodyLean = null;
         [SerializeField] private SmallGamepadHandIKGenerator smallGamepadHandIk = null;
@@ -22,7 +27,7 @@ namespace Baku.VMagicMirror
 
         private void Start()
         {
-            handler.Commands.Subscribe(message =>
+            _handler.Commands.Subscribe(message =>
             {
                 switch (message.Command)
                 {
@@ -69,14 +74,37 @@ namespace Baku.VMagicMirror
                         gamePadBasedBodyLean.ReverseGamepadStickLeanVertical = message.ToBoolean();
                         smallGamepadHandIk.ReverseGamepadStickLeanVertical = message.ToBoolean();
                         break;
-                    case MessageCommandNames.UseGamepadToStartWordToMotion:
-                        gamePadBasedBodyLean.UseGamepadForWordToMotion = message.ToBoolean();
-                        handIkIntegrator.UseGamepadForWordToMotion = message.ToBoolean();
+                    case MessageCommandNames.SetDeviceTypeToStartWordToMotion:
+                        SetDeviceTypeForWordToMotion(message.ToInt());
                         break;
                 }
             });
         }
-        
+
+        private void SetDeviceTypeForWordToMotion(int deviceType)
+        {
+            switch (deviceType)
+            {
+                case DeviceTypeNone:
+                    gamePadBasedBodyLean.UseGamepadForWordToMotion = false;
+                    handIkIntegrator.UseGamepadForWordToMotion = false;
+                    handIkIntegrator.UseKeyboardForWordToMotion = false;
+                    break;
+                case DeviceTypeGamepad:
+                    gamePadBasedBodyLean.UseGamepadForWordToMotion = true;
+                    handIkIntegrator.UseGamepadForWordToMotion = true;
+                    handIkIntegrator.UseKeyboardForWordToMotion = false;
+                    break;
+                case DeviceTypeKeyboard:
+                    gamePadBasedBodyLean.UseGamepadForWordToMotion = false;
+                    handIkIntegrator.UseGamepadForWordToMotion = false;
+                    handIkIntegrator.UseKeyboardForWordToMotion = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+
         //以下については適用先が1つじゃないことに注意
 
         private void SetLengthFromWristToTip(float v)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/KeyboardToWordToMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/KeyboardToWordToMotion.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Zenject;
+using UniRx;
+
+namespace Baku.VMagicMirror
+{
+    public class KeyboardToWordToMotion : MonoBehaviour
+    {
+        //決め打ち設計された、ボタンと実行するアイテムのインデックスのマッピング。
+        //このクラスでは配列外とかそういうのは考慮しないことに注意
+        private static readonly Dictionary<string, int> _keyToItemIndex = new Dictionary<string, int>()
+        {
+            ["D0"] = 0,
+            ["D1"] = 1,
+            ["D2"] = 2,
+            ["D3"] = 3,
+            ["D4"] = 4,
+            ["D5"] = 5,
+            ["D6"] = 6,
+            ["D7"] = 7,
+            ["D8"] = 8,
+            ["NumPad0"] = 0,
+            ["NumPad1"] = 1,
+            ["NumPad2"] = 2,
+            ["NumPad3"] = 3,
+            ["NumPad4"] = 4,
+            ["NumPad5"] = 5,
+            ["NumPad6"] = 6,
+            ["NumPad7"] = 7,
+            ["NumPad8"] = 8,
+        };
+
+        [Tooltip("ボタン押下イベントが押されたらしばらくイベント送出をストップするクールダウンタイム")]
+        [SerializeField] private float cooldownTime = 0.3f;
+
+        /// <summary>Word to Motionの要素を実行してほしいとき、アイテムのインデックスを引数にして発火する。</summary>
+        public event Action<int> RequestExecuteWordToMotionItem;
+        
+        public bool UseKeyboardInput { get; set; } = false;
+        
+        [Inject] private ReceivedMessageHandler _handler = null;
+        private float _cooldownCount = 0;
+
+        private void Start()
+        {
+            _handler.Commands.Subscribe(c =>
+            {
+                if (!UseKeyboardInput ||
+                    _cooldownCount > 0 || 
+                    c.Command != MessageCommandNames.KeyDown
+                    )
+                {
+                    return;
+                }
+                
+                //NOTE: D0-D8とNumPad系のキーはサニタイズ対象じゃないので、そのまま受け取っても大丈夫
+                string keyName = c.Content;
+                if (_keyToItemIndex.ContainsKey(keyName))
+                {
+                    RequestExecuteWordToMotionItem?.Invoke(_keyToItemIndex[keyName]);
+                    _cooldownCount = cooldownTime;
+                }
+            });
+        }
+
+        private void Update()
+        {
+            if (_cooldownCount > 0)
+            {
+                _cooldownCount -= Time.deltaTime;
+            }
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/KeyboardToWordToMotion.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/KeyboardToWordToMotion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a27d6ae3a3e79845940da8cc571003b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionBlendShape.cs
@@ -6,7 +6,7 @@ using VRM;
 namespace Baku.VMagicMirror
 {
     /// <summary>
-    /// Type To Motionのブレンドシェイプを適用する。
+    /// Word To Motionのブレンドシェイプを適用する。
     /// </summary>
     /// <remarks>
     /// このクラスは実行タイミングが遅く、有効時には他の表情制御をほぼ完全にオーバーライドする。
@@ -82,24 +82,23 @@ namespace Baku.VMagicMirror
         {
             if (_proxy == null || _blendShape.Count == 0)
             {
-                //オーバーライド不要
+                //オーバーライド不要なケース
                 _proxy?.Apply();
                 return;
             }
 
+            //一回ApplyすることでAccumulateした値を捨てさせる
+            _proxy.Apply();
+            
+            //実際に適用したい値を入れなおして再度Applyすると完全上書きになる
             for(int i = 0; i < _allBlendShapeKeys.Length; i++)
             {
                 if (_blendShape.TryGetValue(_allBlendShapeKeys[i], out float value))
                 {
                     _proxy.AccumulateValue(_allBlendShapeKeys[i], value);
                 }
-                else
-                {
-                    //ここがポイント: オーバーライドなので関係ないブレンドシェイプは叩き落す
-                    _proxy.AccumulateValue(_allBlendShapeKeys[i], 0f);
-                }
             }
-            _proxy?.Apply();
+            _proxy.Apply();
         }
 
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionManager.cs
@@ -28,6 +28,7 @@ namespace Baku.VMagicMirror
     public class WordToMotionManager : MonoBehaviour
     {
         [SerializeField] private GamepadToWordToMotion gamepad = null;
+        [SerializeField] private KeyboardToWordToMotion keyboard = null;
 
         [SerializeField]
         [Tooltip("この時間だけキー入力が無かったらワードが途切れたものとして入力履歴をクリアする。")]
@@ -58,6 +59,15 @@ namespace Baku.VMagicMirror
         {
             get => gamepad.UseGamepadInput;
             set => gamepad.UseGamepadInput = value;
+        }
+
+        /// <summary>
+        /// キーボード入力をWord to Motionに用いるかどうかを取得、設定します。
+        /// </summary>
+        public bool UseKeyboardForWordToMotion
+        {
+            get => keyboard.UseKeyboardInput;
+            set => keyboard.UseKeyboardInput = value;
         }
 
         /// <summary>キー押下イベントをちゃんと読み込むか否か</summary>
@@ -203,14 +213,16 @@ namespace Baku.VMagicMirror
                 }
             });
 
-            gamepad.RequestExecuteWordToMotionItem += i =>
+            void ExecuteSelectedItem(int i)
             {
                 var request = _mapper.FindMotionByIndex(i);
                 if (request != null)
                 {
                     PlayItem(request);
                 }
-            };
+            }
+            gamepad.RequestExecuteWordToMotionItem += ExecuteSelectedItem;
+            keyboard.RequestExecuteWordToMotionItem += ExecuteSelectedItem;
 
             _vrmLoadable.VrmLoaded += OnVrmLoaded;
             _vrmLoadable.VrmDisposing += OnVrmDisposing;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionManagerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/WordToMotionManagerReceiver.cs
@@ -10,12 +10,17 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class WordToMotionManagerReceiver : MonoBehaviour
     {
-        [Inject] private ReceivedMessageHandler handler = null;
+        //Word to Motionの専用入力に使うデバイスを指定する定数値
+        private const int DeviceTypeNone = 0;
+        private const int DeviceTypeGamepad = 1;
+        private const int DeviceTypeKeyboard = 2;
+
+        [Inject] private ReceivedMessageHandler _handler = null;
         [SerializeField] private WordToMotionManager manager = null;
 
         void Start()
         {
-            handler.Commands.Subscribe(message =>
+            _handler.Commands.Subscribe(message =>
             {
                 switch(message.Command)
                 {
@@ -41,15 +46,36 @@ namespace Baku.VMagicMirror
                         //腕アニメーションが無効なとき、アニメーションの終了処理をちょっと切り替える
                         manager.ShouldSetDefaultClipAfterMotion = !message.ToBoolean();
                         break;
-                    case MessageCommandNames.UseGamepadToStartWordToMotion:
-                        manager.UseGamepadForWordToMotion = message.ToBoolean();
+                    case MessageCommandNames.SetDeviceTypeToStartWordToMotion:
+                        SetWordToMotionInputType(message.ToInt());
                         break;
                     default:
                         break;
                 }
             });
         }
-        
+
+        private void SetWordToMotionInputType(int deviceType)
+        {
+            switch (deviceType)
+            {
+                case DeviceTypeNone:
+                    manager.UseGamepadForWordToMotion = false;
+                    manager.UseKeyboardForWordToMotion = false;
+                    break;
+                case DeviceTypeGamepad:
+                    manager.UseGamepadForWordToMotion = true;
+                    manager.UseKeyboardForWordToMotion = false;
+                    break;
+                case DeviceTypeKeyboard:
+                    manager.UseGamepadForWordToMotion = false;
+                    manager.UseKeyboardForWordToMotion = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+
         private void ReloadMotionRequests(string json)
         {
             try


### PR DESCRIPTION
#130 の対応。

「Word to Motionにどのデバイスを割り当てますか」という主旨のオプションを用意して対応した。デバイス割り当ては「無し」「ゲームパッド」「キーボード(のテンキー又は数値キー)」の3種類から選び、選んだデバイスについては

* UI側にキー割り当て(ゲームパッドのボタン、または0-8までの番号)を表示する。
* 割り当てたボタンを押すと対応するモーションや表情を実行する。
* 割り当てたデバイスを操作しても腕は動かなくなる。とくに、キーボードを選んだとき、マウス操作に反応しなくなる。

また本追加にあたり、Word to Motionの実行中にBlendShapeProxyが完全上書きになっていないのを確認したため修正している。

5df6b1f7710ef1422201d61bd7ced322ab25da4b