### PR TITLE
fix key name received from iFacialMocap

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapBlendShapeNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapBlendShapeNames.cs
@@ -72,7 +72,7 @@ namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
         //まゆげ
         public const string browDownLeft = "browDown_L";
         public const string browOuterUpLeft = "browOuterUp_L";
-        public const string browDownRight = "browDown_Right";
+        public const string browDownRight = "browDown_R";
         public const string browOuterUpRight = "browOuterUp_R";
         public const string browInnerUp = nameof(browInnerUp);
 


### PR DESCRIPTION
ブレンドシェイプ名が間違ってたせいでパーフェクトシンク時に右眉が下がってなかった、という不具合の修正です。