### PR TITLE
FPSなどで右手が動かなくなってた問題の対策

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ sysinfo.txt
 /VMagicMirror/Assets/XinputGamepad/
 /VMagicMirror/Assets/MidiJack/
 /VMagicMirror/Assets/SharpDX/
+/VMagicMirror/Assets/RawInputSharp/
 
 /VMagicMirror/Assets/AniLipSync-VRM.meta
 /VMagicMirror/Assets/DlibFaceLandmarkDetector.meta
@@ -73,3 +74,4 @@ sysinfo.txt
 /VMagicMirror/Assets/XinputGamepad.meta
 /VMagicMirror/Assets/MidiJack.meta
 /VMagicMirror/Assets/SharpDX.meta
+/VMagicMirror/Assets/RawInputSharp.meta

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Unity 2018.3系でUnityプロジェクトを開き、Visual Studio 2019でWPFプ
 * SharpDX.DirectInput 4.2.0
     * [SharpDX](https://www.nuget.org/packages/SharpDX)
     * [SharpDX.DirectInput](https://www.nuget.org/packages/SharpDX.DirectInput/)
+* [RawInput.Sharp](https://www.nuget.org/packages/RawInput.Sharp/) 0.0.3
 * DOTween (アセットストアから)
 
 FinalIKおよびDlib FaceLandmark Detectorが有償アセットであることに注意してください。
@@ -93,6 +94,11 @@ SharpDXは次の手順で導入します。
 
 - 2つのNuGetギャラリーの`Download package`から`.nupkg`ファイルを取得し、それぞれ`.zip`ファイルとして展開します。
 - 展開したzip内の`lib/netstandard1.3/`フォルダにそれぞれ`SharpDX.dll`および`SharpDX.DirectInput.dll`があるので、これらをUnityプロジェクト上の適当な場所に追加します。
+
+RawInput.Sharpもほぼ同様の手順です。
+
+- NuGetギャラリーから取得した`.nupkg`を展開し、中の`lib/netstandard1.1/RawInput.Sharp.dll`を取得します。
+- 取得したDLLを、Unityプロジェクト上でAssets以下に`RawInputSharp`というフォルダを作り、その下に追加します。
 
 ### 4.3. ビルド
 

--- a/README_en.md
+++ b/README_en.md
@@ -84,6 +84,7 @@ Maintainer's environment is as following.
 * SharpDX.DirectInput 4.2.0
     * [SharpDX](https://www.nuget.org/packages/SharpDX)
     * [SharpDX.DirectInput](https://www.nuget.org/packages/SharpDX.DirectInput/)
+* [RawInput.Sharp](https://www.nuget.org/packages/RawInput.Sharp/) 0.0.3
 * DOTween (from Asset Store)
 
 Should be noted that `FinalIK` and `Dlib FaceLandmark Detector` are paid asset, and you need to submit the application to get VRoid SDK.
@@ -96,6 +97,11 @@ Install SharpDX by following steps.
 
 - From 2 URLs get `.nupkg` file by `Download package`, and expand them as zip file.
 - In the expanded zip, see `lib/netstandard1.3/` to get file `SharpDX.dll` and `SharpDX.DirectInput.dll`. Put these file in anywhere on the Unity project.
+
+RawInput.Sharp can be installed with almost same work flow.
+
+- Get `.nupkg` from NuGet gallery and expand as zip to get `lib/netstandard1.1/RawInput.Sharp.dll`
+- Create `RawInputSharp` folder in Unity project's Assets folder, and put dll into the folder.
 
 ### 4.3. Build
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/MonitoringProcess/MonitoringLogics.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/MonitoringProcess/MonitoringLogics.prefab
@@ -146,6 +146,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1690014445440871619, guid: ee92b6c9100e05d4d88246a79d8af1d9,
+        type: 3}
+      propertyPath: diffValueDiminishRate
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 2947756352855395158, guid: ee92b6c9100e05d4d88246a79d8af1d9,
         type: 3}
       propertyPath: handler

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/MonitoringProcess/RawInputChecker.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/MonitoringProcess/RawInputChecker.prefab
@@ -10,8 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 982365954410614437}
   - component: {fileID: 7392682508180169179}
-  - component: {fileID: 5445794628714955643}
   - component: {fileID: 1690014445440871619}
+  - component: {fileID: 5445794628714955643}
+  - component: {fileID: 3728147126937604083}
   m_Layer: 0
   m_Name: RawInputChecker
   m_TagString: Untagged
@@ -45,18 +46,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b157506b0989896458c4443037aeea30, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5445794628714955643
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7939309247728220475}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0f365c46d8ecbff4695e9ac1b5cb469c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1690014445440871619
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -70,3 +59,27 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   diffValueDiminishRate: 6
+--- !u!114 &5445794628714955643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7939309247728220475}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f365c46d8ecbff4695e9ac1b5cb469c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &3728147126937604083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7939309247728220475}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3bee57a89fad8034fb633e04c7864d8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/MonitoringProcess/RawInputChecker.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/MonitoringProcess/RawInputChecker.prefab
@@ -10,6 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 982365954410614437}
   - component: {fileID: 7392682508180169179}
+  - component: {fileID: 5445794628714955643}
+  - component: {fileID: 1690014445440871619}
   m_Layer: 0
   m_Name: RawInputChecker
   m_TagString: Untagged
@@ -43,3 +45,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b157506b0989896458c4443037aeea30, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &5445794628714955643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7939309247728220475}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f365c46d8ecbff4695e9ac1b5cb469c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1690014445440871619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7939309247728220475}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdce11c20059ecd4dad29b0fc634b169, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  diffValueDiminishRate: 6

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs
@@ -22,11 +22,11 @@ namespace Baku.VMagicMirror
             Container.BindInstance(messageHandler);
 
             //入力監視系のコードはメッセージハンドラと同格くらいに扱えそうなので、ここでバインドする: 未登録ならシーン上を探して入れる
-            Container.BindInstance(rawInputChecker || FindObjectOfType<RawInputChecker>());
-            Container.BindInstance(mousePositionProvider || FindObjectOfType<MousePositionProvider>());
-            Container.BindInstance(faceTracker || FindObjectOfType<FaceTracker>());
-            Container.BindInstance(midiInputObserver || FindObjectOfType<MidiInputObserver>());
-            Container.BindInstance(gamepad || FindObjectOfType<StatefulXinputGamePad>());
+            Container.BindInstance(rawInputChecker ?? FindObjectOfType<RawInputChecker>());
+            Container.BindInstance(mousePositionProvider ?? FindObjectOfType<MousePositionProvider>());
+            Container.BindInstance(faceTracker ?? FindObjectOfType<FaceTracker>());
+            Container.BindInstance(midiInputObserver ?? FindObjectOfType<MidiInputObserver>());
+            Container.BindInstance(gamepad ?? FindObjectOfType<StatefulXinputGamePad>());
 
             //Deformを使うオブジェクトがここを参照することで、DeformableManagerを必要な時だけ動かせるようにする
             Container.Bind<DeformableCounter>()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/DI/VMagicMirrorInstaller.cs
@@ -10,10 +10,10 @@ namespace Baku.VMagicMirror
         [SerializeField] private MmfServer mmfServer = null;
 
         [SerializeField] private RawInputChecker rawInputChecker = null;
+        [SerializeField] private MousePositionProvider mousePositionProvider = null;
         [SerializeField] private FaceTracker faceTracker = null;
         [SerializeField] private MidiInputObserver midiInputObserver = null;
         [SerializeField] private StatefulXinputGamePad gamepad = null;
-        
         [SerializeField] private DeformableCounter deformableCounterPrefab = null; 
 
         public override void InstallBindings()
@@ -21,11 +21,12 @@ namespace Baku.VMagicMirror
             //メッセージハンドラの依存はここで注入(偽レシーバを入れたい場合、interfaceを切って別インスタンスを捻じ込めばOK)
             Container.BindInstance(messageHandler);
 
-            //入力監視系のコードはメッセージハンドラと同格くらいに扱えそうなので、ここでバインドする
-            Container.BindInstance(rawInputChecker);
-            Container.BindInstance(faceTracker);
-            Container.BindInstance(midiInputObserver);
-            Container.BindInstance(gamepad);
+            //入力監視系のコードはメッセージハンドラと同格くらいに扱えそうなので、ここでバインドする: 未登録ならシーン上を探して入れる
+            Container.BindInstance(rawInputChecker || FindObjectOfType<RawInputChecker>());
+            Container.BindInstance(mousePositionProvider || FindObjectOfType<MousePositionProvider>());
+            Container.BindInstance(faceTracker || FindObjectOfType<FaceTracker>());
+            Container.BindInstance(midiInputObserver || FindObjectOfType<MidiInputObserver>());
+            Container.BindInstance(gamepad || FindObjectOfType<StatefulXinputGamePad>());
 
             //Deformを使うオブジェクトがここを参照することで、DeformableManagerを必要な時だけ動かせるようにする
             Container.Bind<DeformableCounter>()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/TouchPadProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/HumanInterfaceDevices/TouchPadProvider.cs
@@ -1,9 +1,12 @@
 ﻿using UnityEngine;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class TouchPadProvider : MonoBehaviour
     {
+        [Inject] private MousePositionProvider _mousePositionProvider = null;
+        
         private void Start()
         {
             foreach (var meshRenderer in GetComponentsInChildren<MeshRenderer>())
@@ -20,25 +23,7 @@ namespace Baku.VMagicMirror
         /// <returns></returns>
         public Vector3 GetHandTipPosFromScreenPoint(float x, float y)
         {
-            //ベーシックな方法: ウィンドウのサイズとの比較で場所を決める
-            //return transform.TransformPoint(new Vector2(x * 0.5f, y * 0.5f));
-            
-            //hackな方法: Windowsの全画面の領域と比較して「マウスがこの辺」という計算をする。入力値は捨てます
-            
-            //懸念事項: ここ毎フレーム呼んだら重くなったりしない？なんか重そうな気がする
-            // -> そうでもなかった
-            var p = NativeMethods.GetWindowsMousePosition();
-            int left = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_XVIRTUALSCREEN);
-            int top = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_YVIRTUALSCREEN);
-            int width = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_CXVIRTUALSCREEN);
-            int height = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_CYVIRTUALSCREEN);
-
-            //NOTE: 右方向を+X, 上方向を+Y, 値域を(-0.5, 0.5)にするための変形がかかってます
-            Vector2 cursorPosInVirtualScreen = new Vector2(
-                (p.x - left) * 1.0f / width - 0.5f,
-                0.5f - (p.y - top) * 1.0f / height
-            );
-
+            var cursorPosInVirtualScreen = _mousePositionProvider.NormalizedCursorPosition;
             //NOTE: 0.95をかけて何が嬉しいかというと、パッドのギリギリのエリアを避けてくれるようになります
             return transform.TransformPoint(cursorPosInVirtualScreen * 0.95f);
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/HandIKIntegrator.cs
@@ -124,7 +124,7 @@ namespace Baku.VMagicMirror
                 return;
             }
             
-            mouseMove.MoveMouse(mousePosition);
+            //mouseMove.MoveMouse(mousePosition);
             presentation.MoveMouse(mousePosition);
             SetRightHandIk(EnablePresentationMode ? HandTargetType.Presentation : HandTargetType.Mouse);
             if (_rightTargetType == HandTargetType.Mouse)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/MouseMoveHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MotionControl/IK/MouseMoveHandIKGenerator.cs
@@ -45,6 +45,8 @@ namespace Baku.VMagicMirror
 
         private void Update()
         {
+            MoveMouse(Vector3.zero);
+            
             _rightHand.Position = Vector3.Lerp(
                 _rightHand.Position,
                 _targetPosition,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs
@@ -1,0 +1,78 @@
+﻿using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// このクラスは何とマウスの現在位置を教えてくれるすごいクラスです
+    /// </summary>
+    /// <remarks>
+    /// マウスの絶対位置に対してRawInputの差分情報を載せることで、FPSゲーで遊んでいるときの動作を補償するのが狙いです
+    /// </remarks>
+    [RequireComponent(typeof(RawMouseMoveChecker))]
+    public class MousePositionProvider : MonoBehaviour
+    {
+        [Tooltip("差分値を徐々にゼロ方向に近づけていく係数")]
+        [SerializeField] private float diffValueDiminishRate = 6f;
+
+        /// <summary>
+        /// _x, _yを対スクリーン比率で[-0.5, 0.5]の区間に収まる値になおしたもの
+        /// </summary>
+        public Vector2 NormalizedCursorPosition { get; private set; }
+        
+        private RawMouseMoveChecker _rawMouseMoveChecker = null;
+        private Vector2Int _prevCursosPos;
+        
+        //絶対位置に対して「いやユーザーはこのくらいマウス動かしてるが？」という積分値ベースの差分。徐々に減衰させて用いる。
+        private float _dx = 0;
+        private float _dy = 0;
+
+        //_dx, _dyを加味して求めたマウス位置
+        private int _x = 0;
+        private int _y = 0;
+
+        private void Start()
+        {
+            _rawMouseMoveChecker = GetComponent<RawMouseMoveChecker>();
+            _prevCursosPos = NativeMethods.GetWindowsMousePosition();
+        }
+
+        private void Update()
+        {
+            (int dx, int dy) = _rawMouseMoveChecker.GetAndReset();
+            var p = NativeMethods.GetWindowsMousePosition();
+
+            //NOTE: マウスがプログラム的に動かされちゃってる場合のみ、_dxや_dyに非ゼロの値が加算される
+            //マウスの移動が制限されていない場合、absDifとdx, dyは同じ値になる
+            var absDif = p - _prevCursosPos;
+            _dx += dx - absDif.x;
+            _dy += dy - absDif.y;
+            
+            float rate = 1.0f - diffValueDiminishRate * Time.deltaTime;
+            _dx *= rate;
+            _dy *= rate;
+            
+            int x = (int)(p.x + _dx);
+            int y = (int)(p.y + _dy);
+
+            //カーソルが動いてないときは放置
+            if (_x == x && _y == y)
+            {
+                return;
+            }
+
+            _x = x;
+            _y = y;
+            
+            int left = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_XVIRTUALSCREEN);
+            int top = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_YVIRTUALSCREEN);
+            int width = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_CXVIRTUALSCREEN);
+            int height = NativeMethods.GetSystemMetrics(NativeMethods.SystemMetricsConsts.SM_CYVIRTUALSCREEN);
+            
+            //NOTE: 右方向を+X, 上方向を+Y, 値域を(-0.5, 0.5)にするための変形をやって完成
+            NormalizedCursorPosition = new Vector2(
+                (_x - left) * 1.0f / width - 0.5f,
+                0.5f - (_y - top) * 1.0f / height
+            );           
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs
@@ -41,13 +41,19 @@ namespace Baku.VMagicMirror
             (int dx, int dy) = _rawMouseMoveChecker.GetAndReset();
             var p = NativeMethods.GetWindowsMousePosition();
 
-            //NOTE: マウスがプログラム的に動かされちゃってる場合のみ、_dxや_dyに非ゼロの値が加算される
-            //マウスの移動が制限されていない場合、absDifとdx, dyは同じ値になる
+            //NOTE: (dx, dy)とabsDifが異なるケース == マウスがプログラム的に動かされちゃってるケース
+            //FPSとかで遊んでない限りは2つの値は一致する
             var absDif = p - _prevCursosPos;
             _prevCursosPos = p;
             
             _dx += dx - absDif.x;
             _dy += dy - absDif.y;
+
+#if UNITY_EDITOR
+            //エディタではdx, dyが取れない(常時0になってしまう)ので_dx, _dyは捨てて、絶対座標だけに頼る
+            _dx = 0;
+            _dy = 0;
+#endif
             
             float rate = 1.0f - diffValueDiminishRate * Time.deltaTime;
             _dx *= rate;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs
@@ -44,6 +44,8 @@ namespace Baku.VMagicMirror
             //NOTE: マウスがプログラム的に動かされちゃってる場合のみ、_dxや_dyに非ゼロの値が加算される
             //マウスの移動が制限されていない場合、absDifとdx, dyは同じ値になる
             var absDif = p - _prevCursosPos;
+            _prevCursosPos = p;
+            
             _dx += dx - absDif.x;
             _dy += dy - absDif.y;
             
@@ -70,9 +72,9 @@ namespace Baku.VMagicMirror
             
             //NOTE: 右方向を+X, 上方向を+Y, 値域を(-0.5, 0.5)にするための変形をやって完成
             NormalizedCursorPosition = new Vector2(
-                (_x - left) * 1.0f / width - 0.5f,
-                0.5f - (_y - top) * 1.0f / height
-            );           
+                Mathf.Clamp((_x - left) * 1.0f / width - 0.5f, -0.5f, 0.5f),
+                Mathf.Clamp(0.5f - (_y - top) * 1.0f / height, -0.5f, 0.5f)
+                );           
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/MousePositionProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdce11c20059ecd4dad29b0fc634b169
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/RawMouseMoveChecker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/RawMouseMoveChecker.cs
@@ -78,7 +78,15 @@ namespace Baku.VMagicMirror
                     RawInputDeviceFlags.InputSink | RawInputDeviceFlags.NoLegacy, 
                     window.Handle
                     );
-                Forms.Application.Run();
+
+                //NOTE: Application.Runだと怒られるので素のイベントループを書いてみました
+                MSG msg;
+                while (GetMessage(out msg, IntPtr.Zero, 0, 0))
+                {
+                    TranslateMessage(ref msg);
+                    DispatchMessage(ref msg);
+                }
+                // Forms.Application.Run();
             }
             finally
             {
@@ -86,10 +94,33 @@ namespace Baku.VMagicMirror
             }
         }
         
+        
+        [DllImport("user32.dll")]
+        static extern bool GetMessage(out MSG lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+
         [DllImport("user32.dll")]
         static extern bool PostThreadMessage(int idThread, uint msg, IntPtr wParam, IntPtr lParam);
 
+        [DllImport("user32.dll")]
+        static extern bool TranslateMessage(ref MSG lpMsg);
+
+        [DllImport("user32.dll")]
+        static extern bool DispatchMessage(ref MSG lpMsg);
+        
         const int WM_QUIT = 0x0012;
+        const int WM_INPUT = 0x00FF;
+        
+        public struct MSG
+        {
+            public IntPtr hwnd;
+            public int message;
+            public IntPtr wParam;
+            public IntPtr lParam;
+            public uint time;
+            public int px;
+            public int py;
+            public IntPtr refobject;
+        }
     }
 
     /// <summary>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/RawMouseMoveChecker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/RawMouseMoveChecker.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows.Forms;
+using Forms = System.Windows.Forms;
+using UnityEngine;
+using Linearstar.Windows.RawInput;
+using Linearstar.Windows.RawInput.Native;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// RawInput方式でマウス移動イベントを取得するすごいやつだよ
+    /// </summary>
+    public class RawMouseMoveChecker : MonoBehaviour
+    {
+        private Thread _thread = null;
+        private int _dx;
+        private int _dy;
+        private readonly object _difLock = new object();
+
+        /// <summary>
+        /// 前回呼び出してからの間にマウス移動が積分された合計値を取得します。
+        /// 読み出すことで累計値は0にリセットされます。
+        /// </summary>
+        /// <returns></returns>
+        public (int dx, int dy) GetAndReset()
+        {
+            lock (_difLock)
+            {
+                int x = _dx;
+                int y = _dy;
+                _dx = 0;
+                _dy = 0;
+                return (x, y);
+            }
+        }
+        
+        private void Start()
+        {
+            _thread = new Thread(ObserveRoutine);
+            _thread.Start();
+        }
+        
+        private void OnDestroy()
+        {
+            PostThreadMessage(_thread.ManagedThreadId, WM_QUIT, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        private void AddDif(int dx, int dy)
+        {
+            lock (_difLock)
+            {
+                _dx += dx;
+                _dy += dy;
+            }
+        }
+        
+        private void ObserveRoutine()
+        {
+            var window = new ReceiverWindow();
+            window.Input += data =>
+            {
+                if (data is RawInputMouseData mouseData &&
+                    mouseData.Mouse.Flags.HasFlag(RawMouseFlags.MoveRelative))
+                {
+                    AddDif(
+                        mouseData.Mouse.LastX,
+                        mouseData.Mouse.LastY
+                    );
+                }
+            };
+
+            try
+            {
+                RawInputDevice.RegisterDevice(
+                    HidUsageAndPage.Mouse, 
+                    RawInputDeviceFlags.InputSink | RawInputDeviceFlags.NoLegacy, 
+                    window.Handle
+                    );
+                Forms.Application.Run();
+            }
+            finally
+            {
+                RawInputDevice.UnregisterDevice(HidUsageAndPage.Mouse);
+            }
+        }
+        
+        [DllImport("user32.dll")]
+        static extern bool PostThreadMessage(int idThread, uint msg, IntPtr wParam, IntPtr lParam);
+
+        const int WM_QUIT = 0x0012;
+    }
+
+    /// <summary>
+    /// RawInputのイベントを受け取るために立てるWindow
+    /// </summary>
+    public class ReceiverWindow : NativeWindow
+    {
+        private const int WM_INPUT = 0x00FF;
+        
+        public event Action<RawInputData> Input;
+
+        public ReceiverWindow()
+        {
+            CreateHandle(new CreateParams
+            {
+                X = 0,
+                Y = 0,
+                Width = 0,
+                Height = 0,
+                Style = 0x800000,
+            });
+        }
+
+        protected override void WndProc(ref System.Windows.Forms.Message m)
+        {
+            if (m.Msg == WM_INPUT)
+            {
+                Input?.Invoke(RawInputData.FromHandle(m.LParam));
+            }
+            base.WndProc(ref m);
+        }        
+    }
+    
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/RawMouseMoveChecker.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/RawMouseMoveChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f365c46d8ecbff4695e9ac1b5cb469c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WinFormKeys.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WinFormKeys.cs
@@ -5,7 +5,7 @@
 namespace System.Windows.Forms
 {
     [Flags]
-    public enum _Obsolete_Keys
+    public enum Keys
     {
         //
         // 概要:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WinFormKeys.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WinFormKeys.cs
@@ -5,7 +5,7 @@
 namespace System.Windows.Forms
 {
     [Flags]
-    public enum Keys
+    public enum _Obsolete_Keys
     {
         //
         // 概要:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WindowProcedureHook.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WindowProcedureHook.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// RawInput用のWindowsメッセージだけイベントとして取り出す事ができるようにウィンドウプロシージャを差し替えるやつです
+    /// </summary>
+    public class WindowProcedureHook : MonoBehaviour
+    {
+        delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        /// <summary>
+        /// RawInputメッセージが来た場合にLParamを引数にして発火します。
+        /// </summary>
+        public event Action<IntPtr> ReceiveRawInput;
+     
+        private IntPtr _oldWndProcPtr;
+        private IntPtr _newWndProcPtr;
+        private WndProcDelegate _newWndProc;
+        
+        private void Start() 
+        {
+            // ウインドウプロシージャをフックする
+            _newWndProc = WndProc;
+            _newWndProcPtr = Marshal.GetFunctionPointerForDelegate(_newWndProc);
+#if !UNITY_EDITOR
+            _oldWndProcPtr = SetWindowLongPtr(
+                NativeMethods.GetUnityWindowHandle(), GWLP_WNDPROC, _newWndProcPtr
+                );
+#endif
+        }
+        
+        private IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            if (msg == WM_INPUT)
+            {
+                ReceiveRawInput?.Invoke(lParam);
+            }
+            return CallWindowProc(_oldWndProcPtr, hWnd, msg, wParam, lParam);
+        }
+     
+        private void OnDisable() 
+        {
+            // ウィンドウプロシージャを元に戻す
+#if !UNITY_EDITOR            
+            SetWindowLongPtr(NativeMethods.GetUnityWindowHandle(), GWLP_WNDPROC, _oldWndProcPtr);
+#endif
+            _oldWndProcPtr = IntPtr.Zero;
+            _newWndProcPtr = IntPtr.Zero;
+            _newWndProc = null;
+        }
+
+        private const uint WM_INPUT = 0x00FF;
+        private const int GWLP_WNDPROC = -4;
+        
+        [DllImport("user32.dll")]
+        private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+   }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WindowProcedureHook.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/RawInputObserver/WindowProcedureHook.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bee57a89fad8034fb633e04c7864d8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要

#4 がついに直るよ、という話です。

## 実装の概要

- RawInputを使っています。
    - ※グローバルフックではないです(そのため、UnityRawInputとかとも別のアプローチです)
- UnityのUIスレッド上で、Windowsのイベントループ内で物理マウスが操作されたメッセージを受け取ることで、根本的にマウスの動きがプログラム依存か、ユーザー入力依存か判定しています。
- ただし物理マウス操作は積分値ベースのもので絶対的に信頼性があるわけではないので、実際には絶対値のカーソル位置と物理マウスの移動量を合計した値を用いて「それっぽいマウス座標」を生成しています。
