### PR TITLE
多重起動対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfBasedMessageIo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfBasedMessageIo.cs
@@ -10,8 +10,6 @@ namespace Baku.VMagicMirror.InterProcess
         IMessageReceiver, IMessageSender, IMessageDispatcher,
         IReleaseBeforeQuit, ITickable
     {
-        private const string ChannelName = "Baku.VMagicMirror";
-
         private MmfBasedMessageIo()
         {
             _server = new MemoryMappedFileConnectServer();
@@ -20,7 +18,7 @@ namespace Baku.VMagicMirror.InterProcess
             //NOTE: awaitする意味がないのでawaitをつけず、かつコレは警告が出るので止めてます。
             //コンストラクタでいきなりStartするのがマナー悪い、というのは無くもないです
 #pragma warning disable CS4014
-            _server.Start(ChannelName);
+            _server.Start(MmfChannelIdSource.ChannelId);
 #pragma warning restore CS4014
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfChannelIdSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfChannelIdSource.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Baku.VMagicMirror.Mmf
+{
+    /// <summary> MemoryMappedFileのチャンネル名を管理するクラス。Editor/Runtimeで挙動が変わります。 </summary>
+    public static class MmfChannelIdSource
+    {
+        private const string DefaultChannelName = "Baku.VMagicMirror";
+        
+        private static string _channelId = null;
+        /// <summary> UnityおよびWPFで使用すべき、メモリマップトファイルの名前を取得します。</summary>
+        public static string ChannelId => _channelId ?? (_channelId = CreateChannelId());
+
+        private static string CreateChannelId()
+        {
+            
+#if UNITY_EDITOR
+            //NOTE: エディタではデフォルト名を使う。
+            //このときProcess.StartでのWPF起動は行われない。
+            //WPFは手動でダブルクリックで立ち上がるが、この場合はWPFもデフォルト名を想定してくるため、結果として接続が成立する。
+            return DefaultChannelName;
+#else
+            //NOTE: 実実行ではワンタイムで文字列を作る。
+            //これをWPF側も受け取って使ってくれるため、多重起動したときにIPCがぶつからなくなる。
+            return DefaultChannelName + Guid.NewGuid().ToString();
+#endif
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfChannelIdSource.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfChannelIdSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f2f8f4bb8c21f104b8f2b37955eb6e5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
@@ -18,6 +18,8 @@ namespace Baku.VMagicMirror
         private static Message WithArg(string content, [CallerMemberName]string command = "")
             => new Message(command, content);
 
+        public Message SetUnityProcessId(int id) => WithArg(id.ToString());
+        
         public Message CloseConfigWindow() => NoArg();
 
         public Message SetCalibrateFaceData(string data) => WithArg(data);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/WpfStartAndQuit.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/WpfStartAndQuit.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using UnityEngine;
 using System.Threading.Tasks;
+using Baku.VMagicMirror.Mmf;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -95,11 +96,13 @@ namespace Baku.VMagicMirror
                 //他スクリプトの初期化とUpdateが回ってからの方がよいので少しだけ遅らせる
                 yield return null;
                 yield return null;
-#if !UNITY_EDITOR
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo()
+                var startInfo = new ProcessStartInfo()
                 {
                     FileName = path,
-                });
+                    Arguments = "/channelId " + MmfChannelIdSource.ChannelId
+                };
+#if !UNITY_EDITOR
+                Process.Start(startInfo);
 #endif
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/WpfStartAndQuit.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/WpfStartAndQuit.cs
@@ -103,6 +103,7 @@ namespace Baku.VMagicMirror
                 };
 #if !UNITY_EDITOR
                 Process.Start(startInfo);
+                _sender.SendCommand(MessageFactory.Instance.SetUnityProcessId(Process.GetCurrentProcess().Id));
 #endif
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
@@ -57,7 +57,10 @@ namespace Baku.VMagicMirror
         [DllImport("user32.dll")]
         public static extern IntPtr FindWindow(string className, string windowName);
         public static IntPtr CurrentWindowHandle = IntPtr.Zero;
-        public static IntPtr GetUnityWindowHandle() => CurrentWindowHandle == IntPtr.Zero ? CurrentWindowHandle = FindWindow(null, Application.productName) : CurrentWindowHandle;
+        public static IntPtr GetUnityWindowHandle() => CurrentWindowHandle == IntPtr.Zero 
+            ? CurrentWindowHandle = System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle
+            //? CurrentWindowHandle = FindWindow(null, Application.productName) 
+            : CurrentWindowHandle;
 
         [DllImport("user32.dll")]
         public static extern int SetWindowLong(IntPtr hWnd, int nIndex, uint dwNewLong); /*x uint o int unchecked*/


### PR DESCRIPTION
fixed #328 

- 多重起動したときに、WindowHandleとかプロセス間通信に関する問題が起きていたのを対策しました。

ただし対策レベルとしては非常に控えめで、例えばこういう制約があります。

- 完全に同一のexeを2回起動したときの動作を保証するものではありません。推奨する操作としては、VMagicMirrorのzipを別のフォルダに2回展開し、別々に立ち上げることを想定しています。
- 複数起動するとき、キャラウィンドウの初期位置がかぶってしまいやすいです(PlayerPrefsの同じ保存値を拾うため)
- webカメラやリップシンク用のマイク入力は、先にデバイスを押さえたほうのプロセスで占有されます。もう一方のプロセスで、占有済みのカメラやマイクを選んだ場合、エラー表示はさほど親切にはなりません(選んでもなぜか動かない、という状態になります)。

とくにデバイスの占有問題については改善の余地があります…が、そもそも複数起動する人は少ないはずなので、これ以上のサポートするほどはバリューが無い、という判断です。
