### PR TITLE
ランダム打鍵モード

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageCommandNames.cs
@@ -57,6 +57,7 @@
         public const string HandYOffsetAfterKeyDown = nameof(HandYOffsetAfterKeyDown);
 
         // Motion, Arm
+        public const string EnableHidRandomTyping = nameof(EnableHidRandomTyping);
         public const string EnableShoulderMotionModify = nameof(EnableShoulderMotionModify);
         public const string SetWaistWidth = nameof(SetWaistWidth);
         public const string SetElbowCloseStrength = nameof(SetElbowCloseStrength);


### PR DESCRIPTION
#281 

ランダム時はすべてのインプットをアルファベットキー、または0~9(※NumPadじゃないほう)のどこかにランダムに割り当てます。

全キーからのランダムではないのは、実装上めんどくさいのと、腕が現実以上に動きまくる懸念を防ぐため。
