### PR TITLE
ゲームパッド持ってるときの手IKの改善

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
@@ -54,6 +54,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   blendShapeInitializer: {fileID: 7797473119978373343}
   lipSyncContext: {fileID: 3748904030990320927}
+  lipSyncIntegrator: {fileID: 6125060425342205146}
 --- !u!114 &3748028266611161169
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
@@ -442,6 +442,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   typing: {fileID: 5813678810404708595}
   gamepadFinger: {fileID: 5813678810404708492}
+  waitingBody: {fileID: 5813678808713813113}
   fingerController: {fileID: 2951044793089892564}
   gamepadSetting:
     imageBasedBodyMotion: {fileID: 5813678808713813112}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncIntegrator.cs
@@ -25,6 +25,18 @@ namespace Baku.VMagicMirror
         {
             _config = config;
         }
+
+        public float VoiceRate
+        {
+            get
+            {
+                var src = PreferExternalTrackerLipSync
+                    ? externalTrackerLipSync.LipSyncSource
+                    : animMorphEasedTarget.LipSyncSource;
+                //NOTE: params引数を使うと配列化されそうでヤダなあという書き方です
+                return Mathf.Max(src.A, Mathf.Max(src.I, Mathf.Max(src.U, Mathf.Max(src.E, src.O))));
+            }
+        }
         
         public void Accumulate(VRMBlendShapeProxy proxy)
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -81,6 +81,7 @@ namespace Baku.VMagicMirror
             IKTargetTransforms ikTargets, 
             Camera cam,
             ParticleStore particleStore,
+            LipSyncIntegrator lipSyncIntegrator,
             GamepadProvider gamepadProvider,
             MidiControllerProvider midiControllerProvider,
             TouchPadProvider touchPadProvider,
@@ -95,7 +96,7 @@ namespace Baku.VMagicMirror
 
             MouseMove = new MouseMoveHandIKGenerator(this, touchPadProvider);
             MidiHand = new MidiHandIkGenerator(this, midiControllerProvider);
-            GamepadHand = new GamepadHandIKGenerator(this, gamepadProvider, gamepadSetting);
+            GamepadHand = new GamepadHandIKGenerator(this, lipSyncIntegrator, gamepadProvider, gamepadSetting);
             Presentation = new PresentationHandIKGenerator(this, vrmLoadable, cam);
             _imageBaseHand = new ImageBaseHandIkGenerator(this, handTracker, imageBaseHandSetting, vrmLoadable);
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -20,6 +20,8 @@ namespace Baku.VMagicMirror
 
         [SerializeField] private GamepadFingerController gamepadFinger = null;
 
+        [SerializeField] private WaitingBodyMotion waitingBody = null;
+
         public MouseMoveHandIKGenerator MouseMove { get; private set; }
 
         public GamepadHandIKGenerator GamepadHand { get; private set; }
@@ -81,7 +83,6 @@ namespace Baku.VMagicMirror
             IKTargetTransforms ikTargets, 
             Camera cam,
             ParticleStore particleStore,
-            LipSyncIntegrator lipSyncIntegrator,
             GamepadProvider gamepadProvider,
             MidiControllerProvider midiControllerProvider,
             TouchPadProvider touchPadProvider,
@@ -97,7 +98,7 @@ namespace Baku.VMagicMirror
             MouseMove = new MouseMoveHandIKGenerator(this, touchPadProvider);
             MidiHand = new MidiHandIkGenerator(this, midiControllerProvider);
             GamepadHand = new GamepadHandIKGenerator(
-                this, vrmLoadable, lipSyncIntegrator, gamepadProvider, gamepadSetting
+                this, vrmLoadable, waitingBody, gamepadProvider, gamepadSetting
                 );
             Presentation = new PresentationHandIKGenerator(this, vrmLoadable, cam);
             _imageBaseHand = new ImageBaseHandIkGenerator(this, handTracker, imageBaseHandSetting, vrmLoadable);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -96,7 +96,9 @@ namespace Baku.VMagicMirror
 
             MouseMove = new MouseMoveHandIKGenerator(this, touchPadProvider);
             MidiHand = new MidiHandIkGenerator(this, midiControllerProvider);
-            GamepadHand = new GamepadHandIKGenerator(this, lipSyncIntegrator, gamepadProvider, gamepadSetting);
+            GamepadHand = new GamepadHandIKGenerator(
+                this, vrmLoadable, lipSyncIntegrator, gamepadProvider, gamepadSetting
+                );
             Presentation = new PresentationHandIKGenerator(this, vrmLoadable, cam);
             _imageBaseHand = new ImageBaseHandIkGenerator(this, handTracker, imageBaseHandSetting, vrmLoadable);
         }
@@ -492,6 +494,10 @@ namespace Baku.VMagicMirror
             {
                 _imageBaseHand.InitializeHandPosture(ReactedHand.Left, _prevLeftHand);
             }
+            
+            GamepadHand.HandIsOnController = 
+                _leftTargetType == HandTargetType.Gamepad ||
+                _rightTargetType == HandTargetType.Gamepad;
         }
 
         private void SetRightHandIk(HandTargetType targetType)
@@ -535,6 +541,10 @@ namespace Baku.VMagicMirror
             {
                 _imageBaseHand.InitializeHandPosture(ReactedHand.Right, _prevRightHand);
             }
+
+            GamepadHand.HandIsOnController = 
+                _leftTargetType == HandTargetType.Gamepad ||
+                _rightTargetType == HandTargetType.Gamepad;
         }
 
         //クールダウンタイムを考慮したうえで、モーションを適用してよいかどうかを確認します。

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using Random = UnityEngine.Random;
 
 namespace Baku.VMagicMirror
 {
@@ -10,7 +11,7 @@ namespace Baku.VMagicMirror
     public class GamepadHandIKGenerator : HandIkGeneratorBase
     {
         [Serializable]
-        public struct GamepadHandIkGeneratorSetting
+        public class GamepadHandIkGeneratorSetting
         {
             public ImageBasedBodyMotion imageBasedBodyMotion;            
         }
@@ -26,13 +27,20 @@ namespace Baku.VMagicMirror
         
         public GamepadHandIKGenerator(
             MonoBehaviour coroutineResponder, 
+            LipSyncIntegrator lipSyncIntegrator,
             GamepadProvider gamepadProvider,
             GamepadHandIkGeneratorSetting setting) : base(coroutineResponder)
         {
+            _lipSync = lipSyncIntegrator;
             _gamePad = gamepadProvider;
             _setting = setting;
         }
 
+        private readonly InputBasedJitter _inputJitter = new InputBasedJitter();
+        private readonly TimeBasedJitter _timeJitter = new TimeBasedJitter();
+        private readonly VoiceBasedJitter _voiceJitter = new VoiceBasedJitter();
+
+        private readonly LipSyncIntegrator _lipSync;
         private readonly GamepadProvider _gamePad;
         private readonly GamepadHandIkGeneratorSetting _setting;
         
@@ -46,22 +54,6 @@ namespace Baku.VMagicMirror
 
         private Vector2 _rawStickPos = Vector2.zero;
         private Vector2 _filterStickPos = Vector2.zero;
-        
-        //NOTE: raw系の値はゲームパッドの位置からただちに求まる、ローパスされていない値
-        private Vector3 _rawLeftPos = Vector3.zero;
-        private Quaternion _rawLeftRot = Quaternion.identity;
-        
-        private Vector3 _rawRightPos = Vector3.zero;
-        private Quaternion _rawRightRot = Quaternion.identity;
-        
-        //NOTE: filter系の値はraw系の値にlerpがかかったやつ
-        private Vector3 _filterLeftPos = Vector3.zero;
-        private Quaternion _filterLeftRot = Quaternion.identity;
-        
-        private Vector3 _filterRightPos = Vector3.zero;
-        private Quaternion _filterRightRot = Quaternion.identity;
-        
-        
 
         private float _offsetY = 0;
         private int _buttonDownCount = 0;
@@ -85,6 +77,7 @@ namespace Baku.VMagicMirror
         
         public void ButtonDown(GamepadKey key)
         {
+            _inputJitter.AddButtonInput();
             if (GamepadProvider.IsSideKey(key))
             {
                 return;
@@ -111,6 +104,7 @@ namespace Baku.VMagicMirror
         
         public void LeftStick(Vector2 stickPos)
         {
+            _inputJitter.SetLeftStickPos(stickPos);
             if (_leanMode == GamepadLeanModes.GamepadLeanLeftStick)
             {
                 ApplyStickPosition(stickPos);
@@ -119,6 +113,7 @@ namespace Baku.VMagicMirror
 
         public void RightStick(Vector2 stickPos)
         {
+            _inputJitter.SetRightStickPos(stickPos);
             if (_leanMode == GamepadLeanModes.GamepadLeanRightStick)
             {
                 ApplyStickPosition(stickPos);
@@ -153,33 +148,38 @@ namespace Baku.VMagicMirror
             //とりあえず初期位置までゲームコントローラIKの場所を持ち上げておく:
             //やらないとIK位置が0,0,0のままになって良くない
             ApplyStickPosition(Vector2.zero);
-
-            (_filterLeftPos, _filterLeftRot, _filterRightPos, _filterRightRot) =
-                (_rawLeftPos, _rawLeftRot, _rawRightPos, _rawRightRot);
         }
         
         public override void Update()
         {
-            UpdateRawPositions();
-            UpdateButtonDownYOffset();
+            UpdateButtonDownYOffset();            
+            _voiceJitter.Update(_lipSync.VoiceRate, Time.deltaTime);
+            _timeJitter.Update(Time.deltaTime);
+            _inputJitter.Update(Time.deltaTime);
             
-            //とりあえず全部Lerp
+            //とりあえずLerp
             _filterStickPos = Vector2.Lerp(_filterStickPos, _rawStickPos, SpeedFactor * Time.deltaTime);
-            _filterLeftPos = Vector3.Lerp(_filterLeftPos, _rawLeftPos, SpeedFactor * Time.deltaTime);
-            _filterLeftRot = Quaternion.Slerp(_filterLeftRot, _rawLeftRot, SpeedFactor * Time.deltaTime);
-            _filterRightPos = Vector3.Lerp(_filterRightPos, _rawRightPos, SpeedFactor * Time.deltaTime);
-            _filterRightRot = Quaternion.Slerp(_filterRightRot, _rawRightRot, SpeedFactor * Time.deltaTime);
 
-            var offset = Vector3.up * _offsetY + _setting.imageBasedBodyMotion.BodyIkOffset * BodyMotionToGamepadPosApplyFactor;
+            //いろいろな理由で後処理が載るのを計算
+            var posOffset =
+                Vector3.up * _offsetY +
+                _setting.imageBasedBodyMotion.BodyIkOffset * BodyMotionToGamepadPosApplyFactor +
+                _timeJitter.PosOffset +
+                _voiceJitter.PosOffset +
+                _inputJitter.PosOffset;
 
-            //ボタン押し状態、および体の動きを考慮して最終的なIKを適用
-            _leftHand.Position = _filterLeftPos + offset;
-            _leftHand.Rotation = _filterLeftRot;
-            _rightHand.Position = _filterRightPos + offset;
-            _rightHand.Rotation = _filterRightRot;
+            var rotOffset = _timeJitter.Rotation * _voiceJitter.Rotation * _inputJitter.Rotation;
 
-            //手の実際の位置を与えてゲームパッドのモデル位置を再調整
-            _gamePad.SetFilteredPosition(_filterStickPos, offset);
+            //フィルタリングとオフセットを考慮してゲームパッドの位置自体をちょっと調整
+            _gamePad.SetFilteredPositionAndRotation(_filterStickPos, posOffset, rotOffset);
+            
+            //調整後のコントローラ位置に合わせて手を持っていく
+            var (leftPos, leftRot) = _gamePad.GetLeftHand();
+            var (rightPos,rightRot) = _gamePad.GetRightHand();
+            _leftHand.Position = leftPos;
+            _leftHand.Rotation = leftRot;
+            _rightHand.Position = rightPos;
+            _rightHand.Rotation = rightRot;
         }
 
         private void UpdateButtonDownYOffset()
@@ -201,13 +201,147 @@ namespace Baku.VMagicMirror
             GamepadLeanLeftButtons,
             GamepadLeanLeftStick,
             GamepadLeanRightStick,
-        }        
+        }
+
+        //色々な理由による手の動き
         
-        private void UpdateRawPositions()
+        /// <summary> コントローラ入力があると動くぶんの補正。細かくXYZ全方向に動き、やや素早い </summary>
+        sealed class InputBasedJitter
         {
-            _gamePad.SetHorizontalPosition(_rawStickPos);            
-            (_rawLeftPos, _rawLeftRot) = _gamePad.GetLeftHand();
-            (_rawRightPos, _rawRightRot) = _gamePad.GetRightHand();
+            public Vector3 PosOffset { get; private set; }
+            public Quaternion Rotation { get; private set; }
+
+            private const float TargetChangeProbability = 0.25f;
+            private static readonly Vector3 MotionScale = new Vector3(0.01f, 0.02f, 0.01f);
+            private static readonly Vector3 RotScaleEuler = new Vector3(8f, 1f, 8f);
+            private const float TimeLerpFactor = 6.0f;
+
+            //ガチャガチャしてるとコントローラが動きやすい、という処理で使うしきい値
+            private const float StickDiffToChangeTargetThreshold = 0.8f;
+            private const float StickDiffDecreaseRate = 0.1f;
+
+            private float _stickDiffCount = 0f;
+            
+            private Vector3 _offsetTarget = Vector3.zero;
+            private Quaternion _rotationTarget = Quaternion.identity;
+
+            private Vector2 _leftPos = Vector2.zero;
+            private Vector2 _rightPos = Vector2.zero;
+            
+            public void AddButtonInput()
+            {
+                TryChangeTarget();
+            }
+
+            public void SetLeftStickPos(Vector2 pos)
+            {
+                AddStickInput(Vector2.Distance(_leftPos, pos));
+                _leftPos = pos;
+            }
+
+            public void SetRightStickPos(Vector2 pos)
+            {
+                AddStickInput(Vector2.Distance(_rightPos, pos));
+                _rightPos = pos;
+            }
+
+            private void AddStickInput(float diff)
+            {
+                _stickDiffCount += diff;
+                if (_stickDiffCount > StickDiffToChangeTargetThreshold)
+                {
+                    _stickDiffCount -= StickDiffToChangeTargetThreshold;
+                    TryChangeTarget();
+                }
+            }
+        
+            public void Update(float deltaTime)
+            {
+                _stickDiffCount -= StickDiffDecreaseRate * deltaTime;
+                if (_stickDiffCount < 0) _stickDiffCount = 0f;
+                
+                PosOffset = Vector3.Lerp(PosOffset, _offsetTarget, TimeLerpFactor * deltaTime);
+                Rotation = Quaternion.Slerp(Rotation, _rotationTarget, TimeLerpFactor * deltaTime);
+            }
+
+            private void TryChangeTarget()
+            {
+                if (Random.Range(0f, 1f) > TargetChangeProbability)
+                {
+                    return;
+                }
+                _offsetTarget = RandomVec(MotionScale);
+                _rotationTarget = Quaternion.Euler(RandomVec(RotScaleEuler));
+            }
+        }
+
+        /// <summary> 純粋に時間依存で動く補正。ほぼYZ平面上に限定で、ゆっくりで、ほどほど動く </summary>
+        sealed class TimeBasedJitter
+        {
+            public Vector3 PosOffset { get; private set; }
+            public Quaternion Rotation { get; private set; }
+
+            private const float TargetUpdateIntervalMin = 2f;
+            private const float TargetUpdateIntervalMax = 6f;
+            
+            private static readonly Vector3 MotionScale = new Vector3(0.01f, 0.03f, 0.01f);
+            private static readonly Vector3 RotScaleEuler = new Vector3(5f, 0, 5f);
+
+            private const float TimeLerpFactor = 3f;
+
+            private float _timeCount = 0f;
+            private float _interval = TargetUpdateIntervalMax;
+            private Vector3 _offsetTarget = Vector3.zero;
+            private Quaternion _rotationTarget = Quaternion.identity;
+            
+            public void Update(float deltaTime)
+            {
+                PosOffset = Vector3.Lerp(PosOffset, _offsetTarget, TimeLerpFactor * deltaTime);
+                Rotation = Quaternion.Slerp(Rotation, _rotationTarget, TimeLerpFactor * deltaTime);
+
+                _timeCount += deltaTime;
+                if (_timeCount < _interval)
+                {
+                    return;
+                }
+
+                _timeCount = 0;
+                _interval = Random.Range(TargetUpdateIntervalMin, TargetUpdateIntervalMax);
+                _offsetTarget = RandomVec(MotionScale);
+                _rotationTarget = Quaternion.Euler(RandomVec(RotScaleEuler));
+            }
+        } 
+        
+        
+        /// <summary> 声が出てるときにかかる補正。Y方向に上がる+ピッチのみ動かす、ろくろ回し？的な補正 </summary>
+        sealed class VoiceBasedJitter
+        {
+            public Vector3 PosOffset { get; private set; }
+            public Quaternion Rotation { get; private set; }
+
+            private const float TimeLerpFactor = 3f;
+            private const float PosOffsetMax = 0.02f;
+            private const float PitchMaxDeg = 10f;
+
+            private float _rate = 0f;
+
+            public void Update(float voiceRate, float deltaTime)
+            {
+                _rate = Mathf.Lerp(_rate, voiceRate, TimeLerpFactor * deltaTime);
+                PosOffset = new Vector3(0, _rate * PosOffsetMax);
+                Rotation = Quaternion.AngleAxis(-_rate * PitchMaxDeg, Vector3.right);
+            }
+        }
+        
+        
+        private static Vector3 RandomVec(Vector3 scale)
+        {
+            return new Vector3(
+                Random.Range(-scale.x, scale.x),
+                Random.Range(-scale.y, scale.y),
+                Random.Range(-scale.z, scale.z)
+            );
         }
     }
+    
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
@@ -139,12 +139,7 @@ namespace Baku.VMagicMirror
                 stickPos.x * (ReverseGamepadStickLeanHorizontal ? -1f : 1f),
                 stickPos.y * (ReverseGamepadStickLeanVertical ? -1f : 1f)
                 );
-
             _rawStickPos = pos;
-            _gamePad.SetHorizontalPosition(pos);
-            
-            (_rawLeftPos, _rawLeftRot) = _gamePad.GetLeftHand();
-            (_rawRightPos, _rawRightRot) = _gamePad.GetRightHand();   
         }
 
         private static Vector2 NormalizedStickPos(Vector2Int v)
@@ -165,6 +160,7 @@ namespace Baku.VMagicMirror
         
         public override void Update()
         {
+            UpdateRawPositions();
             UpdateButtonDownYOffset();
             
             //とりあえず全部Lerp
@@ -206,5 +202,12 @@ namespace Baku.VMagicMirror
             GamepadLeanLeftStick,
             GamepadLeanRightStick,
         }        
+        
+        private void UpdateRawPositions()
+        {
+            _gamePad.SetHorizontalPosition(_rawStickPos);            
+            (_rawLeftPos, _rawLeftRot) = _gamePad.GetLeftHand();
+            (_rawRightPos, _rawRightRot) = _gamePad.GetRightHand();
+        }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
@@ -247,8 +247,8 @@ namespace Baku.VMagicMirror
 
             private const float TargetChangeProbability = 0.4f;
             private static readonly Vector3 MotionScale = new Vector3(0.01f, 0.02f, 0.01f);
-            private static readonly Vector3 RotScaleEuler = new Vector3(8f, 1f, 8f);
-            private const float TimeLerpFactor = 6.0f;
+            private static readonly Vector3 RotScaleEuler = new Vector3(6f, 1f, 6f);
+            private const float TimeLerpFactor = 4.0f;
             
             //ボタンを素早く押すとコントローラが動きやすい、という処理で使うしきい値
             private const float ButtonDiffToChangeTargetThreshold = 1.5f;
@@ -351,7 +351,7 @@ namespace Baku.VMagicMirror
             private const float PitchInterval = 19f;
             private const float RollInterval = 22f;
             
-            private static readonly Vector3 MotionScale = new Vector3(0.005f, 0.01f, 0.005f);
+            private static readonly Vector3 MotionScale = new Vector3(0.01f, 0.02f, 0.01f);
             private static readonly Vector3 RotScaleEuler = new Vector3(2f, 0, 2f);
 
             private float _count = 0f;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Receiver/MotionSettingReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Receiver/MotionSettingReceiver.cs
@@ -16,9 +16,10 @@ namespace Baku.VMagicMirror
         private const int DeviceTypeMidiController = 3;
         
         [SerializeField] private GamepadBasedBodyLean gamePadBasedBodyLean = null;
-        [SerializeField] private GamepadHandIKGenerator smallGamepadHandIk = null;
         [SerializeField] private HandIKIntegrator handIkIntegrator = null;
         [SerializeField] private HeadIkIntegrator headIkIntegrator = null;
+
+        private GamepadHandIKGenerator smallGamepadHandIk => handIkIntegrator.GamepadHand;
         
         private XInputGamePad _gamePad = null;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/GamepadProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/GamepadProvider.cs
@@ -66,45 +66,29 @@ namespace Baku.VMagicMirror
                 );
             t.localScale = (baseScale * parameters.ArmLengthFactor) * Vector3.one;
         }
-        
-        /// <summary>
-        /// [-1, 1]の範囲で表現されたスティック情報をもとにゲームパッドの位置を変更します。
-        /// </summary>
-        /// <param name="pos"></param>
-        public void SetHorizontalPosition(Vector2 pos)
-        {
-            gamepadCenter.localPosition = new Vector3(
-                moveRange.x * pos.x,
-                0.0f,
-                moveRange.y * pos.y
-                );
-            
-            //並進に合わせて回転もする
-            gamepadCenter.localRotation = Quaternion.Euler(
-                pos.y * posToEulerAngle.y,
-                0,
-                -pos.x * posToEulerAngle.x
-                );
-        }
 
         /// <summary>
         /// このゲームパッドを持っているはずの両手の位置の中点、およびスティックの傾きを表す値を指定することで、
         /// コントローラの望ましい位置、姿勢を生成します。
         /// </summary>
         /// <param name="pos"></param>
-        /// <param name="offset"></param>
-        public void SetFilteredPosition(Vector2 pos, Vector3 offset)
+        /// <param name="posOffset"></param>
+        /// <param name="rotOffset"></param>
+        public void SetFilteredPositionAndRotation(Vector2 pos, Vector3 posOffset, Quaternion rotOffset)
         {
-            modelRoot.localPosition = new Vector3(moveRange.x * pos.x, 0.0f, moveRange.y * pos.y);
-            modelRoot.position += offset;
-            
-            //並進に合わせて回転もする
-            modelRoot.localRotation = Quaternion.Euler(
-                pos.y * posToEulerAngle.y,
-                0,
-                -pos.x * posToEulerAngle.x
-            );
-            
+            //NOTE: 2種類のTransformを使ってるのはローカルスケールの適用をやる関係で両者を分けておきたいから。
+            //…なんだけど
+            var localPos =new Vector3(moveRange.x * pos.x, 0.0f, moveRange.y * pos.y);
+            var localRot = rotOffset * 
+                Quaternion.Euler(pos.y * posToEulerAngle.y, 0, -pos.x * posToEulerAngle.x);
+
+            gamepadCenter.localPosition = localPos;
+            gamepadCenter.position += posOffset;
+            gamepadCenter.localRotation = localRot;
+
+            modelRoot.localPosition = localPos;
+            modelRoot.position += posOffset;
+            modelRoot.localRotation = localRot;
         }
         
         //ワールドのを渡す点に注意

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/FaceControlInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/FaceControlInstaller.cs
@@ -1,5 +1,4 @@
-﻿using Baku.VMagicMirror.ExternalTracker;
-using UnityEngine;
+﻿using UnityEngine;
 using Zenject;
 
 namespace Baku.VMagicMirror.Installer
@@ -9,12 +8,14 @@ namespace Baku.VMagicMirror.Installer
     {
         [SerializeField] private BlendShapeInitializer blendShapeInitializer = null;
         [SerializeField] private DeviceSelectableLipSyncContext lipSyncContext = null;
+        [SerializeField] private LipSyncIntegrator lipSyncIntegrator = null;
 
         public override void Install(DiContainer container)
         {
             container.Bind<VRMBlendShapeStore>().AsCached();
             container.BindInstance(blendShapeInitializer).AsCached();
             container.BindInstance(lipSyncContext).AsCached();
+            container.BindInstance(lipSyncIntegrator).AsCached();
         }
     }
 }


### PR DESCRIPTION
fixed #376 
fixed #388 

とくに #376 について

- 呼吸モーションの周期に合わせてゲームパッドIKの手を動かす
- 入力が多いと手がワキワキ動く
- 手の並進移動量については足～頭の高さをリファレンスにしてスケールする
- (ついで)ゲームパッドIKの処理が微妙に煩雑だったので簡略化する方向に修正
