### PR TITLE
UniVRMのバージョンをv0.53.0に戻す

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Unity 2018.3系でUnityプロジェクトを開き、Visual Studio 2019でWPFプ
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
 * [OpenCV for Unity](https://assetstore.unity.com/packages/tools/integration/opencv-for-unity-21088)
-* [UniVRM](https://github.com/vrm-c/UniVRM) v0.55.0
+* [UniVRM](https://github.com/vrm-c/UniVRM) v0.53.0
 * [UniRx](https://github.com/neuecc/UniRx) (アセットストアから)
 * [XinputGamepad](https://github.com/kaikikazu/XinputGamePad/releases) v0.3b
 * [AniLipSync VRM](https://github.com/sh-akira/AniLipSync-VRM/releases) v1.0.1

--- a/README_en.md
+++ b/README_en.md
@@ -73,7 +73,7 @@ Maintainer's environment is as following.
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [OpenCV for Unity](https://assetstore.unity.com/packages/tools/integration/opencv-for-unity-21088)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
-* [UniVRM](https://dwango.github.io/vrm/) v0.55.0
+* [UniVRM](https://dwango.github.io/vrm/) v0.53.0
 * [UniRx](https://github.com/neuecc/UniRx) (from Asset Store)
 * [XinputGamepad](https://github.com/kaikikazu/XinputGamePad/releases) v0.3b
 * [AniLipSync VRM](https://github.com/sh-akira/AniLipSync-VRM/releases) v1.0.1


### PR DESCRIPTION
#244 の対策。

- 公開版のv0.9.8がv0.53.0を使っているので戻してもデグレしない
- どっちかというとUniVRM v0.55.0へのアップグレードのほうが危険そう

という事であえて古いのを使い続けるぞ、という判断です。

