### PR TITLE
直立特化モード + ウィンドウ位置がロスる問題の対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
@@ -153,9 +153,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   offsetAmplifier: {x: 0.05, y: 0.1, z: 0.5}
+  offsetAmplifierWhenNoHandTrack: {x: 0.4, y: 0.25, z: 0.5}
   offsetLowerLimit: {x: -1, y: -1, z: -0.05}
   offsetUpperLimit: {x: 1, y: 1, z: 0.1}
   offsetToBodyRotEulerFactor: {x: -80, y: 0, z: 0}
+  offsetToBodyRotEulerFactorWhenNoHandTrack: {x: 0, y: 0, z: 0}
   speedFactor: 12
   timeScaleFactor: 0.3
   enableBodyLeanZ: 0
@@ -213,6 +215,9 @@ MonoBehaviour:
   applyScale: {x: -0.15, y: 0.15, z: 0.1}
   applyMin: {x: -0.02, y: -0.02, z: -0.01}
   applyMax: {x: 0.02, y: 0.02, z: 0.01}
+  applyScaleWhenNoHandTrack: {x: -0.8, y: 0.7, z: 0.6}
+  applyMinWhenNoHandTrack: {x: -0.2, y: -0.2, z: -0.1}
+  applyMaxWhenNoHandTrack: {x: 0.2, y: 0.2, z: 0.1}
   lerpFactor: 18
 --- !u!1 &5813678809054739212
 GameObject:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
@@ -156,7 +156,7 @@ MonoBehaviour:
   offsetAmplifierWhenNoHandTrack: {x: 0.4, y: 0.25, z: 0.5}
   offsetLowerLimit: {x: -1, y: -1, z: -0.05}
   offsetUpperLimit: {x: 1, y: 1, z: 0.1}
-  offsetToBodyRotEulerFactor: {x: -80, y: 0, z: 0}
+  offsetToBodyRotEulerFactor: {x: 10, y: 0, z: 0}
   offsetToBodyRotEulerFactorWhenNoHandTrack: {x: 0, y: 0, z: 0}
   speedFactor: 12
   timeScaleFactor: 0.3

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerBodyOffset.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerBodyOffset.cs
@@ -12,13 +12,17 @@ namespace Baku.VMagicMirror
     {
         [Tooltip("受け取った値の適用スケール。割と小さい方がいいかも")]
         [SerializeField] private Vector3 applyScale = new Vector3(0.3f, 0.3f, 0.3f);
-        
         //NOTE: 移動量もフレーバー程度ということで小さめに。
         [SerializeField] private Vector3 applyMin = new Vector3(-0.05f, -0.05f, -0.02f);
         [SerializeField] private Vector3 applyMax = new Vector3(0.05f, 0.05f, 0.02f);
 
-        [SerializeField] private float lerpFactor = 18f;
+        //NOTE: この場合もxの比率は1.0にはせず、代わりに首回転にもとづく胴体の回転で並進が載るのに頼る
+        [SerializeField] private Vector3 applyScaleWhenNoHandTrack = new Vector3(0.8f, 1f, 0.6f);
+        [SerializeField] private Vector3 applyMinWhenNoHandTrack = new Vector3(-0.2f, -0.2f, -0.1f);
+        [SerializeField] private Vector3 applyMaxWhenNoHandTrack = new Vector3(0.2f, 0.2f, 0.1f);
         
+        [SerializeField] private float lerpFactor = 18f;
+
         private FaceControlConfiguration _config;
         private ExternalTrackerDataSource _externalTracker;
         
@@ -30,6 +34,7 @@ namespace Baku.VMagicMirror
         }
         
         public Vector3 BodyOffset { get; private set; }
+        public bool NoHandTrackMode { get; set; }
 
         private void Update()
         {
@@ -41,12 +46,16 @@ namespace Baku.VMagicMirror
             }
             
             var offset = _externalTracker.HeadPositionOffset;
-
+            
+            var (scale, min, max) = NoHandTrackMode
+                ? (applyScaleWhenNoHandTrack, applyMinWhenNoHandTrack, applyMaxWhenNoHandTrack)
+                : (applyScale, applyMin, applyMax);
+            
             var goal = _externalTracker.Connected
                 ? new Vector3(
-                    Mathf.Clamp(offset.x * applyScale.x, applyMin.x, applyMax.x),
-                    Mathf.Clamp(offset.y * applyScale.y, applyMin.z, applyMax.z),
-                    Mathf.Clamp(offset.z * applyScale.z, applyMin.z, applyMax.z)
+                    Mathf.Clamp(offset.x * scale.x, min.x, max.x),
+                    Mathf.Clamp(offset.y * scale.y, min.z, max.z),
+                    Mathf.Clamp(offset.z * scale.z, min.z, max.z)
                 )
                 : Vector3.zero;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManager.cs
@@ -72,5 +72,11 @@ namespace Baku.VMagicMirror
 
         public void EnableImageBaseBodyLeanZ(bool enable)
             => imageBasedBodyMotion.EnableBodyLeanZ = enable;
+
+        public void SetNoHandTrackMode(bool enable)
+        {
+            imageBasedBodyMotion.NoHandTrackMode = enable;
+            exTrackerBodyMotion.NoHandTrackMode = enable;
+        }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManagerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManagerReceiver.cs
@@ -24,7 +24,10 @@ namespace Baku.VMagicMirror
                 VmmCommands.EnableBodyLeanZ,
                 message => bodyMotionManager.EnableImageBaseBodyLeanZ(message.ToBoolean())
                 );
-            
+            receiver.AssignCommandHandler(
+                VmmCommands.EnableNoHandTrackMode,
+                message => bodyMotionManager.SetNoHandTrackMode(message.ToBoolean())
+                );
             _waitingMotionSize = _bodyMotionManager.WaitingBodyMotion.MotionSize;
             SetWaitMotionScale(1.25f);
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamepadFingerController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamepadFingerController.cs
@@ -21,6 +21,11 @@ namespace Baku.VMagicMirror
         {
             int fingerNumber = KeyToFingerNumber(key);
             _fingerPressButtonCounts[fingerNumber]--;
+            if (_fingerPressButtonCounts[fingerNumber] < 0)
+            {
+                _fingerPressButtonCounts[fingerNumber] = 0;
+            }
+            
             fingerController.Hold(
                 fingerNumber,
                 GetBendingAngle(fingerNumber, _fingerPressButtonCounts[fingerNumber] > 0)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>常に手を下げた姿勢になるような手IKの生成処理。</summary>
+    public sealed class AlwaysDownHandIkGenerator : HandIkGeneratorBase
+    {
+        // ハンドトラッキングがロスしたときにAポーズへ落とし込むときの、腕の下げ角度(手首の曲げもコレに準拠します
+        private const float APoseArmDownAngleDeg = 70f;
+        // Aポーズから少しだけ手首の位置を斜め前方上にズラすオフセット
+        private readonly Vector3 APoseHandPosOffset = new Vector3(0f, 0.02f, 0.02f);
+
+        private readonly IKDataRecord _leftHand = new IKDataRecord();
+        public IIKGenerator LeftHand => _leftHand;
+        private readonly IKDataRecord _rightHand = new IKDataRecord();
+        public IIKGenerator RightHand => _rightHand;
+
+        private bool _hasModel = false;
+
+        private Transform _leftUpperArm;
+        private Transform _rightUpperArm;
+        private Vector3 _rightPosUpperArmOffset;
+        private Vector3 _leftPosUpperArmOffset;
+        private readonly Quaternion RightRot = Quaternion.Euler(0, 0, -APoseArmDownAngleDeg);
+        private readonly Quaternion LeftRot = Quaternion.Euler(0, 0, APoseArmDownAngleDeg);
+        
+        public AlwaysDownHandIkGenerator(MonoBehaviour coroutineResponder, IVRMLoadable vrmLoadable)
+            : base(coroutineResponder)
+        {
+            _leftHand.Rotation = LeftRot;
+            _rightHand.Rotation = RightRot;
+
+            vrmLoadable.VrmLoaded += info =>
+            {
+                var animator = info.animator;
+
+                _rightUpperArm = animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+                var rightUpperArmPos = _rightUpperArm.position;
+                var rightWristPos = animator.GetBoneTransform(HumanBodyBones.RightHand).position;
+
+                _rightPosUpperArmOffset =
+                    _rightUpperArm.InverseTransformPoint(
+                        _rightUpperArm.position +
+                        Quaternion.AngleAxis(-APoseArmDownAngleDeg, Vector3.forward) * (rightWristPos - rightUpperArmPos) + 
+                        APoseHandPosOffset
+                    );
+
+                _leftUpperArm = animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
+                var leftUpperArmPos = _leftUpperArm.position;
+                var leftWristPos = animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
+
+                _leftPosUpperArmOffset =
+                    _leftUpperArm.InverseTransformPoint(
+                        _leftUpperArm.position +
+                        Quaternion.AngleAxis(APoseArmDownAngleDeg, Vector3.forward) * (leftWristPos - leftUpperArmPos) +
+                        APoseHandPosOffset
+                    );
+
+                _leftHand.Position = leftUpperArmPos + _leftPosUpperArmOffset;
+                _rightHand.Position = rightUpperArmPos + _rightPosUpperArmOffset;
+                _hasModel = true;
+            };
+            
+            vrmLoadable.VrmDisposing += () =>
+            {
+                _hasModel = false;
+                _leftUpperArm = null;
+                _rightUpperArm = null;
+            };
+
+            StartCoroutine(SetHandPositionsIfHasModel());
+        }
+
+        private IEnumerator SetHandPositionsIfHasModel()
+        {
+            var eof = new WaitForEndOfFrame();
+            while (true)
+            {
+                yield return eof;
+                if (!_hasModel)
+                {
+                    continue;
+                }
+
+                //やること: LateUpdateの時点で手の位置を合わせる。
+                //フレーム終わりじゃないと調整されたあとのボーン位置が拾えないので、このタイミングでわざわざやってます
+                _leftHand.Position = _leftUpperArm.TransformPoint(_leftPosUpperArmOffset);
+                _rightHand.Position = _rightUpperArm.TransformPoint(_rightPosUpperArmOffset);
+            }
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa07c4d5fabca724fafc2a650be48696
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Receiver/MotionSettingReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Receiver/MotionSettingReceiver.cs
@@ -19,7 +19,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private HandIKIntegrator handIkIntegrator = null;
         [SerializeField] private HeadIkIntegrator headIkIntegrator = null;
 
-        private GamepadHandIKGenerator smallGamepadHandIk => handIkIntegrator.GamepadHand;
+        private GamepadHandIKGenerator GamepadHandIk => handIkIntegrator.GamepadHand;
         
         private XInputGamePad _gamePad = null;
 
@@ -30,6 +30,10 @@ namespace Baku.VMagicMirror
             receiver.AssignCommandHandler(
                 VmmCommands.EnableHidArmMotion,
                 message => handIkIntegrator.EnableHidArmMotion = message.ToBoolean()
+                );
+            receiver.AssignCommandHandler(
+                VmmCommands.EnableNoHandTrackMode,
+                message => handIkIntegrator.AlwaysHandDownMode = message.ToBoolean()
                 );
             receiver.AssignCommandHandler(
                 VmmCommands.LengthFromWristToPalm,
@@ -73,21 +77,21 @@ namespace Baku.VMagicMirror
                 message =>
                 {
                     gamePadBasedBodyLean.SetGamepadLeanMode(message.Content);
-                    smallGamepadHandIk.SetGamepadLeanMode(message.Content);
+                    GamepadHandIk.SetGamepadLeanMode(message.Content);
                 });
             receiver.AssignCommandHandler(
                 VmmCommands.GamepadLeanReverseHorizontal,
                 message =>
                 {
                     gamePadBasedBodyLean.ReverseGamepadStickLeanHorizontal = message.ToBoolean();
-                    smallGamepadHandIk.ReverseGamepadStickLeanHorizontal = message.ToBoolean();
+                    GamepadHandIk.ReverseGamepadStickLeanHorizontal = message.ToBoolean();
                 });
             receiver.AssignCommandHandler(
                 VmmCommands.GamepadLeanReverseVertical,
                 message =>
                 {
                     gamePadBasedBodyLean.ReverseGamepadStickLeanVertical = message.ToBoolean();
-                    smallGamepadHandIk.ReverseGamepadStickLeanVertical = message.ToBoolean();
+                    GamepadHandIk.ReverseGamepadStickLeanVertical = message.ToBoolean();
                 });
             receiver.AssignCommandHandler(
                 VmmCommands.SetDeviceTypeToStartWordToMotion,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -75,6 +75,7 @@ namespace Baku.VMagicMirror
         public const string WaitMotionPeriod = nameof(WaitMotionPeriod);
         
         // Motion, Body
+        public const string EnableNoHandTrackMode = nameof(EnableNoHandTrackMode);
         public const string EnableBodyLeanZ = nameof(EnableBodyLeanZ);
 
         // Motion, Face


### PR DESCRIPTION
fixed #375 
fixed #389 

#389 については最初の2コミット( 4fa3b23 と 74f0e60 )が該当する。

実装のポイントメモ

- HandIKの一種として「手を下げっぱなし」を作った
- モード中はモーションのスケールをでかくするようにした(iOS連携時はほぼ物理スケールになる)
- 肩が斜めになると手先がY軸方向に上下するよう調整した。こうすることで、リラックス状態の人体運動に多少似てくる
- モード遷移時に体がガクッて動くとイヤなのでモーションスケールをTweenしている