### PR TITLE
VRM固有のブレンドシェイプも設定できるようにするやつ

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/WordToMotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/WordToMotionController.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 7427902273662735818}
   - component: {fileID: 7427902273662735821}
   - component: {fileID: 4195983317812337395}
+  - component: {fileID: 3568705224926989393}
   m_Layer: 0
   m_Name: WordToMotionController
   m_TagString: Untagged
@@ -152,3 +153,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   cooldownTime: 0
+--- !u!114 &3568705224926989393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7427902273662735829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7016c8ee0b158eb4bb338088d37ff488, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MessageFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MessageFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 
@@ -31,5 +30,7 @@ namespace Baku.VMagicMirror
         //NOTE: 冗長なパラメータが入ってるが、冗長な部分はWPF側に捨てさせる(どうせ既定値しか入ってない)
         public Message AutoAdjustEyebrowResults(AutoAdjustParameters parameters)
             => WithArg(JsonUtility.ToJson(parameters));
+
+        public Message ExtraBlendShapeClipNames(string names) => WithArg(names);
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/ExtraBlendShapeClipNamesSender.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/ExtraBlendShapeClipNamesSender.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using UnityEngine;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// VRMのロード時に規格外のブレンドシェイプ名をチェックしてWPFに通知するやつ
+    /// </summary>
+    public class ExtraBlendShapeClipNamesSender : MonoBehaviour
+    {
+        [Inject] private IVRMLoadable _vrmLoadable;
+        [Inject] private IMessageSender _sender;
+
+        private void Start()
+        {
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+        }
+
+        private void OnVrmLoaded(VrmLoadedInfo info)
+        {
+            string names = string.Join(",",
+                info.blendShape
+                    .BlendShapeAvatar
+                    .Clips
+                    .Select(c => c.BlendShapeName)
+                    .Where(n => !BasicNames.Contains(n))
+            );
+
+            _sender.SendCommand(
+                MessageFactory.Instance.ExtraBlendShapeClipNames(names)
+                );
+        }
+
+        private static readonly string[] BasicNames = new[]
+        {
+            "Joy",
+            "Angry",
+            "Sorrow",
+            "Fun",
+
+            "A",
+            "I",
+            "U",
+            "E",
+            "O",
+
+            "Neutral",
+            "Blink",
+            "Blink_L",
+            "Blink_R",
+
+            "LookUp",
+            "LookDown",
+            "LookLeft",
+            "LookRight",
+        };
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/ExtraBlendShapeClipNamesSender.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/ExtraBlendShapeClipNamesSender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7016c8ee0b158eb4bb338088d37ff488
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/Models/MotionRequest.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/WordToMotion/Models/MotionRequest.cs
@@ -39,7 +39,10 @@ namespace Baku.VMagicMirror
         public bool PreferLipSync;
 
         //NOTE: 辞書にしないでこのまま使う手も無くはないです
-        [SerializeField] private BlendShapeValues BlendShapeValues = null;
+        
+        public BlendShapeValues BlendShapeValues = null;
+
+        public List<MotionRequestBlendShapeItem> ExtraBlendShapeValues = null;
 
         [NonSerialized]
         private Dictionary<string, float> _blendShapeValues = null;
@@ -52,29 +55,11 @@ namespace Baku.VMagicMirror
             {
                 if (_blendShapeValues == null)
                 {
-                    _blendShapeValues = new Dictionary<string, float>()
+                    _blendShapeValues = BlendShapeValues.ToDic();
+                    foreach (var pair in ExtraBlendShapeValues)
                     {
-                        ["Joy"] = BlendShapeValues.Joy * 0.01f,
-                        ["Angry"] = BlendShapeValues.Angry * 0.01f,
-                        ["Sorrow"] = BlendShapeValues.Sorrow * 0.01f,
-                        ["Fun"] = BlendShapeValues.Fun * 0.01f,
-                        ["Neutral"] = BlendShapeValues.Neutral * 0.01f,
-
-                        ["Blink"] = BlendShapeValues.Blink * 0.01f,
-                        ["Blink_L"] = BlendShapeValues.Blink_L * 0.01f,
-                        ["Blink_R"] = BlendShapeValues.Blink_R * 0.01f,
-
-                        ["A"] = BlendShapeValues.A * 0.01f,
-                        ["I"] = BlendShapeValues.I * 0.01f,
-                        ["U"] = BlendShapeValues.U * 0.01f,
-                        ["E"] = BlendShapeValues.E * 0.01f,
-                        ["O"] = BlendShapeValues.O * 0.01f,
-
-                        ["LookUp"] = BlendShapeValues.LookUp * 0.01f,
-                        ["LookDown"] = BlendShapeValues.LookDown * 0.01f,
-                        ["LookLeft"] = BlendShapeValues.LookLeft * 0.01f,
-                        ["LookRight"] = BlendShapeValues.LookRight * 0.01f,
-                    };
+                        _blendShapeValues[pair.Name] = pair.Value * 0.01f;
+                    }
                 }
                 return _blendShapeValues;
             }
@@ -87,6 +72,13 @@ namespace Baku.VMagicMirror
             //TODO: ちょっとここ安定性低いからtry catchしないとダメじゃないかな！
             return JsonUtility.FromJson<MotionRequest>(content);
         }
+    }
+
+    [Serializable]
+    public class MotionRequestBlendShapeItem
+    {
+        public string Name;
+        public int Value;
     }
 
     /// <summary>
@@ -121,5 +113,26 @@ namespace Baku.VMagicMirror
         public int LookDown;
         public int LookLeft;
         public int LookRight;
+
+        public Dictionary<string, float> ToDic() => new Dictionary<string, float>()
+        {
+            [nameof(Joy)] = Joy * 0.01f,
+            [nameof(Neutral)] = Neutral * 0.01f,
+            [nameof(Angry)] = Angry * 0.01f,
+            [nameof(Sorrow)] = Sorrow * 0.01f,
+            [nameof(Fun)] = Fun * 0.01f,
+            [nameof(Blink)] = Blink * 0.01f,
+            [nameof(Blink_L)] = Blink_L * 0.01f,
+            [nameof(Blink_R)] = Blink_R * 0.01f,
+            [nameof(A)] = A * 0.01f,
+            [nameof(I)] = I * 0.01f,
+            [nameof(U)] = U * 0.01f,
+            [nameof(E)] = E * 0.01f,
+            [nameof(O)] = O * 0.01f,
+            [nameof(LookUp)] = LookUp * 0.01f,
+            [nameof(LookDown)] = LookDown * 0.01f,
+            [nameof(LookLeft)] = LookLeft * 0.01f,
+            [nameof(LookRight)] = LookRight * 0.01f,
+        };
     }
 }


### PR DESCRIPTION
#171 

## 仕様

* 標準以外のブレンドシェイプについて、VRMを読みこんだときに未知のブレンドシェイプがあれば、それを記憶する
* アイテム編集画面では、いま読み込んでいるVRMに含まれるブレンドシェイプのみ値を編集できる。
* いま読み込んでいるVRMに含まれないが、WPF側の設定で保持しているブレンドシェイプについては、ブレンドシェイプのスライダーUIが無効化された状態で表示される。

* 一度覚えたブレンドシェイプ名はデフォルトのアイテムをロードするか、またはアイテム編集画面で明確に削除するまでは記憶し続ける。
* アイテム編集画面で削除できるブレンドシェイプは、現在読み込んでいるVRMに含まれないものに限る。
    - 例: VRoid製のVRMをロードすると"Surprised"ブレンドシェイプが自動で認識される。このブレンドシェイプは"Surprised"ブレンドシェイプを持ってないVRMをロードするまでは削除できない。
