### PR TITLE
首振りがガクガクする問題の対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionController.prefab
@@ -153,7 +153,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   faceTracker: {fileID: 0}
-  speedLerpFactor: 18
+  speedLerpFactor: 9
   speedDumpFactor: 0.86
   timeScaleFactor: 0.2
 --- !u!1 &5813678810248240003
@@ -469,7 +469,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gamePad: {fileID: 0}
+  imageBasedBodyMotion: {fileID: 0}
   speedFactor: 3
+  buttonDownSpeedFactor: 8
+  bodyMotionToGamepadPosApplyFactor: 0.5
 --- !u!114 &5813678810404708593
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
#158 の修正。

* 速度ダンピング項は有効でした
* Lerpの効きが強すぎてダンピングに勝っちゃってたのが原因です

ということでLerpの効きを弱めてヨシとします