### PR TITLE
Fix/doc build error

### DIFF
--- a/docs/pages/english/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/english/docs/external_tracker_ifacialmocap.md
@@ -54,9 +54,7 @@ If your avatar looks wrong orientatoin or face motion does not start, execute `C
 {% include docimg.html file="./images/docs/ex_tracker_30_calibration_after.png" customclass="col l4 m6 s12" imgclass="fit-doc-img" %}
 </div>
 
-<div>
-<a id="troubleshoot"></a>
-</div>
+[]{: #troubleshoot}
 
 ### Troubleshooting
 

--- a/docs/pages/english/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/english/docs/external_tracker_ifacialmocap.md
@@ -54,8 +54,10 @@ If your avatar looks wrong orientatoin or face motion does not start, execute `C
 {% include docimg.html file="./images/docs/ex_tracker_30_calibration_after.png" customclass="col l4 m6 s12" imgclass="fit-doc-img" %}
 </div>
 
-
+<div>
 <a id="troubleshoot"></a>
+</div>
+
 ### Troubleshooting
 
 #### Q1. Failed to connect for the first setup

--- a/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
@@ -53,9 +53,7 @@ iOS端末のアプリ上に表示されたIPアドレスを入力し、`Connect`
 {% include docimg.html file="./images/docs/ex_tracker_30_calibration_after.png" customclass="col l4 m6 s12" imgclass="fit-doc-img" %}
 </div>
 
-<div>
-<a id="troubleshoot"></a>
-</div>
+[]{: #troubleshoot}
 
 ### トラブルシューティング
 

--- a/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
@@ -53,7 +53,10 @@ iOS端末のアプリ上に表示されたIPアドレスを入力し、`Connect`
 {% include docimg.html file="./images/docs/ex_tracker_30_calibration_after.png" customclass="col l4 m6 s12" imgclass="fit-doc-img" %}
 </div>
 
+<div>
 <a id="troubleshoot"></a>
+</div>
+
 ### トラブルシューティング
 
 #### Q1. はじめて接続操作を行ったが、キャラクターが反応しない


### PR DESCRIPTION
jekyllのビルドが失敗していた一因としてanchorのHTMLタグが何か怒られてそうだったため、kramdown寄りの記法に書き直してます