### PR TITLE
最適化と首モーション対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionControlLogics.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionControlLogics.prefab
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f8806990fea2f14bbc57ec6fddd312e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  goalRate: -0.05
+  goalRate: -0.02
   timeFactor: 0.2
   speedDumpFactor: 0.95
   speedLerpFactor: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionControlLogics.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionControlLogics.prefab
@@ -326,7 +326,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c15deca4e07f524b8e9cdcb40566e3c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  angleApplyFactor: 0.8
+  angleApplyFactor: 0.7
 --- !u!1 &5813678810248240003
 GameObject:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionControlLogics.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Logic/MotionControlLogics.prefab
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1f8806990fea2f14bbc57ec6fddd312e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  goalRate: -0.02
+  goalRate: -0.05
   timeFactor: 0.2
   speedDumpFactor: 0.95
   speedLerpFactor: 12
@@ -326,7 +326,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4c15deca4e07f524b8e9cdcb40566e3c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  angleApplyFactor: 0.7
+  angleApplyFactor: 1
+  pitchFactor: 0.8
+  pitchLimitDeg: 25
 --- !u!1 &5813678810248240003
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
#282 + #300 の様子見結果

- 首について: 外部トラッキング使用時、首ピッチが最大でも25degまでしか曲がらないように制限をつけた + ピッチ方向だけ回転を弱める処理を追加。
- 最適化について: iFMの受信処理がちょっと遅かったので手を入れた。まだ若干遅いんだけど、これ以上早くするならスレッド化とか、色々なスクリプトを脱MonoBehaviourするとかのほうが筋が良さそう。

※メッセージ受信の高速化については、今使ってるメッセージ名が130くらいしかないのを踏まえて効果なしと考え、放置。
