### PR TITLE
smallen firewall dialog image

### DIFF
--- a/docs/pages/english/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/english/docs/external_tracker_ifacialmocap.md
@@ -67,7 +67,7 @@ Please quit VMagicMirror and iFacialMocap to retry setup.
 In the next boot of VMagicMirror, you will see the firewall permission dialog.
 
 <div class="row">
-{% include docimg.html file="./images/docs/ex_tracker_firewall_dialog.png" customclass="col l6 m6 s12" imgclass="fit-doc-img" %}
+{% include docimg.html file="./images/docs/ex_tracker_firewall_dialog.png" customclass="col l4 m4 s12" imgclass="fit-doc-img" %}
 </div>
 
 `Allow Access` and retry setup to establish connection.

--- a/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
@@ -65,7 +65,7 @@ A. この問題はWindowsファイアウォールによって、PCとiOSデバ�
 ここで、VMagicMirrorを起動し直すとファイアウォールの設定ダイアログが表示されます。
 
 <div class="row">
-{% include docimg.html file="./images/docs/ex_tracker_firewall_dialog.png" customclass="col l6 m6 s12" imgclass="fit-doc-img" %}
+{% include docimg.html file="./images/docs/ex_tracker_firewall_dialog.png" customclass="col l4 m4 s12" imgclass="fit-doc-img" %}
 </div>
 
 `アクセスを許可する`をクリックし、ふたたび接続を試みることで、接続できます。


### PR DESCRIPTION
見直したらファイアウォールのダイアログ画面がでかすぎたので、せめて他と同じ幅4にしたほうがよいかなと…