### PR TITLE
リップシンク問題の対策/ロード失敗ケースのガード/Colorspace変更

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadControllerHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadControllerHelper.cs
@@ -20,6 +20,8 @@ namespace Baku.VMagicMirror
             var vrmLookAt = go.GetComponent<VRMLookAtHead>();
             vrmLookAt.Target = ikTargets.LookAt;
             
+            //NOTE: BlendShape式のはパラメータ調整をしない:
+            //VRoidがBone方式を採用しているので、そっちだけやっとけばよいかなあという判断です。
             var vrmLookAtBoneApplier = go.GetComponent<VRMLookAtBoneApplyer>();
             if (vrmLookAtBoneApplier != null)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadControllerHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadControllerHelper.cs
@@ -21,11 +21,14 @@ namespace Baku.VMagicMirror
             vrmLookAt.Target = ikTargets.LookAt;
             
             var vrmLookAtBoneApplier = go.GetComponent<VRMLookAtBoneApplyer>();
+            if (vrmLookAtBoneApplier != null)
+            {
+                vrmLookAtBoneApplier.HorizontalInner.CurveYRangeDegree = 15;
+                vrmLookAtBoneApplier.HorizontalOuter.CurveYRangeDegree = 15;
+                vrmLookAtBoneApplier.VerticalDown.CurveYRangeDegree = 10;
+                vrmLookAtBoneApplier.VerticalUp.CurveYRangeDegree = 20;
+            }
 
-            vrmLookAtBoneApplier.HorizontalInner.CurveYRangeDegree = 15;
-            vrmLookAtBoneApplier.HorizontalOuter.CurveYRangeDegree = 15;
-            vrmLookAtBoneApplier.VerticalDown.CurveYRangeDegree = 10;
-            vrmLookAtBoneApplier.VerticalUp.CurveYRangeDegree = 20;
             
             AddLookAtIK(go, ikTargets.LookAt, animator, bipedReferences.root);
             AddFingerRigToRightIndex(animator, ikTargets);

--- a/VMagicMirror/ProjectSettings/ProjectSettings.asset
+++ b/VMagicMirror/ProjectSettings/ProjectSettings.asset
@@ -47,7 +47,7 @@ PlayerSettings:
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0
-  m_ActiveColorSpace: 0
+  m_ActiveColorSpace: 1
   m_MTRendering: 1
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1


### PR DESCRIPTION
fixed #323 
fixed #324 
fixed #335 

※ #323 についてはOVRLipSyncを1.28.0に引き下げるのが実対応だったため、レポジトリ上の差分はありません。
