### PR TITLE
透過モード時の画面歪み対策: 続き

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
@@ -166,18 +166,13 @@ namespace Baku.VMagicMirror
         /// ウィンドウサイズをそのままに保ちつつ、リサイズイベントを発生させます。
         /// 透過モードのオンオフ切り替え時に呼び出すことで、画像の歪みを防げます。
         /// </summary>
-        /// <param name="dx"></param>
-        public static void RefreshWindowSize(int dx)
+        /// <param name="cx"></param>
+        /// <param name="cy"></param>
+        public static void RefreshWindowSize(int cx, int cy)
         {
-            var handle = GetUnityWindowHandle();
-            if (!GetWindowRect(handle, out var rect))
-            {
-                return;
-            }
-            
             SetWindowPos(GetUnityWindowHandle(),
                 IntPtr.Zero,
-                0, 0, rect.right - rect.left + dx, rect.bottom - rect.top,
+                0, 0, cx, cy,
                 SetWindowPosFlags.IgnoreMove | 
                     SetWindowPosFlags.IgnoreZOrder | 
                     SetWindowPosFlags.FrameChanged | 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
@@ -163,8 +163,7 @@ namespace Baku.VMagicMirror
         }
 
         /// <summary>
-        /// ウィンドウサイズをそのままに保ちつつ、リサイズイベントを発生させます。
-        /// 透過モードのオンオフ切り替え時に呼び出すことで、画像の歪みを防げます。
+        /// ウィンドウサイズを設定します。
         /// </summary>
         /// <param name="cx"></param>
         /// <param name="cy"></param>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -372,11 +372,24 @@ namespace Baku.VMagicMirror
             _isTransparent = isTransparent;
 #if !UNITY_EDITOR
             SetDwmTransparent(isTransparent);
-            //NOTE: リサイズイベントが発生しないケースを確実に潰しつつ、ウィンドウサイズは維持するための処置。
-            //透過→不透過の切り替え時に歪まないための対策です
-            RefreshWindowSize(-1);
-            RefreshWindowSize(1);
+            ForceWindowResizeEvent();
 #endif
+        }
+
+        private void ForceWindowResizeEvent()
+        {
+            //NOTE: リサイズ処理は「ズラしてから元に戻す」方式で呼ぶと透過→不透過の切り替え時に画像が歪むのを防げるため、
+            //わざと2回呼ぶようにしてます
+            if (!GetWindowRect(GetUnityWindowHandle(), out var rect))
+            {
+                return;
+            }
+
+            int cx = rect.right - rect.left;
+            int cy = rect.bottom - rect.top;
+            
+            RefreshWindowSize(cx - 1, cy - 1);
+            RefreshWindowSize(cx, cy);
         }
         
         private void SetIgnoreMouseInput(bool ignoreMouseInput)


### PR DESCRIPTION
#348 の対策の続き。

#350 の時点ではリサイズ処理でサイズがずりずり変わっていくリスクがありそうに見えたので、それを防ぐ改修を入れてます。