### PR TITLE
DUAL SHOCK 4の挿抜でリップシンクが止まるやつの対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/VRMAutoBlink.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FaceContol/VRMAutoBlink.cs
@@ -102,6 +102,9 @@ namespace Baku.VMagicMirror
                     yield return null;
                 }
             }
+
+            //途中の動作がカクカクになった場合も最後は目を開いた状態で辻褄をあわせる
+            _currentBlinkValue = 0;
             _isBlinking = false;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/LipSync/DeviceSelectableLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/LipSync/DeviceSelectableLipSyncContext.cs
@@ -6,21 +6,33 @@ namespace Baku.VMagicMirror
 {
     public class DeviceSelectableLipSyncContext : OVRLipSyncContextBase
     {
-        AudioClip clip;
-        int head = 0;
-        const int samplingFrequency = 48000;
-        const int lengthSeconds = 1;
-        readonly float[] processBuffer = new float[1024];
-        readonly float[] microphoneBuffer = new float[lengthSeconds * samplingFrequency];
+        private const int SamplingFrequency = 48000;
+        private const int LengthSeconds = 1;
+        //この回数だけマイク音声の読み取り位置が変化しない状態が継続した場合、自動でマイクの再起動を試みる
+        private const int PositionStopCountLimit = 120;
+        
+        private readonly float[] _processBuffer = new float[1024];
+        private readonly float[] _microphoneBuffer = new float[LengthSeconds * SamplingFrequency];
+        
+        private AudioClip _clip;
+        private int _head = 0;
+
+        private int _prevPosition = -1;
+        private int _positionNotMovedCount = 0;
 
         public bool IsRecording { get; private set; } = false;
         public string DeviceName { get; private set; } = "";
-
+        
         public void StartRecording(string deviceName)
         {
             if (!IsRecording && Microphone.devices.Contains(deviceName))
             {
-                clip = Microphone.Start(deviceName, true, lengthSeconds, samplingFrequency);
+                _head = 0;
+                for (int i = 0; i < _microphoneBuffer.Length; i++)
+                {
+                    _microphoneBuffer[i] = 0;
+                }
+                _clip = Microphone.Start(deviceName, true, LengthSeconds, SamplingFrequency);
                 IsRecording = true;
                 DeviceName = deviceName;
             }
@@ -43,46 +55,76 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            var position = Microphone.GetPosition(DeviceName);
-            if (position < 0 || head == position)
+            int position = Microphone.GetPosition(DeviceName);
+
+            //読み取り位置がずっと動かない場合、マイクを復帰させる。PS4コンを挿抜したときにマイクが勝手に止まる事があります…。
+            if (position == _prevPosition)
+            {
+                _positionNotMovedCount++;
+                if (_positionNotMovedCount > PositionStopCountLimit)
+                {
+                    _positionNotMovedCount = 0;
+                    RestartMicrophone();
+                    return;
+                }
+            }
+            else
+            {
+                _prevPosition = position;
+                _positionNotMovedCount = 0;
+            }
+
+            //マイクの動いてる/動かないの検知とは別で範囲チェック
+            if (position < 0 || _head == position)
             {
                 return;
             }
 
-            clip.GetData(microphoneBuffer, 0);
-            while (GetDataLength(microphoneBuffer.Length, head, position) > processBuffer.Length)
+            _clip.GetData(_microphoneBuffer, 0);
+            while (GetDataLength(_microphoneBuffer.Length, _head, position) > _processBuffer.Length)
             {
-                var remain = microphoneBuffer.Length - head;
-                if (remain < processBuffer.Length)
+                var remain = _microphoneBuffer.Length - _head;
+                if (remain < _processBuffer.Length)
                 {
-                    Array.Copy(microphoneBuffer, head, processBuffer, 0, remain);
-                    Array.Copy(microphoneBuffer, 0, processBuffer, remain, processBuffer.Length - remain);
+                    Array.Copy(_microphoneBuffer, _head, _processBuffer, 0, remain);
+                    Array.Copy(_microphoneBuffer, 0, _processBuffer, remain, _processBuffer.Length - remain);
                 }
                 else
                 {
-                    Array.Copy(microphoneBuffer, head, processBuffer, 0, processBuffer.Length);
+                    Array.Copy(_microphoneBuffer, _head, _processBuffer, 0, _processBuffer.Length);
                 }
 
-                OVRLipSync.ProcessFrame(Context, processBuffer, Frame);
+                OVRLipSync.ProcessFrame(Context, _processBuffer, Frame);
 
-                head += processBuffer.Length;
-                if (head > microphoneBuffer.Length)
+                _head += _processBuffer.Length;
+                if (_head > _microphoneBuffer.Length)
                 {
-                    head -= microphoneBuffer.Length;
+                    _head -= _microphoneBuffer.Length;
                 }
             }
         }
 
-        static int GetDataLength(int bufferLength, int head, int tail)
+        //マイクの録音をリスタートしようとします。もし指定したマイクが完全に認識できない場合、ストップします。
+        private void RestartMicrophone()
         {
-            if (head < tail)
+            Microphone.End(DeviceName);
+            IsRecording = false;
+            if (Microphone.devices.Contains(DeviceName))
             {
-                return tail - head;
+                Debug.Log("Restart Microphone Success: " + DeviceName);
+                StartRecording(DeviceName);
             }
             else
             {
-                return bufferLength - head + tail;
+                Debug.Log("Restart Microphone Failed: " + DeviceName);
             }
         }
+        
+        
+
+        static int GetDataLength(int bufferLength, int head, int tail) 
+            => (head < tail) 
+                ? (tail - head) 
+                : (bufferLength - head + tail);
     }
 }


### PR DESCRIPTION
#204 の対策。

- マイクについては挿抜で完全に動きが止まっちゃうのが原因だったため、リスタート処理を追加
- 自動まばたきが停止するほうは、挿抜時にUnityが低FPSになったときのまばたきCoroutineの終端処理がまずいのが原因のようだったため、かならずまばたきCoroutineの最後に値が0に戻ることを保証した。