### PR TITLE
マイクボリュームを可視化できるやつ

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
@@ -195,13 +195,12 @@ namespace Baku.VMagicMirror
             //ここ遅かったらヤダな～というポイント
             for (int i = 0; i < _processBuffer.Length; i++)
             {
-                //NOTE: clampはもしやるとしてもココでやっていいかが場合による。
-                //ゲイン計算の邪魔になる、という事に留意！
-                _processBuffer[i] *= _sensitivityFactor; //math.clamp(_processBuffer[i] * _sensitivityFactor, -1f, 1f);
+                //NOTE: clampしないでもOVRLipSyncは動くのでclampしないでいい
+                _processBuffer[i] *= _sensitivityFactor;
             }
         }
 
-        //バッファに載ってる音に対してゲイン(-44dB ~ +6dB)を0 ~ 50の数値に変換したものを計算してデータを更新する。
+        //バッファに載ってる音に対してゲインを0 ~ 50の数値に変換したものを計算してデータを更新する。
         private void UpdateVolumeLevelOnBuffer()
         {
             //NOTE: この方法はちょっと桁落ちとかのリスクあるんだけど、そんなにシビアな計算じゃないのでザツにやる
@@ -210,10 +209,9 @@ namespace Baku.VMagicMirror
             {
                 sum += _processBuffer[i] * _processBuffer[i];
             }
-
-            float mean = Mathf.Sqrt(sum / _processBuffer.Length);
-            float meanDb = Mathf.Log10(mean) * 10f;
             
+            float mean = sum / _processBuffer.Length;
+            float meanDb = Mathf.Log10(mean) * 10f;
             int rawResult = Mathf.Clamp((int)(meanDb - BottomVolumeDb), 0, 50);
             _currentVolumeLevel = Mathf.Max(rawResult, _currentVolumeLevel - LevelDecreasePerRefresh);
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Unity.Mathematics;
 using UnityEngine;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -11,9 +12,23 @@ namespace Baku.VMagicMirror
         private const int LengthSeconds = 1;
         //この回数だけマイク音声の読み取り位置が変化しない状態が継続した場合、自動でマイクの再起動を試みる
         private const int PositionStopCountLimit = 120;
+
+        //この値(dB)から+50dBまでの範囲を0 ~ 50のレベル情報として通知する。適正音量の目安になる値。
+        private const int BottomVolumeDb = -38;
+
+        //ボリューム情報は数フレームに1回送ればいいよね、という値
+        private const int SendVolumeLevelSkip = 2;
+        //ボリュームが急に下がった場合は実際の値ではなく、直前フレームからこのdB値だけ落とした値をWPFに通知する
+        private const int LevelDecreasePerRefresh = 1;
         
         private readonly float[] _processBuffer = new float[1024];
         private readonly float[] _microphoneBuffer = new float[LengthSeconds * SamplingFrequency];
+        
+        private IMessageSender _sender;
+        private bool _sendMicrophoneVolumeLevel = false;
+        private int _volumeLevelSendCount = 0;
+        //ボリューム値を記憶する。よくある「ガッと上がってスーッと下がる」をやるために必要。
+        private int _currentVolumeLevel = 0;
         
         private AudioClip _clip;
         private int _head = 0;
@@ -22,7 +37,8 @@ namespace Baku.VMagicMirror
         private int _positionNotMovedCount = 0;
 
         private int _sensitivity = 0;
-
+        
+        private float _sensitivityFactor = 1f;
         /// <summary> マイク感度を[dB]単位で取得、設定します。 </summary>
         public int Sensitivity
         {
@@ -38,10 +54,25 @@ namespace Baku.VMagicMirror
             }
         }
 
-        private float _sensitivityFactor = 1f;
-
         public bool IsRecording { get; private set; } = false;
         public string DeviceName { get; private set; } = "";
+
+        [Inject]
+        public void Initialize(IMessageReceiver receiver, IMessageSender sender)
+        {
+            receiver.AssignCommandHandler(
+                VmmCommands.SetMicrophoneVolumeVisibility,
+                message =>
+                {
+                    _sendMicrophoneVolumeLevel = bool.TryParse(message.Content, out var v) && v;
+                    if (!_sendMicrophoneVolumeLevel)
+                    {
+                        _volumeLevelSendCount = 0;
+                        _currentVolumeLevel = 0;
+                    }
+                });
+            _sender = sender;
+        }
         
         public void StartRecording(string deviceName)
         {
@@ -117,6 +148,16 @@ namespace Baku.VMagicMirror
                 }
 
                 ApplySensitivityToProcessBuffer();
+                if (_sendMicrophoneVolumeLevel)
+                {
+                    _volumeLevelSendCount++;
+                    if (_volumeLevelSendCount >= SendVolumeLevelSkip)
+                    {
+                        _volumeLevelSendCount = 0;
+                        UpdateVolumeLevelOnBuffer();
+                        _sender.SendCommand(MessageFactory.Instance.MicrophoneVolumeLevel(_currentVolumeLevel));
+                    }
+                }
                 OVRLipSync.ProcessFrame(Context, _processBuffer, Frame);
 
                 _head += _processBuffer.Length;
@@ -154,10 +195,28 @@ namespace Baku.VMagicMirror
             //ここ遅かったらヤダな～というポイント
             for (int i = 0; i < _processBuffer.Length; i++)
             {
-                _processBuffer[i] = math.clamp(_processBuffer[i] * _sensitivityFactor, -1f, 1f);
+                //NOTE: clampはもしやるとしてもココでやっていいかが場合による。
+                //ゲイン計算の邪魔になる、という事に留意！
+                _processBuffer[i] *= _sensitivityFactor; //math.clamp(_processBuffer[i] * _sensitivityFactor, -1f, 1f);
             }
         }
 
+        //バッファに載ってる音に対してゲイン(-44dB ~ +6dB)を0 ~ 50の数値に変換したものを計算してデータを更新する。
+        private void UpdateVolumeLevelOnBuffer()
+        {
+            //NOTE: この方法はちょっと桁落ちとかのリスクあるんだけど、そんなにシビアな計算じゃないのでザツにやる
+            float sum = 0;
+            for (int i = 0; i < _processBuffer.Length; i++)
+            {
+                sum += _processBuffer[i] * _processBuffer[i];
+            }
+
+            float mean = Mathf.Sqrt(sum / _processBuffer.Length);
+            float meanDb = Mathf.Log10(mean) * 10f;
+            
+            int rawResult = Mathf.Clamp((int)(meanDb - BottomVolumeDb), 0, 50);
+            _currentVolumeLevel = Mathf.Max(rawResult, _currentVolumeLevel - LevelDecreasePerRefresh);
+        }
 
         static int GetDataLength(int bufferLength, int head, int tail) 
             => (head < tail) 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
@@ -28,6 +28,8 @@ namespace Baku.VMagicMirror
 
         public Message SetBlendShapeNames(string v) => WithArg(v);
 
+        public Message MicrophoneVolumeLevel(int level) => WithArg($"{level}");
+        
         public Message AutoAdjustResults(AutoAdjustParameters parameters)
             => WithArg(JsonUtility.ToJson(parameters));
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -104,6 +104,7 @@ namespace Baku.VMagicMirror
         public const string EnableLipSync = nameof(EnableLipSync);
         public const string SetMicrophoneDeviceName = nameof(SetMicrophoneDeviceName);
         public const string SetMicrophoneSensitivity = nameof(SetMicrophoneSensitivity);
+        public const string SetMicrophoneVolumeVisibility = nameof(SetMicrophoneVolumeVisibility);
 
         // Motion, Eye
         public const string LookAtStyle = nameof(LookAtStyle);


### PR DESCRIPTION
fixed #423 

音量表示をオンにすると大まかなゲイン計算が走るようにした。厳格なゲインは別に必要ないので、リップシンクの動きを見て以下くらいの挙動にしてます。

- `10 * log10 (Mean Square)`でdB値を得る
- この値におうじてGUI側の表示がこうなる。
    - `-18dB`以下→静音
    - `-18dB ~ +2dB`→有効な音
    - `+2dB = +12dB`→でかすぎ

なお、音量表示は地味ながら負荷がある(IPCもあるし波形の計算も絡む)のでデフォルトでは値は表示されません。
