### PR TITLE
VRoid Hubのログイン処理中に認証コードが入力できない問題の修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/WindowProcedureHook.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/WindowProcedureHook.cs
@@ -20,6 +20,7 @@ namespace Baku.VMagicMirror
         private WndProcDelegate _newWndProc;
         
         //起動時に1回だけスタートし、その後Disableまたは明示的な呼び出しによって止まる、という1回きりのオンオフを想定
+        private bool _hasStarted = false;
         private bool _hasStopped = false;
         
         /// <summary> マウスの監視を開始します。 </summary>
@@ -28,6 +29,7 @@ namespace Baku.VMagicMirror
             // ウインドウプロシージャをフックする
             _newWndProc = WndProc;
             _newWndProcPtr = Marshal.GetFunctionPointerForDelegate(_newWndProc);
+            _hasStarted = true;
 #if !UNITY_EDITOR
             _oldWndProcPtr = SetWindowLongPtr(
                 NativeMethods.GetUnityWindowHandle(), GWLP_WNDPROC, _newWndProcPtr
@@ -38,7 +40,7 @@ namespace Baku.VMagicMirror
         /// <summary> マウスの監視を停止します。 </summary>
         public void StopObserve()
         {
-            if (_hasStopped)
+            if (!_hasStarted || _hasStopped)
             {
                 return;
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Interfaces/IMessageSender.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Interfaces/IMessageSender.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Baku.VMagicMirror
 {
@@ -6,5 +7,7 @@ namespace Baku.VMagicMirror
     {
         void SendCommand(Message message);
         Task<string> SendQueryAsync(Message message);
+
+        event Action<Message> SendingMessage;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfBasedMessageIo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/MmfBasedMessageIo.cs
@@ -24,9 +24,21 @@ namespace Baku.VMagicMirror.InterProcess
 
         private readonly IpcMessageDispatcher _dispatcher = new IpcMessageDispatcher();
         private readonly MemoryMappedFileConnectServer _server;
-        
-        public void SendCommand(Message message) 
-            => _server.SendCommand(message.Command + ":" + message.Content);
+
+        public event Action<Message> SendingMessage;
+
+        public void SendCommand(Message message)
+        {
+            try
+            {
+                SendingMessage?.Invoke(message);
+            }
+            catch (Exception ex)
+            {
+                LogOutput.Instance.Write(ex);                
+            }
+            _server.SendCommand(message.Command + ":" + message.Content);
+        }
 
         public async Task<string> SendQueryAsync(Message message) 
             => await _server.SendQueryAsync(message.Command + ":" + message.Content);


### PR DESCRIPTION
#452 

## 確認したこと

- `RawInputChecker`のなかで`RegisterDevice`をやってる間は、Unityの`TextField`が反応しない
- WindowProcedureの書き換えの有無は影響しない

## 対策

VRoid HubのUIを出す時点で`UnregisterDevice`し、閉じたら`RegisterDevice`し直す。

- `RegisterDevice`したままではどうにもならない
- どうせVRoid UIが出てる間はキーボードの監視しても無駄

という背景からこんなもんでしょう、という対症療法的にやってます。
