### PR TITLE
表情切り替え中のリップシンク続行処理についてパーフェクトシンクをサポート

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
@@ -414,7 +414,7 @@ namespace Baku.VMagicMirror.ExternalTracker
         }
         
         /// <summary> 決め打ちされた、パーフェクトシンクで使うブレンドシェイプの一覧 </summary>
-        static class Keys
+        public static class Keys
         {
             static Keys()
             {
@@ -561,6 +561,81 @@ namespace Baku.VMagicMirror.ExternalTracker
                     BrowOuterUpRight,
                     BrowInnerUp,
                 };                
+                
+                PerfectSyncMouthKeys =  new[]
+                {
+                    //口(多い)
+                    MouthLeft,
+                    MouthSmileLeft,
+                    MouthFrownLeft,
+                    MouthPressLeft,
+                    MouthUpperUpLeft,
+                    MouthLowerDownLeft,
+                    MouthStretchLeft,
+                    MouthDimpleLeft,
+
+                    MouthRight,
+                    MouthSmileRight,
+                    MouthFrownRight,
+                    MouthPressRight,
+                    MouthUpperUpRight,
+                    MouthLowerDownRight,
+                    MouthStretchRight,
+                    MouthDimpleRight,
+
+                    MouthClose,
+                    MouthFunnel,
+                    MouthPucker,
+                    MouthShrugUpper,
+                    MouthShrugLower,
+                    MouthRollUpper,
+                    MouthRollLower,
+
+                    //あご
+                    JawOpen,
+                    JawForward,
+                    JawLeft,
+                    JawRight,
+                    
+                    //ほお
+                    CheekPuff,
+                    CheekSquintLeft,
+                    CheekSquintRight,
+
+                    //舌
+                    TongueOut,
+                };                
+                
+                PerfectSyncNonMouthKeys = new[]
+                {
+                    //目
+                    EyeBlinkLeft,
+                    EyeLookUpLeft,
+                    EyeLookDownLeft,
+                    EyeLookInLeft,
+                    EyeLookOutLeft,
+                    EyeWideLeft,
+                    EyeSquintLeft,
+
+                    EyeBlinkRight,
+                    EyeLookUpRight,
+                    EyeLookDownRight,
+                    EyeLookInRight,
+                    EyeLookOutRight,
+                    EyeWideRight,
+                    EyeSquintRight,
+
+                    //鼻
+                    NoseSneerLeft,
+                    NoseSneerRight,
+
+                    //まゆげ
+                    BrowDownLeft,
+                    BrowOuterUpLeft,
+                    BrowDownRight,
+                    BrowOuterUpRight,
+                    BrowInnerUp,
+                };
             }
 
             /// <summary>
@@ -573,6 +648,10 @@ namespace Baku.VMagicMirror.ExternalTracker
             
             /// <summary> Perfect Syncでいじる対象のブレンドシェイプキー一覧を取得します。 </summary>
             public static BlendShapeKey[] PerfectSyncKeys { get; }
+            /// <summary> Perfect Syncの口、ほお、顎、舌のキーを取得します。</summary>
+            public static BlendShapeKey[] PerfectSyncMouthKeys { get; }
+            /// <summary> Perfect Syncの目、鼻、眉のキーを取得します。</summary>
+            public static BlendShapeKey[] PerfectSyncNonMouthKeys { get; }
             
             //TODO: 名前はあとで調べて直すこと！絶対に間違った名前が入ってるぞ！
             

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
@@ -71,10 +71,19 @@ namespace Baku.VMagicMirror
                     _initializer.InitializeBlendShapes(perfectSync.ProgramaticallyAddedVRoidClipKeys);
                 }
                 
+                //TODO: このAccumulateでリップシンク続行オプションがついてるとき、
+                //AIUEOだけじゃなくてパーフェクトシンクのクリップも書くのをスキップしたいよね
                 _wtmBlendShape.Accumulate(_blendShape);
                 if (_wtmBlendShape.SkipLipSyncKeys)
                 {
-                    lipSync.Accumulate(_blendShape);
+                    if (perfectSync.IsActive && perfectSync.PreferWriteMouthBlendShape)
+                    {
+                        perfectSync.Accumulate(_blendShape, false, true, false);
+                    }
+                    else
+                    {
+                        lipSync.Accumulate(_blendShape);
+                    }
                 }
                 return;
             }
@@ -84,14 +93,20 @@ namespace Baku.VMagicMirror
             if (faceSwitch.HasClipToApply)
             {
                 //NOTE: この場合、InitializerでぜんぶInitializeしたあと高々6個だけが重複で適用される。
-                //これはパフォーマンス影響が十分小さそうなのでOKとする
+                //これはパフォーマンス影響が十分小さそうなのでOKとする…と思ったが、パーフェクトシンクの口が適用される場合はちょっと重いよ。
                 _initializer.InitializeBlendShapes();
                 faceSwitch.Accumulate(_blendShape);
                 if (faceSwitch.KeepLipSync)
                 {
-                    lipSync.Accumulate(_blendShape);
+                    if (perfectSync.IsActive && perfectSync.PreferWriteMouthBlendShape)
+                    {
+                        perfectSync.Accumulate(_blendShape, false, true, false);
+                    }
+                    else
+                    {
+                        lipSync.Accumulate(_blendShape);
+                    }
                 }
-
                 return;
             }
             

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
@@ -52,7 +52,7 @@ namespace Baku.VMagicMirror
         }
 
         /// <summary> trueの場合、このスクリプトではリップシンクのブレンドシェイプに書き込みを行いません。 </summary>
-        public bool SkipLipSyncKeys { get; set; }
+        public bool KeepLipSync { get; set; }
         
         /// <summary>
         /// Word To Motionによるブレンドシェイプを指定します。
@@ -99,11 +99,12 @@ namespace Baku.VMagicMirror
             {
                 var key = _allBlendShapeKeys[i];
                 //リップシンク保持オプションがオン = AIUEOはAccumulateしない(元の値をリスペクトする)
-                if (SkipLipSyncKeys && _lipSyncKeys.Any(k => k.Preset == key.Preset && k.Name == key.Name))
+                if (KeepLipSync && _lipSyncKeys.Any(k => k.Preset == key.Preset && k.Name == key.Name))
                 {
                     continue;
                 }
-                    
+                //NOTE: パーフェクトシンクのクリップはリップシンク保持であっても通す。
+                //これはフィルタすると重すぎるので「パーフェクトシンク使う人はそのくらい理解してくれ」という意味です
                 if (_blendShape.TryGetValue(key, out float value) && value > 0f)
                 {
                     proxy.AccumulateValue(key, value);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionManager.cs
@@ -93,7 +93,7 @@ namespace Baku.VMagicMirror
                 {
                     IsPlayingBlendShape = false;
                     _blendShape.ResetBlendShape();
-                    _blendShape.SkipLipSyncKeys = false;
+                    _blendShape.KeepLipSync = false;
                     StopPreviewBuiltInMotion();
                 }
             }
@@ -263,7 +263,7 @@ namespace Baku.VMagicMirror
                     !_currentMotionRequest.HoldBlendShape)
                 {
                     IsPlayingBlendShape = false;
-                    _blendShape.SkipLipSyncKeys = false;
+                    _blendShape.KeepLipSync = false;
                     _blendShape.ResetBlendShape();
                 }
             }
@@ -304,7 +304,7 @@ namespace Baku.VMagicMirror
                 {
                     _blendShape.Add(BlendShapeKeyFactory.CreateFrom(pair.Key), pair.Value);
                 }
-                _blendShape.SkipLipSyncKeys = PreviewRequest.PreferLipSync;
+                _blendShape.KeepLipSync = PreviewRequest.PreferLipSync;
             }
             else
             {
@@ -506,7 +506,7 @@ namespace Baku.VMagicMirror
             {
                 _blendShape.Add(BlendShapeKeyFactory.CreateFrom(pair.Key), pair.Value);
             }
-            _blendShape.SkipLipSyncKeys = request.PreferLipSync;
+            _blendShape.KeepLipSync = request.PreferLipSync;
             _blendShapeResetCountDown = CalculateDuration(request);
         }
 


### PR DESCRIPTION
fixed #362 

メモ: 想定挙動として以下の問題が起きる。ただし、「まあこの組合せはしないでしょ」というのと、ガードかけると処理負荷かコード複雑性がかなり上がる事から、対策無しにしてます。

手順:

- WtMで新規作成した要素について、
    - パーフェクトシンクのクリップを0以外の値にする
    - リップシンク続行チェックをオンにする
- パーフェクトシンク可能なモデルをロードして口をパーフェクトシンクで動かす
- 作ったWtMのクリップを実行する

期待挙動: 

- WtMの要素で指定したパーフェクトシンクのクリップの値が無視され、パーフェクトシンクの値のみが使われる。

実際の挙動

- WtMで指定した値とパーフェクトシンクで取得した値の合計が使われる。この結果、動きすぎになる懸念がある。
