### PR TITLE
Doc/fix lang change

### DIFF
--- a/docs/pages/english/docs/external_tracker.md
+++ b/docs/pages/english/docs/external_tracker.md
@@ -5,7 +5,7 @@ permalink: /en/docs/external_tracker
 lang_prefix: /en/
 ---
 
-[English](../../docs/external_tracker)
+[Japanese](../../docs/external_tracker)
 
 # Exteral Tracker App
 

--- a/docs/pages/english/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/english/docs/external_tracker_ifacialmocap.md
@@ -5,7 +5,7 @@ permalink: /en/docs/external_tracker_ifacialmocap
 lang_prefix: /en/
 ---
 
-[English](../../docs/external_tracker_ifacialmocap)
+[Japanese](../../docs/external_tracker_ifacialmocap)
 
 # Connect to iFacialMocap
 


### PR DESCRIPTION
日本語へのリンクが"English"表記になっていたのを修正。