### PR TITLE
restore troubleshoot tag

### DIFF
--- a/docs/pages/english/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/english/docs/external_tracker_ifacialmocap.md
@@ -54,6 +54,8 @@ If your avatar looks wrong orientatoin or face motion does not start, execute `C
 {% include docimg.html file="./images/docs/ex_tracker_30_calibration_after.png" customclass="col l4 m6 s12" imgclass="fit-doc-img" %}
 </div>
 
+<a id="troubleshoot"></a>
+
 ### Troubleshooting
 
 #### Q1. Failed to connect for the first setup

--- a/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
+++ b/docs/pages/japanese/docs/external_tracker_ifacialmocap.md
@@ -53,6 +53,9 @@ iOS端末のアプリ上に表示されたIPアドレスを入力し、`Connect`
 {% include docimg.html file="./images/docs/ex_tracker_30_calibration_after.png" customclass="col l4 m6 s12" imgclass="fit-doc-img" %}
 </div>
 
+
+<a id="troubleshoot"></a>
+
 ### トラブルシューティング
 
 #### Q1. はじめて接続操作を行ったが、キャラクターが反応しない


### PR DESCRIPTION
iFacialMocap説明ページにて、トラブルシューティングタグがJekyllビルドエラーに関して冤罪を受けて消されてたのを復活します