### PR TITLE
Backside LookAt / Horizontal Flip

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTracker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTracker.cs
@@ -58,6 +58,12 @@ namespace Baku.VMagicMirror
         /// <summary> カメラを起動してから1度以上顔が検出されたかどうか </summary>
         public bool FaceDetectedAtLeastOnce { get; private set; } = false;
 
+        public bool DisableHorizontalFlip
+        {
+            get => FaceParts.DisableHorizontalFlip;
+            set => FaceParts.DisableHorizontalFlip = value;
+        }
+
         private int TextureWidth =>
             (_webCamTexture == null) ? requestedWidth :
             (_webCamTexture.width >= halfResizeWidthThreshold) ? _webCamTexture.width / 2 :
@@ -96,7 +102,7 @@ namespace Baku.VMagicMirror
             get { lock (_faceDetectCompletedLock) return _faceDetectCompleted; }
             set { lock (_faceDetectCompletedLock) _faceDetectCompleted = value; }
         }
-
+        
         //UIスレッドが書き込み、Dlibの呼び出しスレッドが読み込む
         private Color32[] _inputColors = null;
         private int _inputWidth = 0;
@@ -363,8 +369,14 @@ namespace Baku.VMagicMirror
             //出力を拾い終わった時点で次の処理に入ってもらって大丈夫
             FaceDetectCompleted = false;
 
+            float x = (mainPersonRect.xMin - TextureWidth / 2) / TextureWidth;
+            if (DisableHorizontalFlip)
+            {
+                x = -x;
+            }
+            
             DetectedRect = new Rect(
-                (mainPersonRect.xMin - TextureWidth / 2) / TextureWidth,
+                x,
                 -(mainPersonRect.yMax - TextureHeight / 2) / TextureWidth,
                 mainPersonRect.width / TextureWidth,
                 mainPersonRect.height / TextureWidth

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTrackerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceTracking/FaceTrackerReceiver.cs
@@ -34,6 +34,9 @@ namespace Baku.VMagicMirror
                     case MessageCommandNames.SetCalibrateFaceData:
                         _faceTracker.SetCalibrateData(message.Content);
                         break;
+                    case MessageCommandNames.DisableFaceTrackingHorizontalFlip:
+                        _faceTracker.DisableHorizontalFlip = message.ToBoolean();
+                        break;
                 }
             });
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
@@ -57,6 +57,7 @@
         public const string EnableFaceTracking = nameof(EnableFaceTracking);
         public const string SetCameraDeviceName = nameof(SetCameraDeviceName);
         public const string AutoBlinkDuringFaceTracking = nameof(AutoBlinkDuringFaceTracking);
+        public const string DisableFaceTrackingHorizontalFlip = nameof(DisableFaceTrackingHorizontalFlip);
         public const string CalibrateFace = nameof(CalibrateFace);
         public const string SetCalibrateFaceData = nameof(SetCalibrateFaceData);
         public const string FaceDefaultFun = nameof(FaceDefaultFun);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HeadIkIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HeadIkIntegrator.cs
@@ -12,7 +12,7 @@ namespace Baku.VMagicMirror
         private const string UseLookAtPointMousePointer = nameof(UseLookAtPointMousePointer);
         private const string UseLookAtPointMainCamera = nameof(UseLookAtPointMainCamera);
         //手のIKよりLookAtのIKをやや前方にずらして見栄えを調整する決め打ちのパラメータ
-        private const float ZOffsetOnHandIk = 0.3f;
+        private const float ZOffsetOnHeadIk = 0.3f;
 
         [SerializeField] private Transform cam = null;
         [SerializeField] private Transform lookAtTarget = null;
@@ -35,10 +35,35 @@ namespace Baku.VMagicMirror
             //画面中央 = カメラ位置なのでコレで空間的にだいたい正しいハズ
             float xClamped = Mathf.Clamp(x - Screen.width * 0.5f, -1000, 1000) / 1000.0f;
             float yClamped = Mathf.Clamp(y - Screen.height * 0.5f, -1000, 1000) / 1000.0f;
-
-            _mouseBasedLookAt.Position =
+            var baseLookAtPosition =
                 cam.TransformPoint(xClamped, yClamped, 0) + 
-                ZOffsetOnHandIk * Vector3.forward;
+                ZOffsetOnHeadIk * Vector3.forward;
+
+            //Zの決め方に注意: キャラを正面から見ているときと後ろから見ているときで、手前にLookAtさせるか奥にLookAtさせるかを変更
+            var camForward = cam.forward;
+            var horizontalCamForward = new Vector3(camForward.x, 0, camForward.z).normalized;
+            
+            //zの値が小さい = カメラは真横、または後ろを向いている = キャラを正面から見ているハズ
+            if (horizontalCamForward.z < 0.1f)
+            {
+                _mouseBasedLookAt.Position = baseLookAtPosition;
+                return;
+            }
+            
+            //カメラのZ成分が増える(=真後ろから見る)のに近づくにつれて奥側を向かせるようにする
+            float depthFactor = 1.0f;
+            if (horizontalCamForward.z < 0.5f)
+            {
+                depthFactor = (horizontalCamForward.z - 0.1f) * 2.5f;
+            }
+            
+            //キャラを背後から映してるハズ: 奥行き方向にLookAtをずらしていく
+            var camPosition = cam.position;
+            //Vector3.Dotのとこ = カメラからみてキャラが立ってる位置の奥行き。Yを考慮すると面倒なことになるため、XZ平面でやってます
+            float depth = (2 * depthFactor) * Mathf.Abs(Vector3.Dot(
+                new Vector3(camPosition.x, 0, camPosition.z), horizontalCamForward
+                ));
+            _mouseBasedLookAt.Position = baseLookAtPosition + depth * camForward;
         }
         
         public void SetLookAtStyle(string content)
@@ -63,6 +88,8 @@ namespace Baku.VMagicMirror
 
         private void Update()
         {
+            _camBasedLookAt.CheckDepthAndWeight(_head);
+            
             Vector3 pos = 
                 (_lookAtStyle == LookAtStyles.MousePointer) ? _mouseBasedLookAt.Position :
                 (_lookAtStyle == LookAtStyles.MainCamera) ? _camBasedLookAt.Position :
@@ -81,9 +108,53 @@ namespace Baku.VMagicMirror
         {
             public Transform Camera { get; set; }
 
-            public Vector3 Position => Camera.position;
+            public Vector3 Position => Vector3.Lerp(
+                Camera.position + _depth * Camera.forward,
+                _fixedLookAtPos,
+                _fixedLookAtBlendWeight);
                 
             public Quaternion Rotation => Camera.rotation;
+
+            public void CheckDepthAndWeight(Transform head)
+            {
+                //Zの決め方に注意: キャラを正面から見ているときと後ろから見ているときで、手前にLookAtさせるか奥にLookAtさせるかを変更
+                var forward = Camera.forward;
+                var horizontalForward = new Vector3(forward.x, 0, forward.z).normalized;
+            
+                //zの値が小さい = カメラは真横、または後ろを向いている = キャラを正面から見ているハズ
+                if (horizontalForward.z < 0.1f || head == null)
+                {
+                    _depth = 0;
+                    _fixedLookAtBlendWeight = 0;
+                    return;
+                }
+            
+                //カメラのZ成分が増える(=真後ろから見る)のに近づくにつれて奥側を向かせる。
+                //このとき、途中のブレンディングをするとき正面向き成分を混ぜることで、遷移中のLookAtを体にめり込みにくくする
+                float depthFactor = 1.0f;
+                if (horizontalForward.z < 0.5f)
+                {
+                    depthFactor = horizontalForward.z * 2;
+                }
+
+                //キャラを背後から映してるハズ: 奥行き方向にLookAtをずらしていく
+                var camPosition = Camera.position;
+                //Vector3.Dotのとこ = カメラからみてキャラが立ってる位置の奥行き。Yを考慮すると面倒なことになるため、XZ平面でやってます
+                _depth = (2 * depthFactor) * Mathf.Abs(Vector3.Dot(
+                                  new Vector3(camPosition.x, 0, camPosition.z), horizontalForward
+                              ));
+
+                
+                //固定視点LookAtのウェイト (いわゆるテント写像)
+                //depthFactor == 1つまりキャラの中心付近を通るときに1になって固定視点を経由し、両端(=通常のケース)ではゼロになる
+                _fixedLookAtPos = head.position + head.forward * 1.0f;
+                _fixedLookAtBlendWeight = 1.0f - 2.0f * Mathf.Abs(depthFactor - 0.5f);
+            }
+
+            //カメラが前方向き = キャラを後ろから映しているときの見栄えが破綻しないように奥行きを追加するやつ
+            private float _depth = 0f;
+            private Vector3 _fixedLookAtPos = Vector3.zero;
+            private float _fixedLookAtBlendWeight = 0;
 
             public IKTargets Target => IKTargets.HeadLookAt;
         }


### PR DESCRIPTION
#136 

## 背中向けLook Atについて

フリーカメラ機能で背中を向けさせたとき、視点オプションに応じた動きが以下のように変わっている。

* マウス: キャラから向かって正面、つまり画面奥側にマウスポインターがあるものとしてマウスポインターを見る。
* ユーザー: ユーザーとほぼ真反対を見る。
* 固定: とくになし(今までと同じ)

## 左右反転について

左右反転をオフにすると、顔トラッキングの以下3つが反転する。

* 顔の位置のX座標
* 顔のヨー
* 顔のロール

なおキャリブレーションの管理がちょっと甘いので、反転オンオフを切り替えたあとで補正ボタンを押すことが推奨。