### PR TITLE
透過モードで絵がタテに伸びてしまう問題の対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadController.cs
@@ -80,15 +80,7 @@ namespace Baku.VMagicMirror
             }
             catch (Exception ex)
             {
-                string logContent =
-                    _errorInfoFactory.LoadVrmErrorContentPrefix() + 
-                    "--\n" + LogOutput.ExToString(ex) + "\n--";
-                LogOutput.Instance.Write(logContent);
-                _errorSender.SendError(
-                    _errorInfoFactory.LoadVrmErrorTitle(),
-                    logContent,
-                    ErrorIndicateSender.ErrorLevel.Error
-                    );
+                HandleLoadError(ex);
             }
         }
 
@@ -118,21 +110,20 @@ namespace Baku.VMagicMirror
             }
             catch (Exception ex)
             {
-                string logContent =
-                    _errorInfoFactory.LoadVrmErrorContentPrefix() + 
-                    "--\n" + LogOutput.ExToString(ex) + "\n--";
-                LogOutput.Instance.Write(logContent);
-                _errorSender.SendError(
-                    _errorInfoFactory.LoadVrmErrorTitle(),
-                    logContent,
-                    ErrorIndicateSender.ErrorLevel.Error
-                );
+                HandleLoadError(ex);
             }
         }
 
         public void OnVrmLoadedFromVRoidHub(string modelId, GameObject vrmObject)
         {
-            SetModel(vrmObject);
+            try 
+            {
+                SetModel(vrmObject);
+            }
+            catch (Exception ex)
+            {    
+                HandleLoadError(ex);
+            }
         }
 
         //モデルの破棄
@@ -187,6 +178,20 @@ namespace Baku.VMagicMirror
             
             PreVrmLoaded?.Invoke(info);
             VrmLoaded?.Invoke(info);
+        }
+
+        private void HandleLoadError(Exception ex)
+        {
+            string logContent =
+                _errorInfoFactory.LoadVrmErrorContentPrefix() +
+                "--\n" + LogOutput.ExToString(ex) + "\n--";
+
+            LogOutput.Instance.Write(logContent);
+            _errorSender.SendError(
+                _errorInfoFactory.LoadVrmErrorTitle(),
+                logContent,
+                ErrorIndicateSender.ErrorLevel.Error
+                );
         }
         
         [Serializable]

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
@@ -166,7 +166,8 @@ namespace Baku.VMagicMirror
         /// ウィンドウサイズをそのままに保ちつつ、リサイズイベントを発生させます。
         /// 透過モードのオンオフ切り替え時に呼び出すことで、画像の歪みを防げます。
         /// </summary>
-        public static void RefreshWindowSize()
+        /// <param name="dx"></param>
+        public static void RefreshWindowSize(int dx)
         {
             var handle = GetUnityWindowHandle();
             if (!GetWindowRect(handle, out var rect))
@@ -176,7 +177,7 @@ namespace Baku.VMagicMirror
             
             SetWindowPos(GetUnityWindowHandle(),
                 IntPtr.Zero,
-                0, 0, rect.right - rect.left, rect.bottom - rect.top,
+                0, 0, rect.right - rect.left + dx, rect.bottom - rect.top,
                 SetWindowPosFlags.IgnoreMove | 
                     SetWindowPosFlags.IgnoreZOrder | 
                     SetWindowPosFlags.FrameChanged | 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
@@ -133,16 +133,23 @@ namespace Baku.VMagicMirror
         public static extern uint DwmExtendFrameIntoClientArea(IntPtr hWnd, ref DwmMargin margins);
         public static void SetDwmTransparent(bool enable)
         {
-            var margins = new DwmMargin() { cxLeftWidth = enable ? -1 : 0 };
+            int margin = enable ? -1 : 0;
+            var margins = new DwmMargin()
+            {
+                cxLeftWidth = margin,
+                cxRightWidth = margin,
+                cyTopHeight = margin,
+                cyBottomHeight = margin,
+            };
             DwmExtendFrameIntoClientArea(GetUnityWindowHandle(), ref margins);
         }
 
         public const int GWL_STYLE = -16;
-        public const uint WS_POPUP = 0x80000000;
-        public const uint WS_VISIBLE = 0x10000000;
+        public const uint WS_POPUP = 0x8000_0000;
+        public const uint WS_VISIBLE = 0x1000_0000;
         public const int GWL_EXSTYLE = -20;
-        public const uint WS_EX_LAYERED = 0x00080000;
-        public const uint WS_EX_TRANSPARENT = 0x00000020;
+        public const uint WS_EX_LAYERED = 0x0008_0000;
+        public const uint WS_EX_TRANSPARENT = 0x0000_0020;
 
         [DllImport("user32.dll")]
         public static extern bool SetLayeredWindowAttributes(IntPtr hWnd, uint crKey, byte bAlpha, uint dwFlags);
@@ -153,6 +160,30 @@ namespace Baku.VMagicMirror
         public static void SetWindowAlpha(byte alpha)
         {
             SetLayeredWindowAttributes(GetUnityWindowHandle(), 0, alpha, LWA_ALPHA);
+        }
+
+        /// <summary>
+        /// ウィンドウサイズをそのままに保ちつつ、リサイズイベントを発生させます。
+        /// 透過モードのオンオフ切り替え時に呼び出すことで、画像の歪みを防げます。
+        /// </summary>
+        public static void RefreshWindowSize()
+        {
+            var handle = GetUnityWindowHandle();
+            if (!GetWindowRect(handle, out var rect))
+            {
+                return;
+            }
+            
+            SetWindowPos(GetUnityWindowHandle(),
+                IntPtr.Zero,
+                0, 0, rect.right - rect.left, rect.bottom - rect.top,
+                SetWindowPosFlags.IgnoreMove | 
+                    SetWindowPosFlags.IgnoreZOrder | 
+                    SetWindowPosFlags.FrameChanged | 
+                    SetWindowPosFlags.DoNotChangeOwnerZOrder |
+                    SetWindowPosFlags.DoNotActivate | 
+                    SetWindowPosFlags.AsynchronousWindowPosition
+            );
         }
 
         public delegate bool EnumWindowsDelegate(IntPtr hWnd, IntPtr lparam);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -56,6 +56,8 @@ namespace Baku.VMagicMirror
         private Texture2D _colorPickerTexture = null;
         private bool _isOnOpaquePixel = false;
         private bool _isClickThrough = false;
+        //既定値がtrueになる(デフォルトでは常時最前面である)ことに注意
+        private bool _isTopMost = true;
 
         int _wholeWindowTransparencyLevel = TransparencyLevel.WhenOnCharacter;
         byte _wholeWindowAlphaWhenTransparent = 0x80;
@@ -151,9 +153,7 @@ namespace Baku.VMagicMirror
         {
             _colorPickerTexture = new Texture2D(1, 1, TextureFormat.ARGB32, false);
 
-            //既定で最前面に表示
-            SetTopMost(true);
-
+            SetTopMost(_isTopMost);
             StartCoroutine(PickColorCoroutine());
         }
 
@@ -164,7 +164,7 @@ namespace Baku.VMagicMirror
             UpdateWindowPositionCheck();
             UpdateWindowTransparency();
         }
-
+        
         private void OnDestroy()
         {
 #if !UNITY_EDITOR
@@ -361,9 +361,7 @@ namespace Baku.VMagicMirror
         {
             _isWindowFrameHidden = !isVisible;
             var hwnd = GetUnityWindowHandle();
-            uint windowStyle = isVisible ?
-                defaultWindowStyle :
-                WS_POPUP | WS_VISIBLE;
+            uint windowStyle = isVisible ? defaultWindowStyle : WS_POPUP | WS_VISIBLE;
 #if !UNITY_EDITOR
             SetWindowLong(hwnd, GWL_STYLE, windowStyle);
 #endif
@@ -374,9 +372,16 @@ namespace Baku.VMagicMirror
             _isTransparent = isTransparent;
 #if !UNITY_EDITOR
             SetDwmTransparent(isTransparent);
+            StartCoroutine(RefreshWindowSizeWithDelay());
+
+            IEnumerator RefreshWindowSizeWithDelay()
+            {
+                yield return new WaitForSeconds(0.2f);
+                RefreshWindowSize();
+            }
 #endif
         }
-
+        
         private void SetIgnoreMouseInput(bool ignoreMouseInput)
         {
             _preferIgnoreMouseInput = ignoreMouseInput;
@@ -384,8 +389,9 @@ namespace Baku.VMagicMirror
 
         private void SetTopMost(bool isTopMost)
         {
+            _isTopMost = isTopMost;
 #if !UNITY_EDITOR
-        SetUnityWindowTopMost(isTopMost);
+            SetUnityWindowTopMost(isTopMost);
 #endif
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -372,13 +372,10 @@ namespace Baku.VMagicMirror
             _isTransparent = isTransparent;
 #if !UNITY_EDITOR
             SetDwmTransparent(isTransparent);
-            StartCoroutine(RefreshWindowSizeWithDelay());
-
-            IEnumerator RefreshWindowSizeWithDelay()
-            {
-                yield return new WaitForSeconds(0.2f);
-                RefreshWindowSize();
-            }
+            //NOTE: リサイズイベントが発生しないケースを確実に潰しつつ、ウィンドウサイズは維持するための処置。
+            //透過→不透過の切り替え時に歪まないための対策です
+            RefreshWindowSize(-1);
+            RefreshWindowSize(1);
 #endif
         }
         


### PR DESCRIPTION
fixed #348 

やったこと

- issueの指摘にあるリサイズイベントの呼び出しを実施
- 透過→不透過への切り替え時に画像が横に伸びてしまう問題があったため、そのままのリサイズイベントを呼ぶのではなく「ズラして元に戻す」みたいな処理を適用
