### PR TITLE
うなづきモーションをいい感じにするやつ

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
@@ -273,7 +273,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ccd5f299c1abbd4bb7387e98b79aefa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speedDumpForceFactor: 20
+  speedDumpForceFactor: 10
   posDumpForceFactor: 50
   headRate: 0.5
 --- !u!114 &1338865419136667663
@@ -291,6 +291,7 @@ MonoBehaviour:
   angleApplyFactor: 1
   pitchFactor: 0.8
   pitchLimitDeg: 25
+  lerpFactor: 18
 --- !u!1 &5813678810248240003
 GameObject:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FaceAttitudeController.cs
@@ -61,7 +61,7 @@ namespace Baku.VMagicMirror
         //体の回転に反映するとかの都合で首ロールを実際に検出した値より控えめに適用しますよ、というファクター
         private const float HeadRollRateApplyFactor = 0.8f;
         //こっちの2つは角度の指定。これらの値もbodyが動くことまで加味して調整してます
-        private const float HeadYawRateToDegFactor = 28.00f; 
+        private const float HeadYawRateToDegFactor = 25.00f; 
         private const float HeadPitchRateToDegFactor = 25.0f;
         
         private const float HeadTotalRotationLimitDeg = 40.0f;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationCompletedDataSender.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationCompletedDataSender.cs
@@ -6,7 +6,7 @@
         public CalibrationCompletedDataSender(IMessageSender sender, FaceTracker faceTracker)
         {
             faceTracker.CalibrationCompleted += 
-                data => sender.SendCommand(MessageFactory.Instance.SetCalibrateFaceData(data));
+                data => sender.SendCommand(MessageFactory.Instance.SetCalibrationFaceData(data));
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationData.cs
@@ -9,6 +9,7 @@ namespace Baku.VMagicMirror
         public float eyeBrowPosition;
         public float eyeOpenHeight;
         public float noseHeight;
+        public float eyeFaceYDiff;
         //タテヨコを掛けたピクセル総数にあたる値
         public float faceSize;        
         public Vector2 faceCenter;
@@ -18,6 +19,7 @@ namespace Baku.VMagicMirror
             eyeBrowPosition = 1.43f;
             eyeOpenHeight = 0.06f;
             noseHeight = 0.14f;
+            eyeFaceYDiff = 0.0f;
             faceSize = 0.1f;
             faceCenter = Vector2.zero;
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTracker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTracker.cs
@@ -237,6 +237,7 @@ namespace Baku.VMagicMirror
                 CalibrationData.eyeOpenHeight = calibrationData.eyeOpenHeight;
                 CalibrationData.eyeBrowPosition = calibrationData.eyeBrowPosition;
                 CalibrationData.noseHeight = calibrationData.noseHeight;
+                CalibrationData.eyeFaceYDiff = calibrationData.eyeFaceYDiff;
                 CalibrationData.faceCenter = calibrationData.faceCenter;
                 CalibrationData.faceSize = calibrationData.faceSize;
             }
@@ -472,7 +473,8 @@ namespace Baku.VMagicMirror
 
             CalibrationData.noseHeight =
                 FaceParts.Nose.CurrentNoseBaseHeightValue;
-
+            CalibrationData.eyeFaceYDiff =
+                FaceParts.Outline.EyeFaceYDiff;
 
             CalibrationCompleted?.Invoke(JsonUtility.ToJson(CalibrationData));
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/GamePadInput/DirectInputGamePad.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/GamePadInput/DirectInputGamePad.cs
@@ -27,9 +27,13 @@ namespace Baku.VMagicMirror
             _directInput = new DirectInput();
 
             //使えそうなゲームパッド or ジョイスティックを探す
-            //Gamepad, Joystick, どっちも無ければGameControlクラスを順に探します
-            var devices = _directInput
-                .GetDevices(DeviceType.Gamepad, DeviceEnumerationFlags.AllDevices)
+            //FirstPersonが最初なのは暗黙にDUAL SHOCK 4の優先度を上げるため。
+            //(手元環境だとDUAL SHOCK 4はなぜかFirstPersonにヒットする)
+            //他のGamepadとかだとフットペダルみたいなのが先に引っかかることがあるので、それを予防してます。
+            //またGameControlは「拾いすぎ」になりやすいんだけど、これは仕方ないということで今は許容します
+            var devices = 
+                _directInput.GetDevices(DeviceType.FirstPerson, DeviceEnumerationFlags.AllDevices)
+                .Concat(_directInput.GetDevices(DeviceType.Gamepad, DeviceEnumerationFlags.AllDevices))
                 .Concat(_directInput.GetDevices(DeviceType.Joystick, DeviceEnumerationFlags.AllDevices))
                 .Concat(_directInput.GetDevices(DeviceClass.GameControl, DeviceEnumerationFlags.AllDevices))
                 .ToList();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
@@ -24,7 +24,7 @@ namespace Baku.VMagicMirror
         
         public Message CloseConfigWindow() => NoArg();
 
-        public Message SetCalibrateFaceData(string data) => WithArg(data);
+        public Message SetCalibrationFaceData(string data) => WithArg(data);
 
         public Message SetBlendShapeNames(string v) => WithArg(v);
 


### PR DESCRIPTION
fixed #326
ついでに fixed #355 


頭部ピッチの計算方法の改善について:

### 改善前

- 鼻付近の画像ランドマークで得られる四角形のY方向の長さに注目してピッチを得る
    - pro: 計算が割と単純
    - con: 精度がいまいち、ぶれやすい

### 改善後

- 目とこめかみのランドマークの上下関係を見る。で、目のほうがこめかみより上なら見上げた姿勢であり、目のほうが下ならうつむいた姿勢であると判断する
   - pro: そこそこ安定する
   - con: あまり無いが、ロールとピッチが組み合わさると若干よくない
