### PR TITLE
High Power Mode for webcam tracking

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
@@ -204,9 +204,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 361f1b0adb1a379449acbb4d0a28bcdd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  eyeOpenKeepDiffPer16ms: 0.02
+  eyeOpenKeepDiffPer16ms: 0.04
   eyeOpenFromCloseDiffPer16ms: 0.1
-  blinkJumpThreshold: 0.65
+  blinkJumpThreshold: 0.75
 --- !u!114 &2335327280039312852
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
@@ -204,11 +204,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 361f1b0adb1a379449acbb4d0a28bcdd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speedFactor: 18
-  speedDumpFactor: 0.95
-  blinkUpdateTimeScale: 0.1
-  closeThreshold: 0.7
-  blinkUpdateInterval: 0
+  eyeOpenKeepDiffPer16ms: 0.02
+  eyeOpenFromCloseDiffPer16ms: 0.1
+  blinkJumpThreshold: 0.65
 --- !u!114 &2335327280039312852
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
@@ -285,10 +285,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ccd5f299c1abbd4bb7387e98b79aefa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speedDumpForceFactor: {x: 16, y: 16, z: 16}
-  posDumpForceFactor: {x: 50, y: 60, z: 60}
-  headEulerAnglesFactor: {x: 1.3, y: 1.3, z: 1}
+  speedDump: {x: 16, y: 16, z: 16}
+  posDump: {x: 50, y: 60, z: 60}
+  headEulerAnglesFactor: {x: 1.1, y: 1.3, z: 1}
+  speedDumpHighPower: {x: 32, y: 32, z: 32}
+  posDumHighPower: {x: 180, y: 180, z: 180}
+  headEulerAnglesFactorHighPower: {x: 1.1, y: 1.3, z: 1}
   headRate: 0.5
+  facePartsPitchYawFactor: {x: 30, y: 30}
 --- !u!114 &1338865419136667663
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/ImageBasedBlinkController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/ImageBasedBlinkController.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using UniRx;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -13,62 +12,106 @@ namespace Baku.VMagicMirror
         public IBlinkSource BlinkSource => _blinkSource;
         
         [Inject] private FaceTracker _faceTracker = null;
-        
-        [Tooltip("ブレンドシェイプを変化させていく速度ファクター")]
-        [SerializeField]
-        private float speedFactor = 12f;
-        
-        [Tooltip("瞬き速度を減速させるダンピング")]
-        [SerializeField]
-        private float speedDumpFactor = 0.85f;
-        
-        [Tooltip("瞬きの基本的なアップデート時間間隔。短いほど追従性がよい")]
-        [SerializeField]
-        private float blinkUpdateTimeScale = 0.2f;
 
-        [Tooltip("この値以上のBlink値だったら目が完全に閉じているものと扱う")]
-        [SerializeField] private float closeThreshold = 0.8f;
-        
-        public float blinkUpdateInterval = 0.3f;
-        private float _count = 0;
+        [SerializeField] private float eyeOpenKeepDiffPer16ms = 0.04f;
+        [SerializeField] private float eyeOpenFromCloseDiffPer16ms = 0.1f;
+        [Tooltip("Blink値がこの値を下から上にまたいだ場合、直ちにまばたき状態にする")]
+        [SerializeField] private float blinkJumpThreshold = 0.35f;
 
-        //TODO: ここ以前にT5_4Vやったときと同じで、閉じ方向と開き方向の速度を変えると良いかも。
-        
-        //一定間隔で_latestな値をコピーしてきた、当面ターゲットとすべきまばたきブレンドシェイプの値
-        private float _leftBlinkTarget = 0f;
-        private float _rightBlinkTarget = 0f;
-        
-        //_current(Left|Right)Blinkをターゲット値に持って行くときの速度。PD制御チックに動かす為に使います
-        private float _leftBlinkSpeed = 0f;
-        private float _rightBlinkSpeed = 0f;
-
-        private float _latestFilteredLeft = 0f;
-        private float _latestFilteredRight = 0f;
+        private bool _isLeftEyeOpening = false;
+        private bool _isRightEyeOpening = false;
 
         private void Update()
         {
-            _count -= Time.deltaTime;
-            if (_count < 0)
+            //画像処理の精度が無限に良ければコレで済むが、そうもいかないのでフィルターとかをかませる
+            //_blinkSource.Left = _faceTracker.EyeOpen.LeftEyeBlink;
+            //_blinkSource.Right = _faceTracker.EyeOpen.RightEyeBlink;
+
+            //コンセプト:
+            // - 目開け付近(blink 0 ~ 0.3とか)で動くうちはそれに低速で追従
+            // - それ以上に遷移する場合、まばたき状態に倒してから調整する。
+            // つまり、基本的に半目状態は認めない。
+
+            //deltaTime == 16msの場合向けにパラメタが決まってるので、そこで抑えておけばOK。
+            //また_faceTracker.EyeOpenは最初から[0, 1]の範囲の値を返してるので、
+            //openDiffとかcloseDiffのせいで値が01を超えてもよい
+            float openKeepDiff = eyeOpenKeepDiffPer16ms * Time.deltaTime * 60f;
+            float openFromCloseDiff = eyeOpenFromCloseDiffPer16ms * Time.deltaTime * 60f;
+            
+            float left = _faceTracker.EyeOpen.LeftEyeBlink;
+
+            // 目の動きは3パターン考えると分かりやすい(書いてある通りだけど)
+            if (left > blinkJumpThreshold)
             {
-                _leftBlinkTarget = _faceTracker.EyeOpen.LeftEyeBlink;
-                _rightBlinkTarget =  _faceTracker.EyeOpen.RightEyeBlink;
-                _count = blinkUpdateInterval;                
+                //とりあえず値が一定以上 -> ただちに閉じる。
+                _blinkSource.Left = 1.0f;
+                _isLeftEyeOpening = false;
+            }
+            else if (_blinkSource.Left > blinkJumpThreshold)
+            {
+                // 目を閉じてたのを徐々に開く: 見た目分かりやすいのでMax側にも幅を作っているが、
+                // 条件的にmax側は実際には使われない
+                _blinkSource.Left = Mathf.Clamp(
+                    left, _blinkSource.Left - openFromCloseDiff, _blinkSource.Right + openFromCloseDiff
+                );
+                _isLeftEyeOpening = true;
+            }
+            else if (_isLeftEyeOpening)
+            {
+                // 閉じ目を開く動作の途中: 開く方向には高速で動かすことができる
+                float nextLeft = Mathf.Clamp(
+                    left, _blinkSource.Left - openFromCloseDiff, _blinkSource.Right + openKeepDiff
+                );
+
+                //最高速度で目を開く必要がなくなった = 目開き動作が終わったとみなし、より低速の動きに切り替える
+                if (nextLeft > _blinkSource.Left - openFromCloseDiff)
+                {
+                    _isLeftEyeOpening = false;
+                }
+                
+                _blinkSource.Left = nextLeft;
+            }
+            else
+            {
+                // 目が最初から開いてたのが引き続き開いている
+                _blinkSource.Left = Mathf.Clamp(
+                    left, _blinkSource.Left - openKeepDiff, _blinkSource.Left + openKeepDiff
+                );
             }
 
-            float leftSpeed = (_leftBlinkTarget - _latestFilteredLeft) / blinkUpdateTimeScale;
-            float rightSpeed = (_rightBlinkTarget - _latestFilteredRight) / blinkUpdateTimeScale;
+            float right = _faceTracker.EyeOpen.RightEyeBlink;
+            if (right > blinkJumpThreshold)
+            {
+                //とりあえず値が一定以上 -> ただちに閉じる。
+                _blinkSource.Right = 1.0f;
+            }
+            else if (_blinkSource.Right > blinkJumpThreshold)
+            {
+                // 目を閉じてたのを徐々に開く: 見た目分かりやすいのでMax側にも幅を作っているが、
+                // 条件的にmax側は実際には使われない
+                _blinkSource.Right = Mathf.Clamp(
+                    right, _blinkSource.Right - openFromCloseDiff, _blinkSource.Right + openFromCloseDiff
+                );
+            }
+            else if (_isRightEyeOpening)
+            {
+                float nextRight = Mathf.Clamp(
+                    right, _blinkSource.Right - openFromCloseDiff, _blinkSource.Right + openKeepDiff
+                );
 
-            _leftBlinkSpeed = Mathf.Lerp(_leftBlinkSpeed, leftSpeed, speedFactor * Time.deltaTime);
-            _rightBlinkSpeed = Mathf.Lerp(_rightBlinkSpeed, rightSpeed, speedFactor * Time.deltaTime);
-
-            _leftBlinkSpeed *= speedDumpFactor;
-            _rightBlinkSpeed *= speedDumpFactor;
-
-            _latestFilteredLeft += _leftBlinkSpeed * Time.deltaTime;
-            _latestFilteredRight += _rightBlinkSpeed * Time.deltaTime;
-
-            _blinkSource.Left = (_latestFilteredLeft > closeThreshold) ? 1.0f : _latestFilteredLeft;
-            _blinkSource.Right = (_latestFilteredRight > closeThreshold) ? 1.0f : _latestFilteredRight;
+                if (nextRight > _blinkSource.Right - openFromCloseDiff)
+                {
+                    _isRightEyeOpening = false;
+                }
+                
+                _blinkSource.Right = nextRight;
+            }
+            else
+            {
+                _blinkSource.Right = Mathf.Clamp(
+                    right, _blinkSource.Right - openKeepDiff, _blinkSource.Right + openKeepDiff
+                );
+            }
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/ImageBasedBlinkController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/ImageBasedBlinkController.cs
@@ -63,8 +63,8 @@ namespace Baku.VMagicMirror
                     left, _blinkSource.Left - openFromCloseDiff, _blinkSource.Right + openKeepDiff
                 );
 
-                //最高速度で目を開く必要がなくなった = 目開き動作が終わったとみなし、より低速の動きに切り替える
-                if (nextLeft > _blinkSource.Left - openFromCloseDiff)
+                //目が十分開いた or 目を閉じる方向に動いた = 目開き動作が終わったとみなし、より低速の動きに切り替える
+                if (nextLeft < 0.1f || nextLeft > _blinkSource.Left)
                 {
                     _isLeftEyeOpening = false;
                 }
@@ -99,7 +99,7 @@ namespace Baku.VMagicMirror
                     right, _blinkSource.Right - openFromCloseDiff, _blinkSource.Right + openKeepDiff
                 );
 
-                if (nextRight > _blinkSource.Right - openFromCloseDiff)
+                if (nextRight < 0.1f || nextRight > _blinkSource.Right)
                 {
                     _isRightEyeOpening = false;
                 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FaceAttitudeController.cs
@@ -81,7 +81,9 @@ namespace Baku.VMagicMirror
             }
 
             var target = Mul(
-                _faceRotToEuler.GetTargetEulerAngle(facePartsPitchYawFactor, _faceTracker.CalibrationData.eyeFaceYDiff),
+                _faceRotToEuler.GetTargetEulerAngle(
+                    facePartsPitchYawFactor, _faceTracker.CalibrationData.pitchRateOffset
+                    ),
                 headEulerAnglesFactor
                 );
 
@@ -215,13 +217,13 @@ namespace Baku.VMagicMirror
         public Vector3 GetTargetEulerAngle(Vector2 pitchYawFactor, float pitchRateBaseline)
         {
             float pitchRate = Mathf.Clamp(
-                _faceParts.Outline.CurrentFacePitchRate - pitchRateBaseline, -1, 1
+                _faceParts.FacePitchRate - pitchRateBaseline, -1, 1
                 );
 
             return new Vector3(
                 pitchRate * pitchYawFactor.x,
-                _faceParts.Outline.CurrentFaceYawRate * pitchYawFactor.y,
-                _faceParts.Outline.CurrentFaceRollRad * Mathf.Rad2Deg
+                _faceParts.FaceYawRate * pitchYawFactor.y,
+                _faceParts.FaceRollRad * Mathf.Rad2Deg
                 );
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationData.cs
@@ -6,6 +6,10 @@ namespace Baku.VMagicMirror
     [Serializable]
     public class CalibrationData
     {
+        public float eyeBrowPosition;
+        public float eyeOpenHeight;
+        public float eyeFaceYDiff;
+            
         //NOTE: イメージ的には「ユーザー正面向き時のカメラから見たユーザーの位置」っぽいものが入る…はず
         public bool hasOpenCvPose;
         public Vector3 openCvFacePos;
@@ -16,6 +20,10 @@ namespace Baku.VMagicMirror
 
         public void SetDefaultValues()
         {
+            eyeBrowPosition = 1.43f;
+            eyeOpenHeight = 0.06f;
+            eyeFaceYDiff = 0.0f;
+            
             hasOpenCvPose = false;
             openCvFacePos = Vector3.zero;
             openCvFaceRotEuler = Vector3.zero;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/CalibrationData.cs
@@ -6,9 +6,7 @@ namespace Baku.VMagicMirror
     [Serializable]
     public class CalibrationData
     {
-        public float eyeBrowPosition;
-        public float eyeOpenHeight;
-        public float eyeFaceYDiff;
+        public float pitchRateOffset;
             
         //NOTE: イメージ的には「ユーザー正面向き時のカメラから見たユーザーの位置」っぽいものが入る…はず
         public bool hasOpenCvPose;
@@ -20,9 +18,7 @@ namespace Baku.VMagicMirror
 
         public void SetDefaultValues()
         {
-            eyeBrowPosition = 1.43f;
-            eyeOpenHeight = 0.06f;
-            eyeFaceYDiff = 0.0f;
+            pitchRateOffset = 0f;
             
             hasOpenCvPose = false;
             openCvFacePos = Vector3.zero;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 
 namespace Baku.VMagicMirror
 {
-    //NOTE: いったん簡単な実装で載せたいので、番号付けをいい加減にして統計情報チックな扱いに留める。
-
     /// <summary>
-    /// 68点ランドマークの顔情報をもとに顔の個別パーツの情報を更新するクラス
+    /// 17点ランドマークの顔情報をもとに目の開閉と顔の向きを推定するクラス。
+    /// いわゆるPnP(Perspective n-Point)をやらず、カンタンな計算で済ませる事を狙っている
     /// </summary>
     public class FaceParts
     {
@@ -15,46 +13,11 @@ namespace Baku.VMagicMirror
         //値が大きいほど、ヨー角が小さくなる。
         private const float YawMouthDistanceRatio = 1.0f;        
         //EyeFaceYDiffがとる値の限界値の目安。この値で割って正規化する
-        private const float EyeFaceYDiffMax = 0.12f;
+        private const float EyeFaceYDiffMax = 0.3f;
 
-        
-        public const int FaceLandmarkCount = 17;
+        private const int FaceLandmarkCount = 17;
 
         private readonly Vector2[] _landmarks = new Vector2[FaceLandmarkCount];
-
-        // public FaceParts()
-        // {
-        //     Outline = new FaceOutlinePart(this);
-        //
-        //     Nose = new NosePart(this);
-        //
-        //     RightEye = new RightEyePart(this, Nose);
-        //     LeftEye = new LeftEyePart(this, Nose);
-        //
-        //     Mouth = new MouthPart(this);
-        //
-        //     PartsWithoutOutline = new FacePartBase[]
-        //     {
-        //         Nose,
-        //         RightEye,
-        //         LeftEye,
-        //         Mouth,
-        //     };
-        // }
-        
-        // public Vector2 FaceSize { get; private set; } = Vector2.one;
-
-        // public FaceOutlinePart Outline { get; }
-        //
-        // public NosePart Nose { get; }
-        //
-        // public RightEyePart RightEye { get; }
-        // public LeftEyePart LeftEye { get; }
-        //
-        // public MouthPart Mouth { get; }
-        //
-        // //輪郭は顔サイズと傾き除去のために特別扱いしたいので外す
-        // private FacePartBase[] PartsWithoutOutline { get; }
 
         /// <summary> FaceRollRadの符号に影響する。 </summary>
         public bool DisableHorizontalFlip { get; set; }
@@ -63,7 +26,7 @@ namespace Baku.VMagicMirror
 
         public float FacePitchRate { get; private set; }
         public float FaceYawRate => DisableHorizontalFlip ? -_faceYawRate : _faceYawRate;
-        public float FaceRollRad => DisableHorizontalFlip ? _faceRollRad : _faceRollRad;
+        public float FaceRollRad => DisableHorizontalFlip ? -_faceRollRad : _faceRollRad;
 
         public float LeftEyeBlink => DisableHorizontalFlip ? _leftEyeBlink : _rightEyeBlink;
         public float RightEyeBlink => DisableHorizontalFlip ? _rightEyeBlink : _leftEyeBlink;
@@ -136,15 +99,18 @@ namespace Baku.VMagicMirror
             //輪郭の端、つまり両こめかみ付近に線を引いてみたときの傾きをとっている。
             //以前はアゴ先の位置も考慮していたが、それだとヨー運動と合成されてしまうため、使わないようにした。
             Vector2 diffVecSum = _landmarks[8] - _landmarks[6];
-            //TODO: 逆だったら直してね
-            _faceRollRad = Mathf.Atan2(diffVecSum.y, diffVecSum.x);
+            _faceRollRad = -Mathf.Atan2(diffVecSum.y, diffVecSum.x);
+            
+            //NOTE: ↑がマイナス入れてる関係で↓の符号もちょっと怪しい？
+            _faceRollCos = Mathf.Cos(_faceRollRad);
+            _faceRollSin = Mathf.Sin(_faceRollRad);
         }
 
         private void UpdateYaw()
         {
             var mouthCenter = (_landmarks[13] + _landmarks[14] + _landmarks[15] + _landmarks[16]) * 0.25f;
-            float diffLeft = Vector2.Distance(mouthCenter, _landmarks[8]);
-            float diffRight = Vector2.Distance(mouthCenter, _landmarks[6]);
+            float diffLeft = Vector2.Distance(mouthCenter, _landmarks[6]);
+            float diffRight = Vector2.Distance(mouthCenter, _landmarks[8]);
             //ピクセル単位のハズなので1以下ならどちらかの点に被っている(※通常は起きない)
             //通常ケースでは(遠いほうの距離 / 近いほうの距離)の比率をうまく畳んで[-1, 1]の範囲に収めようとしている
             _faceYawRate =
@@ -180,296 +146,5 @@ namespace Baku.VMagicMirror
                 p.x * sin + p.y * cos
                 );
         }        
-        
-        // /// <summary>
-        // /// 値を更新していく。
-        // /// blendRateが0-0.99くらいの値のときは顔トラが始まって間もないのでキャリブ
-        // /// </summary>
-        // /// <param name="mainPersonRect"></param>
-        // /// <param name="landmarks"></param>
-        // public void Update(Rect mainPersonRect, List<Vector2> landmarks)
-        // {
-        //     if (landmarks == null || landmarks.Count < FaceLandmarkCount)
-        //     {
-        //         return;
-        //     }
-        //
-        //     //顔の中心でオフセット取る : たぶん回転の除去とかで都合がよいのでこのスタイルで行きます
-        //     var offset = mainPersonRect.center;
-        //     for(int i = 0; i < _landmarks.Length; i++)
-        //     {
-        //         _landmarks[i] = landmarks[i] - offset;
-        //     }
-        //
-        //     Outline.Update(_landmarks);
-        //     FaceSize = Outline.FaceSize;
-        //     for (int i = 0; i < PartsWithoutOutline.Length; i++)
-        //     {
-        //         PartsWithoutOutline[i].Update(_landmarks);
-        //     }
-        //     Outline.UpdateYaw(Mouth.CurrentCenterPosition);
-        //     Outline.UpdatePitch(LeftEye.GetCenter(), RightEye.GetCenter());
-        // }
-        //
-        // /// <summary>
-        // /// それぞれの顔パーツ情報を初期状態に戻します。
-        // /// </summary>
-        // /// <param name="calibration"></param>
-        // /// <param name="lerpFactor">0-1の範囲で指定される、基準位置に戻すのに使うLerpファクタ</param>
-        // public void LerpToDefault(CalibrationData calibration, float lerpFactor)
-        // {
-        //     Outline.LerpToDefault(calibration, lerpFactor);
-        //     for (int i = 0; i < PartsWithoutOutline.Length; i++)
-        //     {
-        //         PartsWithoutOutline[i].LerpToDefault(calibration, lerpFactor);
-        //     }
-        // }
-        
-        // //todo: 内部実装をSpanでやった方がカッコ良さそう…
-        // public abstract class FacePartBase
-        // {
-        //     protected FacePartBase(FaceParts parent)
-        //     {
-        //         //_positions = new Vector2[LandmarkLength];
-        //         Parent = parent;
-        //     }
-        //
-        //     public FaceParts Parent { get; }
-        //
-        //     /// <summary>
-        //     /// WARN: GCAllocをラクに避けるためにこう書いてるが派生クラスでの書き込みはダメ！
-        //     /// </summary>
-        //     //public Vector2[] Positions => _positions;
-        //
-        //     public abstract void Update(Vector2[] rects);
-        //
-        //     //NOTE: 要らなくなる、はず。
-        //     protected Vector2 GetRollCanceled(Vector2 p)
-        //     {
-        //         //sinにマイナスがつくのは、キャンセル回転のためにもとの角度を(-1)倍した値のsin,cosをセットで得るため
-        //         float cos = Parent.Outline.CurrentFaceRollCos;
-        //         float sin = -Parent.Outline.CurrentFaceRollSin;
-        //         return new Vector2(
-        //             p.x * cos - p.y * sin,
-        //             p.x * sin + p.y * cos
-        //             );
-        //     }
-        //
-        //     /// <summary> パーツの値を基準値まで戻す。このとき、必要ならばキャリブデータを参照してもよい。 </summary>
-        //     public abstract void LerpToDefault(CalibrationData calibration, float lerpFactor);
-        //
-        // }
-        //
-        // public class FaceOutlinePart : FacePartBase
-        // {
-        //     //顔のヨー角を輪郭と口の中心のキョリの非で求める際に用いる比率。
-        //     //値が大きいほど、ヨー角が小さくなる。
-        //     private const float YawMouthDistanceRatio = 3.0f;
-        //
-        //     //EyeFaceYDiffがとる値の限界値の目安。この値で割って正規化する
-        //     private const float EyeFaceYDiffMax = 0.12f;
-        //
-        //     public FaceOutlinePart(FaceParts parent) : base(parent)
-        //     {
-        //     }
-        //
-        //     public Vector2 FaceSize { get; private set; } = Vector2.one;
-        //     
-        //     public float EyeFaceYDiff { get; private set; }
-        //     
-        //
-        //     public float CurrentFaceRollRad { get; private set; }
-        //     //NOTE: sin, cosは回転計算で何度も欲しいのでキャッシュしとく
-        //     public float CurrentFaceRollSin { get; private set; }
-        //     public float CurrentFaceRollCos { get; private set; }
-        //
-        //     /// <summary>
-        //     /// 左右どちらを向いているかを[-1(左), 1(右)]の範囲で表すレート。
-        //     /// </summary>
-        //     /// <remarks>
-        //     /// 計算上レートと角度は比例しないが、近似として比例扱いにしても良い。
-        //     /// </remarks>
-        //     public float CurrentFaceYawRate { get; private set; }
-        //
-        //     /// <summary>
-        //     /// 上下どちらを向いてるかを[-1(下), 1(上)]前後の範囲で表すレート。
-        //     /// このレイヤーでは上が正のほうが直感的だけど、ピッチ角にする時点で符号の反転が必要なことに注意
-        //     /// </summary>
-        //     public float CurrentFacePitchRate => EyeFaceYDiff;
-        //
-        //     protected override void OnUpdated()
-        //     {
-        //         var positions = Positions;
-        //
-        //         //輪郭の端、つまり両こめかみ付近に線を引いてみたときの傾きをとっている。
-        //         //以前はアゴ先の位置も考慮していたが、それだとヨー運動と合成されてしまうため、使わないようにした。
-        //         Vector2 diffVecSum = positions[16] - positions[0];
-        //         
-        //         float faceRollRad = Mathf.Atan2(diffVecSum.y, diffVecSum.x);
-        //         
-        //         //Radは外部で使う値なので左右反転の設定に基づいてひっくり返し、Sin/Cosは内部計算用なのでそのままにする
-        //         CurrentFaceRollSin = Mathf.Sin(faceRollRad);
-        //         CurrentFaceRollCos = Mathf.Cos(faceRollRad);
-        //         CurrentFaceRollRad = Parent.DisableHorizontalFlip ? -faceRollRad : faceRollRad;
-        //         
-        //         //外形の3点だけで顔の矩形計算には足りる(しかもその方が回転不変で良い)
-        //         FaceSize = new Vector2(
-        //             Vector2.Distance(positions[0], positions[16]),
-        //             Vector2.Distance(0.5f * (positions[16] + positions[0]), positions[8])
-        //             );
-        //     }
-        //
-        //     public void UpdateYaw(Vector2 mouthCenter)
-        //     {
-        //         float diffLeft = Vector2.Distance(mouthCenter, Positions[4]);
-        //         float diffRight = Vector2.Distance(mouthCenter, Positions[12]);
-        //
-        //         //ピクセル単位のハズなので1以下ならどちらかの点に被っている(※通常は起きない)
-        //         //通常ケースでは(遠いほうの距離 / 近いほうの距離)の比率をうまく畳んで[-1, 1]の範囲に収めようとしている
-        //
-        //         float yawRate =
-        //             (diffLeft < 1f) ? -1f :
-        //             (diffRight < 1f) ? 1f :
-        //             (diffLeft < diffRight) ? 
-        //                 -Mathf.Clamp(diffRight / diffLeft - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio :
-        //                 Mathf.Clamp(diffLeft / diffRight - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio;
-        //         
-        //         CurrentFaceYawRate = Parent.DisableHorizontalFlip ? -yawRate : yawRate;
-        //     }
-        //
-        //     public void UpdatePitch(Vector2 leftEyeCenter, Vector2 rightEyeCenter)
-        //     {
-        //         //顔のY平均と、目のY平均の上下関係から推定する。
-        //         //目のほうが上にある場合は上をむいており、逆もしかり。
-        //         var faceY = 0.5f * GetRollCanceled(Positions[0] + Positions[16]).y;
-        //         var eyesY = 0.5f * GetRollCanceled(leftEyeCenter + rightEyeCenter).y;
-        //         
-        //         //POINT: FaceSize.yではなくxによって正規化する。
-        //         //Yは口の開閉とか、鎖骨付近を誤検出したときにブレちゃうので、
-        //         //そうした外れ値を安全に避けるのが狙い。
-        //         EyeFaceYDiff = (eyesY - faceY) / FaceSize.x / EyeFaceYDiffMax;
-        //     }
-        //
-        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-        //     {
-        //         CurrentFaceRollRad = Mathf.Lerp(CurrentFaceRollRad, 0, lerpFactor);
-        //         CurrentFaceRollSin = Mathf.Sin(CurrentFaceRollSin);
-        //         CurrentFaceRollCos = Mathf.Cos(CurrentFaceRollCos);
-        //         CurrentFaceYawRate = Mathf.Lerp(CurrentFaceYawRate, 0, lerpFactor);
-        //         EyeFaceYDiff = Mathf.Lerp(EyeFaceYDiff, calibration.eyeFaceYDiff, lerpFactor);
-        //         
-        //         float faceLen = Mathf.Sqrt(calibration.faceSize);
-        //         FaceSize = Vector2.Lerp(FaceSize, new Vector2(faceLen, faceLen), lerpFactor);
-        //     }
-        //     
-        //     public override int LandmarkStartIndex => 0;
-        //     public override int LandmarkLength => 17;
-        // }
-        //
-        // public class NosePart : FacePartBase
-        // {
-        //     public NosePart(FaceParts parent) : base(parent)
-        //     {
-        //     }
-        //
-        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-        //     {
-        //         //何もしないでOK
-        //     }
-        //
-        //     public override int LandmarkStartIndex => 0;
-        //     public override int LandmarkLength => 2;
-        //
-        //     public Vector2 NoseBasePoint => Positions[1];
-        // }
-        //
-        // public abstract class EyePartBase : FacePartBase
-        // {
-        //     public EyePartBase(FaceParts parent, NosePart nose) : base(parent)
-        //     {
-        //         _nose = nose;
-        //         //デフォルトは開いた状態
-        //         CurrentEyeOpenValue = 1.0f;
-        //     }
-        //
-        //     protected readonly NosePart _nose;
-        //
-        //     //TODO: ここにFaceTrackerToEyeOpenの実装があると筋がいいのかも
-        //     public float GetEyeOpenValue()
-        //     {
-        //         var positions = Positions;
-        //         float yMax = positions[0].y;
-        //         float yMin = positions[0].y;
-        //         for (int i = 1; i < positions.Length; i++)
-        //         {
-        //             if (yMax < positions[i].y)
-        //             {
-        //                 yMax = positions[i].y;
-        //             }
-        //             if (yMin > positions[i].y)
-        //             {
-        //                 yMin = positions[i].y;
-        //             }
-        //         }
-        //
-        //         float rawValue = yMax - yMin;
-        //         float normalizedValue = rawValue / Parent.FaceSize.y;
-        //         CurrentEyeOpenValue = normalizedValue;
-        //
-        //         return normalizedValue;
-        //     }
-        //
-        //     public Vector2 GetCenter() => GetCenterPosition();
-        //     
-        //     protected override void OnUpdated()
-        //     {
-        //         base.OnUpdated();
-        //         CurrentEyeOpenValue = GetEyeOpenValue();
-        //     }
-        //
-        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-        //     {
-        //         CurrentEyeOpenValue = Mathf.Lerp(CurrentEyeOpenValue, calibration.eyeOpenHeight, lerpFactor);
-        //     }
-        //
-        //     public float CurrentEyeOpenValue { get; private set; }
-        // }
-        //
-        // public class RightEyePart : EyePartBase
-        // {
-        //     public RightEyePart(FaceParts parent, NosePart nose) : base(parent, nose) { }
-        //     public override int LandmarkStartIndex => 36;
-        //     public override int LandmarkLength => 6;
-        // }
-        //
-        // public class LeftEyePart : EyePartBase
-        // {
-        //     public LeftEyePart(FaceParts parent, NosePart nose) : base(parent, nose) { }
-        //     public override int LandmarkStartIndex => 42;
-        //     public override int LandmarkLength => 6;
-        // }
-        //
-        // public class MouthPart : FacePartBase
-        // {
-        //     public MouthPart(FaceParts parent) : base(parent) { }
-        //
-        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-        //     {
-        //         //何もしない: そもそもプロパティとして外に出してない
-        //     }
-        //
-        //     public Vector2 CurrentCenterPosition { get; private set; }
-        //
-        //     public override int LandmarkStartIndex => 13;
-        //     public override int LandmarkLength => 4;
-        //     
-        //     protected override void OnUpdated()
-        //     {
-        //         base.OnUpdated();
-        //         CurrentCenterPosition = GetCenterPosition();
-        //     }
-        //     
-        // }
     }
-
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs
@@ -1,0 +1,463 @@
+﻿using System;
+using System.Collections.Generic;
+using UniRx;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    //NOTE: いったん簡単な実装で載せたいので、番号付けをいい加減にして統計情報チックな扱いに留める。
+
+    /// <summary>
+    /// 68点ランドマークの顔情報をもとに顔の個別パーツの情報を更新するクラス
+    /// </summary>
+    public class FaceParts
+    {
+        public const int FaceLandmarkCount = 68;
+
+        private readonly Vector2[] _landmarks = new Vector2[FaceLandmarkCount];
+
+        public FaceParts()
+        {
+            Outline = new FaceOutlinePart(this);
+
+            RightEyebrow = new RightEyebrowPart(this);
+            LeftEyebrow = new LeftEyebrowPart(this);
+
+            Nose = new NosePart(this);
+
+            RightEye = new RightEyePart(this);
+            LeftEye = new LeftEyePart(this);
+
+            InnerMouth = new InnerMouthPart(this);
+            OuterMouth = new OuterMouthPart(this);
+
+            PartsWithoutOutline = new FacePartBase[]
+            {
+                RightEyebrow,
+                LeftEyebrow,
+                Nose,
+                RightEye,
+                LeftEye,
+                InnerMouth,
+                OuterMouth,
+            };
+        }
+
+        public Vector2 FaceSize { get; private set; } = Vector2.one;
+
+        public FaceOutlinePart Outline { get; }
+
+        public RightEyebrowPart RightEyebrow { get; }
+        public LeftEyebrowPart LeftEyebrow { get; }
+
+        public NosePart Nose { get; }
+
+        public RightEyePart RightEye { get; }
+        public LeftEyePart LeftEye { get; }
+
+        public InnerMouthPart InnerMouth { get; }
+        public OuterMouthPart OuterMouth { get; }
+
+        //輪郭は顔サイズと傾き除去のために特別扱いしたいので外す
+        private FacePartBase[] PartsWithoutOutline { get; }
+
+        public bool DisableHorizontalFlip { get; set; }
+
+        /// <summary>
+        /// 値を更新していく。
+        /// blendRateが0-0.99くらいの値のときは顔トラが始まって間もないのでキャリブ
+        /// </summary>
+        /// <param name="mainPersonRect"></param>
+        /// <param name="landmarks"></param>
+        public void Update(Rect mainPersonRect, List<Vector2> landmarks)
+        {
+            if (landmarks == null || landmarks.Count < FaceLandmarkCount)
+            {
+                return;
+            }
+
+            //顔の中心でオフセット取る : たぶん回転の除去とかで都合がよいのでこのスタイルで行きます
+            var offset = mainPersonRect.center;
+            for(int i = 0; i < _landmarks.Length; i++)
+            {
+                _landmarks[i] = landmarks[i] - offset;
+            }
+
+            Outline.Update(_landmarks);
+            FaceSize = Outline.FaceSize;
+            for (int i = 0; i < PartsWithoutOutline.Length; i++)
+            {
+                PartsWithoutOutline[i].Update(_landmarks);
+            }
+            Outline.UpdateYaw(InnerMouth.CurrentCenterPosition);
+            Outline.UpdatePitch(LeftEye.GetCenter(), RightEye.GetCenter());
+        }
+
+        /// <summary>
+        /// それぞれの顔パーツ情報を初期状態に戻します。
+        /// </summary>
+        /// <param name="calibration"></param>
+        /// <param name="lerpFactor">0-1の範囲で指定される、基準位置に戻すのに使うLerpファクタ</param>
+        public void LerpToDefault(CalibrationData calibration, float lerpFactor)
+        {
+            Outline.LerpToDefault(calibration, lerpFactor);
+            for (int i = 0; i < PartsWithoutOutline.Length; i++)
+            {
+                PartsWithoutOutline[i].LerpToDefault(calibration, lerpFactor);
+            }
+        }
+        
+        //todo: 内部実装をSpanでやった方がカッコ良さそう…
+        public abstract class FacePartBase
+        {
+            protected FacePartBase(FaceParts parent)
+            {
+                _positions = new Vector2[LandmarkLength];
+                Parent = parent;
+            }
+            private readonly Vector2[] _positions;
+
+            public FaceParts Parent { get; }
+
+            /// <summary>
+            /// WARN: GCAllocをラクに避けるためにこう書いてるが派生クラスでの書き込みはダメ！
+            /// </summary>
+            public Vector2[] Positions => _positions;
+            
+            public void Update(Vector2[] rects)
+            {
+                //ややチェックが雑だが本ファイルの範囲でしか使わないから大丈夫なはず
+                Array.Copy(rects, LandmarkStartIndex, _positions, 0, LandmarkLength);
+                OnUpdated();
+            }
+
+            protected void CancelRollRotation()
+            {
+                //sinにマイナスがつくのは、キャンセル回転のためにもとの角度を(-1)倍した値のsin,cosをセットで得るため
+                float cos = Parent.Outline.CurrentFaceRollCos;
+                float sin = -Parent.Outline.CurrentFaceRollSin;
+                for(int i = 0; i < _positions.Length; i++)
+                {
+                    var p = _positions[i];
+                    _positions[i] = new Vector2(
+                        p.x * cos - p.y * sin,
+                        p.x * sin + p.y * cos
+                        );
+                }
+            }
+
+            protected Vector2 GetRollCanceled(Vector2 p)
+            {
+                //sinにマイナスがつくのは、キャンセル回転のためにもとの角度を(-1)倍した値のsin,cosをセットで得るため
+                float cos = Parent.Outline.CurrentFaceRollCos;
+                float sin = -Parent.Outline.CurrentFaceRollSin;
+                return new Vector2(
+                    p.x * cos - p.y * sin,
+                    p.x * sin + p.y * cos
+                    );
+            }
+
+            /// <summary>この顔パーツが属している特徴点の図心を計算する。</summary>
+            /// <returns></returns>
+            protected Vector2 GetCenterPosition()
+            {
+                //NOTE: LINQ使ってないのはパフォーマンス配慮
+                var sum = new Vector2();
+                var pos = Positions;
+                for (int i = 0; i < pos.Length; i++)
+                {
+                    sum += pos[i];
+                }
+                return sum / pos.Length;
+            }
+
+            /// <summary> パーツの値を基準値まで戻す。このとき、必要ならばキャリブデータを参照してもよい。 </summary>
+            public abstract void LerpToDefault(CalibrationData calibration, float lerpFactor);
+
+            protected virtual void OnUpdated() { }
+
+            public virtual bool HasValidData => _positions.Length > 0;
+
+            public abstract int LandmarkStartIndex { get; }
+            public abstract int LandmarkLength { get; }
+        }
+
+        public class FaceOutlinePart : FacePartBase
+        {
+            //顔のヨー角を輪郭と口の中心のキョリの非で求める際に用いる比率。
+            //値が大きいほど、ヨー角が小さくなる。
+            private const float YawMouthDistanceRatio = 3.0f;
+
+            //EyeFaceYDiffがとる値の限界値の目安。この値で割って正規化する
+            private const float EyeFaceYDiffMax = 0.12f;
+
+            public FaceOutlinePart(FaceParts parent) : base(parent)
+            {
+            }
+
+            public Vector2 FaceSize { get; private set; } = Vector2.one;
+            
+            public float EyeFaceYDiff { get; private set; }
+            
+
+            public float CurrentFaceRollRad { get; private set; }
+            //NOTE: sin, cosは回転計算で何度も欲しいのでキャッシュしとく
+            public float CurrentFaceRollSin { get; private set; }
+            public float CurrentFaceRollCos { get; private set; }
+
+            /// <summary>
+            /// 左右どちらを向いているかを[-1(左), 1(右)]の範囲で表すレート。
+            /// </summary>
+            /// <remarks>
+            /// 計算上レートと角度は比例しないが、近似として比例扱いにしても良い。
+            /// </remarks>
+            public float CurrentFaceYawRate { get; private set; }
+
+            /// <summary>
+            /// 上下どちらを向いてるかを[-1(下), 1(上)]前後の範囲で表すレート。
+            /// このレイヤーでは上が正のほうが直感的だけど、ピッチ角にする時点で符号の反転が必要なことに注意
+            /// </summary>
+            public float CurrentFacePitchRate => EyeFaceYDiff;
+
+            protected override void OnUpdated()
+            {
+                var positions = Positions;
+
+                //輪郭の端、つまり両こめかみ付近に線を引いてみたときの傾きをとっている。
+                //以前はアゴ先の位置も考慮していたが、それだとヨー運動と合成されてしまうため、使わないようにした。
+                Vector2 diffVecSum = positions[16] - positions[0];
+                
+                float faceRollRad = Mathf.Atan2(diffVecSum.y, diffVecSum.x);
+                
+                //Radは外部で使う値なので左右反転の設定に基づいてひっくり返し、Sin/Cosは内部計算用なのでそのままにする
+                CurrentFaceRollSin = Mathf.Sin(faceRollRad);
+                CurrentFaceRollCos = Mathf.Cos(faceRollRad);
+                CurrentFaceRollRad = Parent.DisableHorizontalFlip ? -faceRollRad : faceRollRad;
+                
+                //外形の3点だけで顔の矩形計算には足りる(しかもその方が回転不変で良い)
+                FaceSize = new Vector2(
+                    Vector2.Distance(positions[0], positions[16]),
+                    Vector2.Distance(0.5f * (positions[16] + positions[0]), positions[8])
+                    );
+            }
+
+            public void UpdateYaw(Vector2 mouthCenter)
+            {
+                float diffLeft = Vector2.Distance(mouthCenter, Positions[4]);
+                float diffRight = Vector2.Distance(mouthCenter, Positions[12]);
+
+                //ピクセル単位のハズなので1以下ならどちらかの点に被っている(※通常は起きない)
+                //通常ケースでは(遠いほうの距離 / 近いほうの距離)の比率をうまく畳んで[-1, 1]の範囲に収めようとしている
+
+                float yawRate =
+                    (diffLeft < 1f) ? -1f :
+                    (diffRight < 1f) ? 1f :
+                    (diffLeft < diffRight) ? 
+                        -Mathf.Clamp(diffRight / diffLeft - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio :
+                        Mathf.Clamp(diffLeft / diffRight - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio;
+                
+                CurrentFaceYawRate = Parent.DisableHorizontalFlip ? -yawRate : yawRate;
+            }
+
+            public void UpdatePitch(Vector2 leftEyeCenter, Vector2 rightEyeCenter)
+            {
+                //顔のY平均と、目のY平均の上下関係から推定する。
+                //目のほうが上にある場合は上をむいており、逆もしかり。
+                var faceY = 0.5f * GetRollCanceled(Positions[0] + Positions[16]).y;
+                var eyesY = 0.5f * GetRollCanceled(leftEyeCenter + rightEyeCenter).y;
+                
+                //POINT: FaceSize.yではなくxによって正規化する。
+                //Yは口の開閉とか、鎖骨付近を誤検出したときにブレちゃうので、
+                //そうした外れ値を安全に避けるのが狙い。
+                EyeFaceYDiff = (eyesY - faceY) / FaceSize.x / EyeFaceYDiffMax;
+            }
+
+            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+            {
+                CurrentFaceRollRad = Mathf.Lerp(CurrentFaceRollRad, 0, lerpFactor);
+                CurrentFaceRollSin = Mathf.Sin(CurrentFaceRollSin);
+                CurrentFaceRollCos = Mathf.Cos(CurrentFaceRollCos);
+                CurrentFaceYawRate = Mathf.Lerp(CurrentFaceYawRate, 0, lerpFactor);
+                EyeFaceYDiff = Mathf.Lerp(EyeFaceYDiff, calibration.eyeFaceYDiff, lerpFactor);
+                
+                float faceLen = Mathf.Sqrt(calibration.faceSize);
+                FaceSize = Vector2.Lerp(FaceSize, new Vector2(faceLen, faceLen), lerpFactor);
+            }
+            
+            public override int LandmarkStartIndex => 0;
+            public override int LandmarkLength => 17;
+        }
+
+        public abstract class EyebrowPartBase : FacePartBase
+        {
+            public EyebrowPartBase(FaceParts parent) : base(parent)
+            {
+            }
+
+            protected override void OnUpdated()
+            {
+                CancelRollRotation();
+
+                var positions = Positions;
+                float ySum = 0;
+                for (int i = 0; i < positions.Length; i++)
+                {
+                    ySum += positions[i].y;
+                }
+
+                float height = ySum / positions.Length;
+                float normalizedHeight = (Parent.FaceSize.y - height) / Parent.FaceSize.y;
+                CurrentHeight = normalizedHeight;
+                _height.OnNext(normalizedHeight);
+            }
+
+            //NOTE: キャリブ情報には両眉の平均値が載っているので、リセット時は平均値を両方に当て込めばOK
+            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+            {
+                CurrentHeight = Mathf.Lerp(CurrentHeight, calibration.eyeBrowPosition, lerpFactor);
+                _height.OnNext(CurrentHeight);
+            }
+
+            public float CurrentHeight { get; private set; }
+
+            protected Subject<float> _height = new Subject<float>();
+            public IObservable<float> Height => _height;
+        }
+
+        public class RightEyebrowPart : EyebrowPartBase
+        {
+            public RightEyebrowPart(FaceParts parent) : base(parent)
+            {
+            }
+
+            public override int LandmarkStartIndex => 17;
+            public override int LandmarkLength => 5;
+        }
+
+        public class LeftEyebrowPart : EyebrowPartBase
+        {
+            public LeftEyebrowPart(FaceParts parent) : base(parent)
+            {
+            }
+            public override int LandmarkStartIndex => 22;
+            public override int LandmarkLength => 5;
+        }
+
+        public class NosePart : FacePartBase
+        {
+            public NosePart(FaceParts parent) : base(parent)
+            {
+            }
+
+            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+            {
+                //何もしないでOK
+            }
+
+            public override int LandmarkStartIndex => 27;
+            public override int LandmarkLength => 9;
+        }
+
+        public abstract class EyePartBase : FacePartBase
+        {
+            public EyePartBase(FaceParts parent) : base(parent)
+            {
+                //デフォルトは開いた状態
+                CurrentEyeOpenValue = 1.0f;
+            }
+
+            public float GetEyeOpenValue()
+            {
+                var positions = Positions;
+                float yMax = positions[0].y;
+                float yMin = positions[0].y;
+                for (int i = 1; i < positions.Length; i++)
+                {
+                    if (yMax < positions[i].y)
+                    {
+                        yMax = positions[i].y;
+                    }
+                    if (yMin > positions[i].y)
+                    {
+                        yMin = positions[i].y;
+                    }
+                }
+
+                float rawValue = yMax - yMin;
+                //float rawValue = positions.Max(r => r.y) - positions.Min(r => r.y);
+                float normalizedValue = rawValue / Parent.FaceSize.y;
+                CurrentEyeOpenValue = normalizedValue;
+
+                return normalizedValue;
+            }
+
+            public Vector2 GetCenter() => GetCenterPosition();
+            
+            protected override void OnUpdated()
+            {
+                base.OnUpdated();
+                _eyeOpenValue.OnNext(GetEyeOpenValue());
+            }
+
+            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+            {
+                CurrentEyeOpenValue = Mathf.Lerp(CurrentEyeOpenValue, calibration.eyeOpenHeight, lerpFactor);
+                _eyeOpenValue.OnNext(CurrentEyeOpenValue);
+            }
+
+            private readonly Subject<float> _eyeOpenValue = new Subject<float>();
+            public float CurrentEyeOpenValue { get; private set; }
+
+            public IObservable<float> EyeOpenValue => _eyeOpenValue;
+        }
+
+        public class RightEyePart : EyePartBase
+        {
+            public RightEyePart(FaceParts parent) : base(parent) { }
+            public override int LandmarkStartIndex => 36;
+            public override int LandmarkLength => 6;
+        }
+
+        public class LeftEyePart : EyePartBase
+        {
+            public LeftEyePart(FaceParts parent) : base(parent) { }
+            public override int LandmarkStartIndex => 42;
+            public override int LandmarkLength => 6;
+        }
+
+        public class OuterMouthPart : FacePartBase
+        {
+            public OuterMouthPart(FaceParts parent) : base(parent) { }
+
+            public override int LandmarkStartIndex => 48;
+            public override int LandmarkLength => 12;
+            
+            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+            {
+                //何もしない: そもそもプロパティとして外に出してない
+            }
+        }
+
+        public class InnerMouthPart : FacePartBase
+        {
+            public InnerMouthPart(FaceParts parent) : base(parent) { }
+
+            protected override void OnUpdated()
+            {
+                base.OnUpdated();
+                CurrentCenterPosition = GetCenterPosition();
+            }
+
+            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+            {
+                //何もしない: そもそもプロパティとして外に出してない
+            }
+
+            public Vector2 CurrentCenterPosition { get; private set; }
+
+            public override int LandmarkStartIndex => 60;
+            public override int LandmarkLength => 8;
+        }
+    }
+
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using UniRx;
 using UnityEngine;
 
 namespace Baku.VMagicMirror
@@ -12,452 +11,465 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class FaceParts
     {
-        public const int FaceLandmarkCount = 68;
+        //顔のヨー角を輪郭と口の中心のキョリの非で求める際に用いる比率。
+        //値が大きいほど、ヨー角が小さくなる。
+        private const float YawMouthDistanceRatio = 1.0f;        
+        //EyeFaceYDiffがとる値の限界値の目安。この値で割って正規化する
+        private const float EyeFaceYDiffMax = 0.12f;
+
+        
+        public const int FaceLandmarkCount = 17;
 
         private readonly Vector2[] _landmarks = new Vector2[FaceLandmarkCount];
 
-        public FaceParts()
-        {
-            Outline = new FaceOutlinePart(this);
+        // public FaceParts()
+        // {
+        //     Outline = new FaceOutlinePart(this);
+        //
+        //     Nose = new NosePart(this);
+        //
+        //     RightEye = new RightEyePart(this, Nose);
+        //     LeftEye = new LeftEyePart(this, Nose);
+        //
+        //     Mouth = new MouthPart(this);
+        //
+        //     PartsWithoutOutline = new FacePartBase[]
+        //     {
+        //         Nose,
+        //         RightEye,
+        //         LeftEye,
+        //         Mouth,
+        //     };
+        // }
+        
+        // public Vector2 FaceSize { get; private set; } = Vector2.one;
 
-            RightEyebrow = new RightEyebrowPart(this);
-            LeftEyebrow = new LeftEyebrowPart(this);
+        // public FaceOutlinePart Outline { get; }
+        //
+        // public NosePart Nose { get; }
+        //
+        // public RightEyePart RightEye { get; }
+        // public LeftEyePart LeftEye { get; }
+        //
+        // public MouthPart Mouth { get; }
+        //
+        // //輪郭は顔サイズと傾き除去のために特別扱いしたいので外す
+        // private FacePartBase[] PartsWithoutOutline { get; }
 
-            Nose = new NosePart(this);
-
-            RightEye = new RightEyePart(this);
-            LeftEye = new LeftEyePart(this);
-
-            InnerMouth = new InnerMouthPart(this);
-            OuterMouth = new OuterMouthPart(this);
-
-            PartsWithoutOutline = new FacePartBase[]
-            {
-                RightEyebrow,
-                LeftEyebrow,
-                Nose,
-                RightEye,
-                LeftEye,
-                InnerMouth,
-                OuterMouth,
-            };
-        }
-
-        public Vector2 FaceSize { get; private set; } = Vector2.one;
-
-        public FaceOutlinePart Outline { get; }
-
-        public RightEyebrowPart RightEyebrow { get; }
-        public LeftEyebrowPart LeftEyebrow { get; }
-
-        public NosePart Nose { get; }
-
-        public RightEyePart RightEye { get; }
-        public LeftEyePart LeftEye { get; }
-
-        public InnerMouthPart InnerMouth { get; }
-        public OuterMouthPart OuterMouth { get; }
-
-        //輪郭は顔サイズと傾き除去のために特別扱いしたいので外す
-        private FacePartBase[] PartsWithoutOutline { get; }
-
+        /// <summary> FaceRollRadの符号に影響する。 </summary>
         public bool DisableHorizontalFlip { get; set; }
+        
+        #region 出力値いろいろ
 
-        /// <summary>
-        /// 値を更新していく。
-        /// blendRateが0-0.99くらいの値のときは顔トラが始まって間もないのでキャリブ
-        /// </summary>
-        /// <param name="mainPersonRect"></param>
-        /// <param name="landmarks"></param>
+        public float FacePitchRate { get; private set; }
+        public float FaceYawRate => DisableHorizontalFlip ? -_faceYawRate : _faceYawRate;
+        public float FaceRollRad => DisableHorizontalFlip ? _faceRollRad : _faceRollRad;
+
+        public float LeftEyeBlink => DisableHorizontalFlip ? _leftEyeBlink : _rightEyeBlink;
+        public float RightEyeBlink => DisableHorizontalFlip ? _rightEyeBlink : _leftEyeBlink;
+
+        private float _faceRollRad;
+        private float _faceYawRate;
+        private float _leftEyeBlink;
+        private float _rightEyeBlink;
+        
+        //NOTE: 1回のアップデートあたり4回くらい使いたくなるのでキャッシュ
+        private float _faceRollCos;
+        private float _faceRollSin;
+        
+        #endregion
+        
         public void Update(Rect mainPersonRect, List<Vector2> landmarks)
         {
-            if (landmarks == null || landmarks.Count < FaceLandmarkCount)
+            for (int i = 0; i < FaceLandmarkCount; i++)
             {
-                return;
+                _landmarks[i] = landmarks[i];
             }
-
-            //顔の中心でオフセット取る : たぶん回転の除去とかで都合がよいのでこのスタイルで行きます
-            var offset = mainPersonRect.center;
-            for(int i = 0; i < _landmarks.Length; i++)
-            {
-                _landmarks[i] = landmarks[i] - offset;
-            }
-
-            Outline.Update(_landmarks);
-            FaceSize = Outline.FaceSize;
-            for (int i = 0; i < PartsWithoutOutline.Length; i++)
-            {
-                PartsWithoutOutline[i].Update(_landmarks);
-            }
-            Outline.UpdateYaw(InnerMouth.CurrentCenterPosition);
-            Outline.UpdatePitch(LeftEye.GetCenter(), RightEye.GetCenter());
+            
+            UpdateEyeOpen();
+            UpdateFaceRotation();
         }
-
-        /// <summary>
-        /// それぞれの顔パーツ情報を初期状態に戻します。
-        /// </summary>
-        /// <param name="calibration"></param>
-        /// <param name="lerpFactor">0-1の範囲で指定される、基準位置に戻すのに使うLerpファクタ</param>
+    
         public void LerpToDefault(CalibrationData calibration, float lerpFactor)
         {
-            Outline.LerpToDefault(calibration, lerpFactor);
-            for (int i = 0; i < PartsWithoutOutline.Length; i++)
-            {
-                PartsWithoutOutline[i].LerpToDefault(calibration, lerpFactor);
-            }
+            var factor = 1.0f - lerpFactor;
+            _leftEyeBlink *= factor;
+            _rightEyeBlink *= factor;
+            
+            //TODO: キャリブレーション次第で変えないとダメ。とくにピッチ
+            
+            FacePitchRate *= factor;
+            _faceYawRate *= factor;
+            _faceRollRad *= factor;
+            
+            // Outline.LerpToDefault(calibration, lerpFactor);
+            // for (int i = 0; i < PartsWithoutOutline.Length; i++)
+            // {
+            //     PartsWithoutOutline[i].LerpToDefault(calibration, lerpFactor);
+            // }
         }
         
-        //todo: 内部実装をSpanでやった方がカッコ良さそう…
-        public abstract class FacePartBase
+
+        private void UpdateEyeOpen()
         {
-            protected FacePartBase(FaceParts parent)
-            {
-                _positions = new Vector2[LandmarkLength];
-                Parent = parent;
-            }
-            private readonly Vector2[] _positions;
+            float leftEyeHeight = new Vector2 (_landmarks [12].x - _landmarks [11].x, _landmarks [12].y - _landmarks [11].y).sqrMagnitude;
+            float rightEyeHeight = new Vector2 (_landmarks [10].x - _landmarks [9].x, _landmarks [10].y - _landmarks [9].y).sqrMagnitude;
+            float noseHeight = new Vector2 (_landmarks [1].x - (_landmarks [3].x + _landmarks [4].x) / 2, _landmarks [1].y - (_landmarks [3].y + _landmarks [4].y) / 2).sqrMagnitude;
 
-            public FaceParts Parent { get; }
+            float leftEyeOpenRatio = leftEyeHeight / noseHeight;
+            _leftEyeBlink = 1.0f - Mathf.InverseLerp (0.003f, 0.009f, leftEyeOpenRatio);
 
-            /// <summary>
-            /// WARN: GCAllocをラクに避けるためにこう書いてるが派生クラスでの書き込みはダメ！
-            /// </summary>
-            public Vector2[] Positions => _positions;
+            float rightEyeOpenRatio = rightEyeHeight / noseHeight;
+            _rightEyeBlink = 1.0f - Mathf.InverseLerp (0.003f, 0.009f, rightEyeOpenRatio);
+        }
+
+        private void UpdateFaceRotation()
+        {
+            UpdateRoll();
+            UpdateYaw();
+            //NOTE: Rollより後にやる必要があるので注意
+            UpdatePitch();
+        }
+
+        private void UpdateRoll()
+        {
+            //輪郭の端、つまり両こめかみ付近に線を引いてみたときの傾きをとっている。
+            //以前はアゴ先の位置も考慮していたが、それだとヨー運動と合成されてしまうため、使わないようにした。
+            Vector2 diffVecSum = _landmarks[8] - _landmarks[6];
+            //TODO: 逆だったら直してね
+            _faceRollRad = Mathf.Atan2(diffVecSum.y, diffVecSum.x);
+        }
+
+        private void UpdateYaw()
+        {
+            var mouthCenter = (_landmarks[13] + _landmarks[14] + _landmarks[15] + _landmarks[16]) * 0.25f;
+            float diffLeft = Vector2.Distance(mouthCenter, _landmarks[8]);
+            float diffRight = Vector2.Distance(mouthCenter, _landmarks[6]);
+            //ピクセル単位のハズなので1以下ならどちらかの点に被っている(※通常は起きない)
+            //通常ケースでは(遠いほうの距離 / 近いほうの距離)の比率をうまく畳んで[-1, 1]の範囲に収めようとしている
+            _faceYawRate =
+                (diffLeft < 1f) ? -1f :
+                (diffRight < 1f) ? 1f :
+                (diffLeft < diffRight) ? 
+                    -Mathf.Clamp(diffRight / diffLeft - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio :
+                    Mathf.Clamp(diffLeft / diffRight - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio;
+        }
+
+        private void UpdatePitch()
+        {
+            //顔のY平均と、目のY平均の上下関係から推定する。
+            //目のほうが上にある場合は上をむいており、逆もしかり。
             
-            public void Update(Vector2[] rects)
-            {
-                //ややチェックが雑だが本ファイルの範囲でしか使わないから大丈夫なはず
-                Array.Copy(rects, LandmarkStartIndex, _positions, 0, LandmarkLength);
-                OnUpdated();
-            }
-
-            protected void CancelRollRotation()
-            {
-                //sinにマイナスがつくのは、キャンセル回転のためにもとの角度を(-1)倍した値のsin,cosをセットで得るため
-                float cos = Parent.Outline.CurrentFaceRollCos;
-                float sin = -Parent.Outline.CurrentFaceRollSin;
-                for(int i = 0; i < _positions.Length; i++)
-                {
-                    var p = _positions[i];
-                    _positions[i] = new Vector2(
-                        p.x * cos - p.y * sin,
-                        p.x * sin + p.y * cos
-                        );
-                }
-            }
-
-            protected Vector2 GetRollCanceled(Vector2 p)
-            {
-                //sinにマイナスがつくのは、キャンセル回転のためにもとの角度を(-1)倍した値のsin,cosをセットで得るため
-                float cos = Parent.Outline.CurrentFaceRollCos;
-                float sin = -Parent.Outline.CurrentFaceRollSin;
-                return new Vector2(
-                    p.x * cos - p.y * sin,
-                    p.x * sin + p.y * cos
-                    );
-            }
-
-            /// <summary>この顔パーツが属している特徴点の図心を計算する。</summary>
-            /// <returns></returns>
-            protected Vector2 GetCenterPosition()
-            {
-                //NOTE: LINQ使ってないのはパフォーマンス配慮
-                var sum = new Vector2();
-                var pos = Positions;
-                for (int i = 0; i < pos.Length; i++)
-                {
-                    sum += pos[i];
-                }
-                return sum / pos.Length;
-            }
-
-            /// <summary> パーツの値を基準値まで戻す。このとき、必要ならばキャリブデータを参照してもよい。 </summary>
-            public abstract void LerpToDefault(CalibrationData calibration, float lerpFactor);
-
-            protected virtual void OnUpdated() { }
-
-            public virtual bool HasValidData => _positions.Length > 0;
-
-            public abstract int LandmarkStartIndex { get; }
-            public abstract int LandmarkLength { get; }
-        }
-
-        public class FaceOutlinePart : FacePartBase
-        {
-            //顔のヨー角を輪郭と口の中心のキョリの非で求める際に用いる比率。
-            //値が大きいほど、ヨー角が小さくなる。
-            private const float YawMouthDistanceRatio = 3.0f;
-
-            //EyeFaceYDiffがとる値の限界値の目安。この値で割って正規化する
-            private const float EyeFaceYDiffMax = 0.12f;
-
-            public FaceOutlinePart(FaceParts parent) : base(parent)
-            {
-            }
-
-            public Vector2 FaceSize { get; private set; } = Vector2.one;
+            var leftEyeCenter = 0.25f * (_landmarks[4] + _landmarks[5] + _landmarks[11] + _landmarks[12]);
+            var rightEyeCenter = 0.25f * (_landmarks[2] + _landmarks[3] + _landmarks[9] + _landmarks[10]);
             
-            public float EyeFaceYDiff { get; private set; }
+            var faceY = 0.5f * GetRollCanceled(_landmarks[6] + _landmarks[8]).y;
+            var eyesY = 0.5f * GetRollCanceled(leftEyeCenter + rightEyeCenter).y;
+                
+            //POINT: 顔の横方向サイズで正規化する。こうすると口の開閉とか鎖骨付近の領域の誤検出にちょっと強いので
+            FacePitchRate = (eyesY - faceY) / (_landmarks[6] - _landmarks[8]).magnitude / EyeFaceYDiffMax;
+        }
             
-
-            public float CurrentFaceRollRad { get; private set; }
-            //NOTE: sin, cosは回転計算で何度も欲しいのでキャッシュしとく
-            public float CurrentFaceRollSin { get; private set; }
-            public float CurrentFaceRollCos { get; private set; }
-
-            /// <summary>
-            /// 左右どちらを向いているかを[-1(左), 1(右)]の範囲で表すレート。
-            /// </summary>
-            /// <remarks>
-            /// 計算上レートと角度は比例しないが、近似として比例扱いにしても良い。
-            /// </remarks>
-            public float CurrentFaceYawRate { get; private set; }
-
-            /// <summary>
-            /// 上下どちらを向いてるかを[-1(下), 1(上)]前後の範囲で表すレート。
-            /// このレイヤーでは上が正のほうが直感的だけど、ピッチ角にする時点で符号の反転が必要なことに注意
-            /// </summary>
-            public float CurrentFacePitchRate => EyeFaceYDiff;
-
-            protected override void OnUpdated()
-            {
-                var positions = Positions;
-
-                //輪郭の端、つまり両こめかみ付近に線を引いてみたときの傾きをとっている。
-                //以前はアゴ先の位置も考慮していたが、それだとヨー運動と合成されてしまうため、使わないようにした。
-                Vector2 diffVecSum = positions[16] - positions[0];
-                
-                float faceRollRad = Mathf.Atan2(diffVecSum.y, diffVecSum.x);
-                
-                //Radは外部で使う値なので左右反転の設定に基づいてひっくり返し、Sin/Cosは内部計算用なのでそのままにする
-                CurrentFaceRollSin = Mathf.Sin(faceRollRad);
-                CurrentFaceRollCos = Mathf.Cos(faceRollRad);
-                CurrentFaceRollRad = Parent.DisableHorizontalFlip ? -faceRollRad : faceRollRad;
-                
-                //外形の3点だけで顔の矩形計算には足りる(しかもその方が回転不変で良い)
-                FaceSize = new Vector2(
-                    Vector2.Distance(positions[0], positions[16]),
-                    Vector2.Distance(0.5f * (positions[16] + positions[0]), positions[8])
-                    );
-            }
-
-            public void UpdateYaw(Vector2 mouthCenter)
-            {
-                float diffLeft = Vector2.Distance(mouthCenter, Positions[4]);
-                float diffRight = Vector2.Distance(mouthCenter, Positions[12]);
-
-                //ピクセル単位のハズなので1以下ならどちらかの点に被っている(※通常は起きない)
-                //通常ケースでは(遠いほうの距離 / 近いほうの距離)の比率をうまく畳んで[-1, 1]の範囲に収めようとしている
-
-                float yawRate =
-                    (diffLeft < 1f) ? -1f :
-                    (diffRight < 1f) ? 1f :
-                    (diffLeft < diffRight) ? 
-                        -Mathf.Clamp(diffRight / diffLeft - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio :
-                        Mathf.Clamp(diffLeft / diffRight - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio;
-                
-                CurrentFaceYawRate = Parent.DisableHorizontalFlip ? -yawRate : yawRate;
-            }
-
-            public void UpdatePitch(Vector2 leftEyeCenter, Vector2 rightEyeCenter)
-            {
-                //顔のY平均と、目のY平均の上下関係から推定する。
-                //目のほうが上にある場合は上をむいており、逆もしかり。
-                var faceY = 0.5f * GetRollCanceled(Positions[0] + Positions[16]).y;
-                var eyesY = 0.5f * GetRollCanceled(leftEyeCenter + rightEyeCenter).y;
-                
-                //POINT: FaceSize.yではなくxによって正規化する。
-                //Yは口の開閉とか、鎖骨付近を誤検出したときにブレちゃうので、
-                //そうした外れ値を安全に避けるのが狙い。
-                EyeFaceYDiff = (eyesY - faceY) / FaceSize.x / EyeFaceYDiffMax;
-            }
-
-            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-            {
-                CurrentFaceRollRad = Mathf.Lerp(CurrentFaceRollRad, 0, lerpFactor);
-                CurrentFaceRollSin = Mathf.Sin(CurrentFaceRollSin);
-                CurrentFaceRollCos = Mathf.Cos(CurrentFaceRollCos);
-                CurrentFaceYawRate = Mathf.Lerp(CurrentFaceYawRate, 0, lerpFactor);
-                EyeFaceYDiff = Mathf.Lerp(EyeFaceYDiff, calibration.eyeFaceYDiff, lerpFactor);
-                
-                float faceLen = Mathf.Sqrt(calibration.faceSize);
-                FaceSize = Vector2.Lerp(FaceSize, new Vector2(faceLen, faceLen), lerpFactor);
-            }
-            
-            public override int LandmarkStartIndex => 0;
-            public override int LandmarkLength => 17;
-        }
-
-        public abstract class EyebrowPartBase : FacePartBase
+        private Vector2 GetRollCanceled(Vector2 p)
         {
-            public EyebrowPartBase(FaceParts parent) : base(parent)
-            {
-            }
-
-            protected override void OnUpdated()
-            {
-                CancelRollRotation();
-
-                var positions = Positions;
-                float ySum = 0;
-                for (int i = 0; i < positions.Length; i++)
-                {
-                    ySum += positions[i].y;
-                }
-
-                float height = ySum / positions.Length;
-                float normalizedHeight = (Parent.FaceSize.y - height) / Parent.FaceSize.y;
-                CurrentHeight = normalizedHeight;
-                _height.OnNext(normalizedHeight);
-            }
-
-            //NOTE: キャリブ情報には両眉の平均値が載っているので、リセット時は平均値を両方に当て込めばOK
-            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-            {
-                CurrentHeight = Mathf.Lerp(CurrentHeight, calibration.eyeBrowPosition, lerpFactor);
-                _height.OnNext(CurrentHeight);
-            }
-
-            public float CurrentHeight { get; private set; }
-
-            protected Subject<float> _height = new Subject<float>();
-            public IObservable<float> Height => _height;
-        }
-
-        public class RightEyebrowPart : EyebrowPartBase
-        {
-            public RightEyebrowPart(FaceParts parent) : base(parent)
-            {
-            }
-
-            public override int LandmarkStartIndex => 17;
-            public override int LandmarkLength => 5;
-        }
-
-        public class LeftEyebrowPart : EyebrowPartBase
-        {
-            public LeftEyebrowPart(FaceParts parent) : base(parent)
-            {
-            }
-            public override int LandmarkStartIndex => 22;
-            public override int LandmarkLength => 5;
-        }
-
-        public class NosePart : FacePartBase
-        {
-            public NosePart(FaceParts parent) : base(parent)
-            {
-            }
-
-            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-            {
-                //何もしないでOK
-            }
-
-            public override int LandmarkStartIndex => 27;
-            public override int LandmarkLength => 9;
-        }
-
-        public abstract class EyePartBase : FacePartBase
-        {
-            public EyePartBase(FaceParts parent) : base(parent)
-            {
-                //デフォルトは開いた状態
-                CurrentEyeOpenValue = 1.0f;
-            }
-
-            public float GetEyeOpenValue()
-            {
-                var positions = Positions;
-                float yMax = positions[0].y;
-                float yMin = positions[0].y;
-                for (int i = 1; i < positions.Length; i++)
-                {
-                    if (yMax < positions[i].y)
-                    {
-                        yMax = positions[i].y;
-                    }
-                    if (yMin > positions[i].y)
-                    {
-                        yMin = positions[i].y;
-                    }
-                }
-
-                float rawValue = yMax - yMin;
-                //float rawValue = positions.Max(r => r.y) - positions.Min(r => r.y);
-                float normalizedValue = rawValue / Parent.FaceSize.y;
-                CurrentEyeOpenValue = normalizedValue;
-
-                return normalizedValue;
-            }
-
-            public Vector2 GetCenter() => GetCenterPosition();
-            
-            protected override void OnUpdated()
-            {
-                base.OnUpdated();
-                _eyeOpenValue.OnNext(GetEyeOpenValue());
-            }
-
-            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-            {
-                CurrentEyeOpenValue = Mathf.Lerp(CurrentEyeOpenValue, calibration.eyeOpenHeight, lerpFactor);
-                _eyeOpenValue.OnNext(CurrentEyeOpenValue);
-            }
-
-            private readonly Subject<float> _eyeOpenValue = new Subject<float>();
-            public float CurrentEyeOpenValue { get; private set; }
-
-            public IObservable<float> EyeOpenValue => _eyeOpenValue;
-        }
-
-        public class RightEyePart : EyePartBase
-        {
-            public RightEyePart(FaceParts parent) : base(parent) { }
-            public override int LandmarkStartIndex => 36;
-            public override int LandmarkLength => 6;
-        }
-
-        public class LeftEyePart : EyePartBase
-        {
-            public LeftEyePart(FaceParts parent) : base(parent) { }
-            public override int LandmarkStartIndex => 42;
-            public override int LandmarkLength => 6;
-        }
-
-        public class OuterMouthPart : FacePartBase
-        {
-            public OuterMouthPart(FaceParts parent) : base(parent) { }
-
-            public override int LandmarkStartIndex => 48;
-            public override int LandmarkLength => 12;
-            
-            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-            {
-                //何もしない: そもそもプロパティとして外に出してない
-            }
-        }
-
-        public class InnerMouthPart : FacePartBase
-        {
-            public InnerMouthPart(FaceParts parent) : base(parent) { }
-
-            protected override void OnUpdated()
-            {
-                base.OnUpdated();
-                CurrentCenterPosition = GetCenterPosition();
-            }
-
-            public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
-            {
-                //何もしない: そもそもプロパティとして外に出してない
-            }
-
-            public Vector2 CurrentCenterPosition { get; private set; }
-
-            public override int LandmarkStartIndex => 60;
-            public override int LandmarkLength => 8;
-        }
+            //sinにマイナスがつくのは、キャンセル回転のためにもとの角度を(-1)倍した値のsin,cosをセットで得るため
+            float cos =  _faceRollCos;
+            float sin = -_faceRollSin;
+            return new Vector2(
+                p.x * cos - p.y * sin,
+                p.x * sin + p.y * cos
+                );
+        }        
+        
+        // /// <summary>
+        // /// 値を更新していく。
+        // /// blendRateが0-0.99くらいの値のときは顔トラが始まって間もないのでキャリブ
+        // /// </summary>
+        // /// <param name="mainPersonRect"></param>
+        // /// <param name="landmarks"></param>
+        // public void Update(Rect mainPersonRect, List<Vector2> landmarks)
+        // {
+        //     if (landmarks == null || landmarks.Count < FaceLandmarkCount)
+        //     {
+        //         return;
+        //     }
+        //
+        //     //顔の中心でオフセット取る : たぶん回転の除去とかで都合がよいのでこのスタイルで行きます
+        //     var offset = mainPersonRect.center;
+        //     for(int i = 0; i < _landmarks.Length; i++)
+        //     {
+        //         _landmarks[i] = landmarks[i] - offset;
+        //     }
+        //
+        //     Outline.Update(_landmarks);
+        //     FaceSize = Outline.FaceSize;
+        //     for (int i = 0; i < PartsWithoutOutline.Length; i++)
+        //     {
+        //         PartsWithoutOutline[i].Update(_landmarks);
+        //     }
+        //     Outline.UpdateYaw(Mouth.CurrentCenterPosition);
+        //     Outline.UpdatePitch(LeftEye.GetCenter(), RightEye.GetCenter());
+        // }
+        //
+        // /// <summary>
+        // /// それぞれの顔パーツ情報を初期状態に戻します。
+        // /// </summary>
+        // /// <param name="calibration"></param>
+        // /// <param name="lerpFactor">0-1の範囲で指定される、基準位置に戻すのに使うLerpファクタ</param>
+        // public void LerpToDefault(CalibrationData calibration, float lerpFactor)
+        // {
+        //     Outline.LerpToDefault(calibration, lerpFactor);
+        //     for (int i = 0; i < PartsWithoutOutline.Length; i++)
+        //     {
+        //         PartsWithoutOutline[i].LerpToDefault(calibration, lerpFactor);
+        //     }
+        // }
+        
+        // //todo: 内部実装をSpanでやった方がカッコ良さそう…
+        // public abstract class FacePartBase
+        // {
+        //     protected FacePartBase(FaceParts parent)
+        //     {
+        //         //_positions = new Vector2[LandmarkLength];
+        //         Parent = parent;
+        //     }
+        //
+        //     public FaceParts Parent { get; }
+        //
+        //     /// <summary>
+        //     /// WARN: GCAllocをラクに避けるためにこう書いてるが派生クラスでの書き込みはダメ！
+        //     /// </summary>
+        //     //public Vector2[] Positions => _positions;
+        //
+        //     public abstract void Update(Vector2[] rects);
+        //
+        //     //NOTE: 要らなくなる、はず。
+        //     protected Vector2 GetRollCanceled(Vector2 p)
+        //     {
+        //         //sinにマイナスがつくのは、キャンセル回転のためにもとの角度を(-1)倍した値のsin,cosをセットで得るため
+        //         float cos = Parent.Outline.CurrentFaceRollCos;
+        //         float sin = -Parent.Outline.CurrentFaceRollSin;
+        //         return new Vector2(
+        //             p.x * cos - p.y * sin,
+        //             p.x * sin + p.y * cos
+        //             );
+        //     }
+        //
+        //     /// <summary> パーツの値を基準値まで戻す。このとき、必要ならばキャリブデータを参照してもよい。 </summary>
+        //     public abstract void LerpToDefault(CalibrationData calibration, float lerpFactor);
+        //
+        // }
+        //
+        // public class FaceOutlinePart : FacePartBase
+        // {
+        //     //顔のヨー角を輪郭と口の中心のキョリの非で求める際に用いる比率。
+        //     //値が大きいほど、ヨー角が小さくなる。
+        //     private const float YawMouthDistanceRatio = 3.0f;
+        //
+        //     //EyeFaceYDiffがとる値の限界値の目安。この値で割って正規化する
+        //     private const float EyeFaceYDiffMax = 0.12f;
+        //
+        //     public FaceOutlinePart(FaceParts parent) : base(parent)
+        //     {
+        //     }
+        //
+        //     public Vector2 FaceSize { get; private set; } = Vector2.one;
+        //     
+        //     public float EyeFaceYDiff { get; private set; }
+        //     
+        //
+        //     public float CurrentFaceRollRad { get; private set; }
+        //     //NOTE: sin, cosは回転計算で何度も欲しいのでキャッシュしとく
+        //     public float CurrentFaceRollSin { get; private set; }
+        //     public float CurrentFaceRollCos { get; private set; }
+        //
+        //     /// <summary>
+        //     /// 左右どちらを向いているかを[-1(左), 1(右)]の範囲で表すレート。
+        //     /// </summary>
+        //     /// <remarks>
+        //     /// 計算上レートと角度は比例しないが、近似として比例扱いにしても良い。
+        //     /// </remarks>
+        //     public float CurrentFaceYawRate { get; private set; }
+        //
+        //     /// <summary>
+        //     /// 上下どちらを向いてるかを[-1(下), 1(上)]前後の範囲で表すレート。
+        //     /// このレイヤーでは上が正のほうが直感的だけど、ピッチ角にする時点で符号の反転が必要なことに注意
+        //     /// </summary>
+        //     public float CurrentFacePitchRate => EyeFaceYDiff;
+        //
+        //     protected override void OnUpdated()
+        //     {
+        //         var positions = Positions;
+        //
+        //         //輪郭の端、つまり両こめかみ付近に線を引いてみたときの傾きをとっている。
+        //         //以前はアゴ先の位置も考慮していたが、それだとヨー運動と合成されてしまうため、使わないようにした。
+        //         Vector2 diffVecSum = positions[16] - positions[0];
+        //         
+        //         float faceRollRad = Mathf.Atan2(diffVecSum.y, diffVecSum.x);
+        //         
+        //         //Radは外部で使う値なので左右反転の設定に基づいてひっくり返し、Sin/Cosは内部計算用なのでそのままにする
+        //         CurrentFaceRollSin = Mathf.Sin(faceRollRad);
+        //         CurrentFaceRollCos = Mathf.Cos(faceRollRad);
+        //         CurrentFaceRollRad = Parent.DisableHorizontalFlip ? -faceRollRad : faceRollRad;
+        //         
+        //         //外形の3点だけで顔の矩形計算には足りる(しかもその方が回転不変で良い)
+        //         FaceSize = new Vector2(
+        //             Vector2.Distance(positions[0], positions[16]),
+        //             Vector2.Distance(0.5f * (positions[16] + positions[0]), positions[8])
+        //             );
+        //     }
+        //
+        //     public void UpdateYaw(Vector2 mouthCenter)
+        //     {
+        //         float diffLeft = Vector2.Distance(mouthCenter, Positions[4]);
+        //         float diffRight = Vector2.Distance(mouthCenter, Positions[12]);
+        //
+        //         //ピクセル単位のハズなので1以下ならどちらかの点に被っている(※通常は起きない)
+        //         //通常ケースでは(遠いほうの距離 / 近いほうの距離)の比率をうまく畳んで[-1, 1]の範囲に収めようとしている
+        //
+        //         float yawRate =
+        //             (diffLeft < 1f) ? -1f :
+        //             (diffRight < 1f) ? 1f :
+        //             (diffLeft < diffRight) ? 
+        //                 -Mathf.Clamp(diffRight / diffLeft - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio :
+        //                 Mathf.Clamp(diffLeft / diffRight - 1, 0, YawMouthDistanceRatio) / YawMouthDistanceRatio;
+        //         
+        //         CurrentFaceYawRate = Parent.DisableHorizontalFlip ? -yawRate : yawRate;
+        //     }
+        //
+        //     public void UpdatePitch(Vector2 leftEyeCenter, Vector2 rightEyeCenter)
+        //     {
+        //         //顔のY平均と、目のY平均の上下関係から推定する。
+        //         //目のほうが上にある場合は上をむいており、逆もしかり。
+        //         var faceY = 0.5f * GetRollCanceled(Positions[0] + Positions[16]).y;
+        //         var eyesY = 0.5f * GetRollCanceled(leftEyeCenter + rightEyeCenter).y;
+        //         
+        //         //POINT: FaceSize.yではなくxによって正規化する。
+        //         //Yは口の開閉とか、鎖骨付近を誤検出したときにブレちゃうので、
+        //         //そうした外れ値を安全に避けるのが狙い。
+        //         EyeFaceYDiff = (eyesY - faceY) / FaceSize.x / EyeFaceYDiffMax;
+        //     }
+        //
+        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+        //     {
+        //         CurrentFaceRollRad = Mathf.Lerp(CurrentFaceRollRad, 0, lerpFactor);
+        //         CurrentFaceRollSin = Mathf.Sin(CurrentFaceRollSin);
+        //         CurrentFaceRollCos = Mathf.Cos(CurrentFaceRollCos);
+        //         CurrentFaceYawRate = Mathf.Lerp(CurrentFaceYawRate, 0, lerpFactor);
+        //         EyeFaceYDiff = Mathf.Lerp(EyeFaceYDiff, calibration.eyeFaceYDiff, lerpFactor);
+        //         
+        //         float faceLen = Mathf.Sqrt(calibration.faceSize);
+        //         FaceSize = Vector2.Lerp(FaceSize, new Vector2(faceLen, faceLen), lerpFactor);
+        //     }
+        //     
+        //     public override int LandmarkStartIndex => 0;
+        //     public override int LandmarkLength => 17;
+        // }
+        //
+        // public class NosePart : FacePartBase
+        // {
+        //     public NosePart(FaceParts parent) : base(parent)
+        //     {
+        //     }
+        //
+        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+        //     {
+        //         //何もしないでOK
+        //     }
+        //
+        //     public override int LandmarkStartIndex => 0;
+        //     public override int LandmarkLength => 2;
+        //
+        //     public Vector2 NoseBasePoint => Positions[1];
+        // }
+        //
+        // public abstract class EyePartBase : FacePartBase
+        // {
+        //     public EyePartBase(FaceParts parent, NosePart nose) : base(parent)
+        //     {
+        //         _nose = nose;
+        //         //デフォルトは開いた状態
+        //         CurrentEyeOpenValue = 1.0f;
+        //     }
+        //
+        //     protected readonly NosePart _nose;
+        //
+        //     //TODO: ここにFaceTrackerToEyeOpenの実装があると筋がいいのかも
+        //     public float GetEyeOpenValue()
+        //     {
+        //         var positions = Positions;
+        //         float yMax = positions[0].y;
+        //         float yMin = positions[0].y;
+        //         for (int i = 1; i < positions.Length; i++)
+        //         {
+        //             if (yMax < positions[i].y)
+        //             {
+        //                 yMax = positions[i].y;
+        //             }
+        //             if (yMin > positions[i].y)
+        //             {
+        //                 yMin = positions[i].y;
+        //             }
+        //         }
+        //
+        //         float rawValue = yMax - yMin;
+        //         float normalizedValue = rawValue / Parent.FaceSize.y;
+        //         CurrentEyeOpenValue = normalizedValue;
+        //
+        //         return normalizedValue;
+        //     }
+        //
+        //     public Vector2 GetCenter() => GetCenterPosition();
+        //     
+        //     protected override void OnUpdated()
+        //     {
+        //         base.OnUpdated();
+        //         CurrentEyeOpenValue = GetEyeOpenValue();
+        //     }
+        //
+        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+        //     {
+        //         CurrentEyeOpenValue = Mathf.Lerp(CurrentEyeOpenValue, calibration.eyeOpenHeight, lerpFactor);
+        //     }
+        //
+        //     public float CurrentEyeOpenValue { get; private set; }
+        // }
+        //
+        // public class RightEyePart : EyePartBase
+        // {
+        //     public RightEyePart(FaceParts parent, NosePart nose) : base(parent, nose) { }
+        //     public override int LandmarkStartIndex => 36;
+        //     public override int LandmarkLength => 6;
+        // }
+        //
+        // public class LeftEyePart : EyePartBase
+        // {
+        //     public LeftEyePart(FaceParts parent, NosePart nose) : base(parent, nose) { }
+        //     public override int LandmarkStartIndex => 42;
+        //     public override int LandmarkLength => 6;
+        // }
+        //
+        // public class MouthPart : FacePartBase
+        // {
+        //     public MouthPart(FaceParts parent) : base(parent) { }
+        //
+        //     public override void LerpToDefault(CalibrationData calibration, float lerpFactor)
+        //     {
+        //         //何もしない: そもそもプロパティとして外に出してない
+        //     }
+        //
+        //     public Vector2 CurrentCenterPosition { get; private set; }
+        //
+        //     public override int LandmarkStartIndex => 13;
+        //     public override int LandmarkLength => 4;
+        //     
+        //     protected override void OnUpdated()
+        //     {
+        //         base.OnUpdated();
+        //         CurrentCenterPosition = GetCenterPosition();
+        //     }
+        //     
+        // }
     }
 
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceParts.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 977ae3977cd01d943bc3ec36554abd1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTracker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTracker.cs
@@ -283,9 +283,7 @@ namespace Baku.VMagicMirror
             try
             {
                 var calibrationData = JsonUtility.FromJson<CalibrationData>(data);
-                CalibrationData.eyeOpenHeight = calibrationData.eyeOpenHeight;
-                CalibrationData.eyeBrowPosition = calibrationData.eyeBrowPosition;
-                CalibrationData.eyeFaceYDiff = calibrationData.eyeFaceYDiff;
+                CalibrationData.pitchRateOffset = calibrationData.pitchRateOffset;
                 CalibrationData.faceCenter = calibrationData.faceCenter;
                 CalibrationData.faceSize = calibrationData.faceSize;
                 CalibrationDataReceived?.Invoke(calibrationData);
@@ -536,18 +534,7 @@ namespace Baku.VMagicMirror
             CalibrationRequired?.Invoke(CalibrationData);
 
             //TODO: この処理はイベントハンドラ越しでやるべきでは。
-            CalibrationData.eyeOpenHeight = 0.5f * (
-                FaceParts.LeftEye.CurrentEyeOpenValue +
-                FaceParts.RightEye.CurrentEyeOpenValue
-                );
-
-            CalibrationData.eyeBrowPosition = 0.5f * (
-                FaceParts.LeftEyebrow.CurrentHeight + 
-                FaceParts.RightEyebrow.CurrentHeight
-                );
-
-            CalibrationData.eyeFaceYDiff =
-                FaceParts.Outline.EyeFaceYDiff;            
+            CalibrationData.pitchRateOffset = FaceParts.FacePitchRate;
 
             CalibrationCompleted?.Invoke(JsonUtility.ToJson(CalibrationData));
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTracker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTracker.cs
@@ -18,20 +18,17 @@ namespace Baku.VMagicMirror
     {
         const string FaceTrackingDataFileName = "sp_human_face_17.dat";
 
-        [SerializeField]
-        private string requestedDeviceName = null;
+        [SerializeField] private string requestedDeviceName = null;
         
-        [SerializeField]
-        private int requestedWidth = 320;
+        [SerializeField] private bool isHighPowerMode = false;
         
-        [SerializeField]
-        private int requestedHeight = 240;
+        [SerializeField] private int requestedWidth = 320;
         
-        [SerializeField]
-        private int requestedFps = 30;
+        [SerializeField] private int requestedHeight = 240;
         
-        [SerializeField]
-        private int halfResizeWidthThreshold = 640;
+        [SerializeField] private int requestedFps = 30;
+        
+        [SerializeField] private int halfResizeWidthThreshold = 640;
 
         [Tooltip("顔トラッキングがオンであるにも関わらず表情データが降ってこない状態が続き、異常値と判定するまでの秒数")]
         [SerializeField] private float activeButNotTrackedCount = 1.0f;
@@ -88,12 +85,12 @@ namespace Baku.VMagicMirror
 
         private int TextureWidth =>
             (_webCamTexture == null) ? requestedWidth :
-            (_webCamTexture.width >= halfResizeWidthThreshold) ? _webCamTexture.width / 2 :
+            (!isHighPowerMode && _webCamTexture.width >= halfResizeWidthThreshold) ? _webCamTexture.width / 2 :
             _webCamTexture.width;
 
         private int TextureHeight =>
             (_webCamTexture == null) ? requestedHeight :
-            (_webCamTexture.width >= halfResizeWidthThreshold) ? _webCamTexture.height / 2 :
+            (!isHighPowerMode && _webCamTexture.width >= halfResizeWidthThreshold) ? _webCamTexture.height / 2 :
             _webCamTexture.height;
 
         private bool _calibrationRequested = false;
@@ -201,7 +198,7 @@ namespace Baku.VMagicMirror
                     
                 try
                 {
-                    if (_webCamTexture.width >= halfResizeWidthThreshold)
+                    if (!isHighPowerMode && _webCamTexture.width >= halfResizeWidthThreshold)
                     {
                         _webCamTexture.GetPixels32(_rawSizeColors);
                         SetHalfSizePixels(_rawSizeColors, _colors, _webCamTexture.width, _webCamTexture.height);
@@ -262,9 +259,10 @@ namespace Baku.VMagicMirror
             _cts?.Cancel();
         }
 
-        public void ActivateCamera(string cameraDeviceName)
+        public void ActivateCamera(string cameraDeviceName, bool highPowerMode)
         {
             requestedDeviceName = cameraDeviceName;
+            isHighPowerMode = highPowerMode;
             Initialize();
         }
 
@@ -317,7 +315,13 @@ namespace Baku.VMagicMirror
                     if (WebCamTexture.devices[i].name == requestedDeviceName)
                     {
                         _webCamDevice = WebCamTexture.devices[i];
-                        _webCamTexture = new WebCamTexture(_webCamDevice.name, requestedWidth, requestedHeight, requestedFps);
+                        int sizeFactor = isHighPowerMode ? 2 : 1;
+                        _webCamTexture = new WebCamTexture(
+                            _webCamDevice.name, 
+                            requestedWidth * sizeFactor, 
+                            requestedHeight * sizeFactor, 
+                            requestedFps
+                            );
                         break;
                     }
                 }
@@ -350,7 +354,7 @@ namespace Baku.VMagicMirror
 
             if (_colors == null || _colors.Length != _webCamTexture.width * _webCamTexture.height)
             {
-                if (_webCamTexture.width >= halfResizeWidthThreshold)
+                if (!isHighPowerMode && _webCamTexture.width >= halfResizeWidthThreshold)
                 {
                     //画像が大きすぎるので、画像処理では0.5 x 0.5サイズを使う
                     _rawSizeColors = new Color32[_webCamTexture.width * _webCamTexture.height];

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTrackerReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTrackerReceiver.cs
@@ -9,6 +9,7 @@ namespace Baku.VMagicMirror
         private readonly FaceTracker _faceTracker;
         
         private bool _enableFaceTracking = true;
+        private bool _enableHighPowerMode = false;
         private string _cameraDeviceName = "";
         private bool _enableExTracker = false;
 
@@ -23,6 +24,10 @@ namespace Baku.VMagicMirror
             receiver.AssignCommandHandler(
                 VmmCommands.EnableFaceTracking,
                 message => SetEnableFaceTracking(message.ToBoolean())
+                );
+            receiver.AssignCommandHandler(
+                VmmCommands.EnableWebCamHighPowerMode,
+                message => SetWebCamHighPowerMode(message.ToBoolean())
                 );
             receiver.AssignCommandHandler(
                 VmmCommands.ExTrackerEnable,
@@ -57,6 +62,17 @@ namespace Baku.VMagicMirror
             _enableFaceTracking = enable;
             UpdateFaceDetectorState();
         }
+        
+        private void SetWebCamHighPowerMode(bool enable)
+        {
+            if (_enableHighPowerMode == enable)
+            {
+                return;
+            }
+
+            _enableHighPowerMode = enable;
+            UpdateFaceDetectorState();
+        }
 
         private void SetEnableExTracker(bool enable)
         {
@@ -79,7 +95,7 @@ namespace Baku.VMagicMirror
         {
             if (_enableFaceTracking && !_enableExTracker && !string.IsNullOrWhiteSpace(_cameraDeviceName))
             {
-                _faceTracker.ActivateCamera(_cameraDeviceName);
+                _faceTracker.ActivateCamera(_cameraDeviceName, _enableHighPowerMode);
             }
             else
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTrackerToEyeOpen.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTrackerToEyeOpen.cs
@@ -6,22 +6,11 @@ namespace Baku.VMagicMirror
     public class FaceTrackerToEyeOpen 
     {
         //NOTE: 点を貰った瞬間に目の開閉を計算し終えてしまう
-        //TODO: 68点向けの処理を消してもよさそう
         public void UpdatePoints(List<Vector2> points)
         {
-            float leftEyeHeight = 0f;
-            float rightEyeHeight = 0f;
-            float noseHeight = 0f;
-            
-            if (points.Count == 68) {
-                leftEyeHeight = new Vector2 ((points [47].x + points [46].x) / 2 - (points [43].x + points [44].x) / 2, (points [47].y + points [46].y) / 2 - (points [43].y + points [44].y) / 2).sqrMagnitude;
-                rightEyeHeight = new Vector2 ((points [40].x + points [41].x) / 2 - (points [38].x + points [37].x) / 2, (points [40].y + points [41].y) / 2 - (points [38].y + points [37].y) / 2).sqrMagnitude;
-                noseHeight = new Vector2 (points [33].x - (points [39].x + points [42].x) / 2, points [33].y - (points [39].y + points [42].y) / 2).sqrMagnitude;
-            } else if (points.Count == 17) {
-                leftEyeHeight = new Vector2 (points [12].x - points [11].x, points [12].y - points [11].y).sqrMagnitude;
-                rightEyeHeight = new Vector2 (points [10].x - points [9].x, points [10].y - points [9].y).sqrMagnitude;
-                noseHeight = new Vector2 (points [1].x - (points [3].x + points [4].x) / 2, points [1].y - (points [3].y + points [4].y) / 2).sqrMagnitude;
-            }
+            var leftEyeHeight = new Vector2 (points [12].x - points [11].x, points [12].y - points [11].y).sqrMagnitude;
+            var rightEyeHeight = new Vector2 (points [10].x - points [9].x, points [10].y - points [9].y).sqrMagnitude;
+            var noseHeight = new Vector2 (points [1].x - (points [3].x + points [4].x) / 2, points [1].y - (points [3].y + points [4].y) / 2).sqrMagnitude;
 
             float leftEyeOpenRatio = leftEyeHeight / noseHeight;
             _leftEyeBlink = 1.0f - Mathf.InverseLerp (0.003f, 0.009f, leftEyeOpenRatio);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTrackerToEyeOpen.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/FaceTracker/FaceTrackerToEyeOpen.cs
@@ -6,6 +6,7 @@ namespace Baku.VMagicMirror
     public class FaceTrackerToEyeOpen 
     {
         //NOTE: 点を貰った瞬間に目の開閉を計算し終えてしまう
+        //TODO: 68点向けの処理を消してもよさそう
         public void UpdatePoints(List<Vector2> points)
         {
             float leftEyeHeight = 0f;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -78,6 +78,7 @@ namespace Baku.VMagicMirror
         // Motion, Face
         public const string EnableFaceTracking = nameof(EnableFaceTracking);
         public const string SetCameraDeviceName = nameof(SetCameraDeviceName);
+        public const string EnableWebCamHighPowerMode = nameof(EnableWebCamHighPowerMode);
         public const string AutoBlinkDuringFaceTracking = nameof(AutoBlinkDuringFaceTracking);
         public const string EnableHeadRotationBasedBlinkAdjust = nameof(EnableHeadRotationBasedBlinkAdjust);
         public const string EnableLipSyncBasedBlinkAdjust = nameof(EnableLipSyncBasedBlinkAdjust);
@@ -95,7 +96,6 @@ namespace Baku.VMagicMirror
         public const string EyebrowRightDownKey = nameof(EyebrowRightDownKey);
         public const string EyebrowUpScale = nameof(EyebrowUpScale);
         public const string EyebrowDownScale = nameof(EyebrowDownScale);
-
 
         // Motion, Mouth
         public const string EnableLipSync = nameof(EnableLipSync);


### PR DESCRIPTION
#415 

When High Power Mode is on,

- Tracking would be more stable
- Head tracking will be slightly faster
- Internally webcam resolution is set to 640 x 480, which causes higher CPU load

This option is off by default, for backward compatible behavior.
