### PR TITLE
UniVRM v0.61.1へのアップデート

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ sysinfo.txt
 /VMagicMirror/Assets/MidiJack/
 /VMagicMirror/Assets/SharpDX/
 /VMagicMirror/Assets/RawInputSharp/
+/VMagicMirror/Assets/VRMShaders/
+/VMagicMirror/Assets/MeshUtility/
 
 /VMagicMirror/Assets/AniLipSync-VRM.meta
 /VMagicMirror/Assets/OpenCVforUnity.meta
@@ -79,6 +81,8 @@ sysinfo.txt
 /VMagicMirror/Assets/MidiJack.meta
 /VMagicMirror/Assets/SharpDX.meta
 /VMagicMirror/Assets/RawInputSharp.meta
+/VMagicMirror/Assets/VRMShaders.meta
+/VMagicMirror/Assets/MeshUtility.meta
 
 # Assets to ignore (from BOOTH)
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,9 @@ Unity 2019.4系でUnityプロジェクトを開き、Visual Studio 2019でWPFプ
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
 * [OpenCV for Unity](https://assetstore.unity.com/packages/tools/integration/opencv-for-unity-21088)
-* [UniVRM](https://github.com/vrm-c/UniVRM) v0.55.0
+* [UniVRM](https://github.com/vrm-c/UniVRM) v0.61.1
 * [UniRx](https://github.com/neuecc/UniRx) (アセットストアから)
-* [AniLipSync VRM](https://github.com/sh-akira/AniLipSync-VRM/releases) v1.0.1
-    + AniLipSyncが依存している[OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/)のインストールも必要です。
+* [OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/)
 * [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI/releases) v0.3
 * [Zenject](https://github.com/svermeulen/Extenject) (アセットストアから)
 * [MidiJack](https://github.com/malaybaku/MidiJack)

--- a/README_en.md
+++ b/README_en.md
@@ -74,10 +74,9 @@ Maintainer's environment is as following.
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
 * [OpenCV for Unity](https://assetstore.unity.com/packages/tools/integration/opencv-for-unity-21088)
-* [UniVRM](https://dwango.github.io/vrm/) v0.55.0
+* [UniVRM](https://dwango.github.io/vrm/) v0.61.1
 * [UniRx](https://github.com/neuecc/UniRx) (from Asset Store)
-* [AniLipSync VRM](https://github.com/sh-akira/AniLipSync-VRM/releases) v1.0.1
-    + AniLipSync requires installation of [OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/).
+* [OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/)
 * [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI/releases) v0.3
 * [Zenject](https://github.com/svermeulen/Extenject) (from Asset Store)
 * [MidiJack](https://github.com/malaybaku/MidiJack)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
@@ -68,8 +68,8 @@ namespace Baku.VMagicMirror
 
         private static BlendShapeKey CreateKey(string name) => 
             _presets.ContainsKey(name)
-                ? new BlendShapeKey(_presets[name])
-                : new BlendShapeKey(name);
+                ? BlendShapeKey.CreateFromPreset(_presets[name])
+                : BlendShapeKey.CreateUnknown(name);
 
         private static readonly Dictionary<string, BlendShapePreset> _presets = new Dictionary<string, BlendShapePreset>()
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
@@ -138,7 +138,7 @@ namespace Baku.VMagicMirror.ExternalTracker
             _vroidDefaultClips = vroidDefaultBlendShapeAvatar.Clips
                 .Where(c =>
                 {
-                    var key = BlendShapeKey.CreateFrom(c);
+                    var key = BlendShapeKey.CreateFromClip(c);
                     return
                         c.Preset == BlendShapePreset.Unknown &&
                         perfectSyncKeys.Any(k => k.Name == key.Name && k.Preset == key.Preset);
@@ -386,7 +386,7 @@ namespace Baku.VMagicMirror.ExternalTracker
             return _modelBaseClips
                 .Where(c =>
                 {
-                    var key = new BlendShapeKey(c.BlendShapeName, c.Preset);
+                    var key = BlendShapeKey.CreateFromClip(c);
                     return !overwriteClipKeys.Contains(key);
                 })
                 .Concat(_vroidDefaultClips)
@@ -396,10 +396,10 @@ namespace Baku.VMagicMirror.ExternalTracker
         private BlendShapeKey[] LoadAddedClipKeys()
         {
             var baseKeys = _modelBaseClips
-                .Select(BlendShapeKey.CreateFrom)
+                .Select(BlendShapeKey.CreateFromClip)
                 .ToArray();
             return _modelClipsWithVRoidSetting
-                .Select(BlendShapeKey.CreateFrom)
+                .Select(BlendShapeKey.CreateFromClip)
                 .Where(key => !baseKeys.Any(k => k.Preset == key.Preset && k.Name == key.Name))
                 .ToArray();
         }
@@ -408,7 +408,7 @@ namespace Baku.VMagicMirror.ExternalTracker
         {
             var perfectSyncKeys = Keys.PerfectSyncKeys;
             return _modelBaseClips
-                .Select(BlendShapeKey.CreateFrom)
+                .Select(BlendShapeKey.CreateFromClip)
                 .Where(key => !perfectSyncKeys.Any(k => k.Preset == key.Preset && k.Name == key.Name))
                 .ToArray();
         }
@@ -656,73 +656,73 @@ namespace Baku.VMagicMirror.ExternalTracker
             //TODO: 名前はあとで調べて直すこと！絶対に間違った名前が入ってるぞ！
             
             //目
-            public static readonly BlendShapeKey EyeBlinkLeft = new BlendShapeKey(nameof(EyeBlinkLeft));
-            public static readonly BlendShapeKey EyeLookUpLeft = new BlendShapeKey(nameof(EyeLookUpLeft));
-            public static readonly BlendShapeKey EyeLookDownLeft = new BlendShapeKey(nameof(EyeLookDownLeft));
-            public static readonly BlendShapeKey EyeLookInLeft = new BlendShapeKey(nameof(EyeLookInLeft));
-            public static readonly BlendShapeKey EyeLookOutLeft = new BlendShapeKey(nameof(EyeLookOutLeft));
-            public static readonly BlendShapeKey EyeWideLeft = new BlendShapeKey(nameof(EyeWideLeft));
-            public static readonly BlendShapeKey EyeSquintLeft = new BlendShapeKey(nameof(EyeSquintLeft));
+            public static readonly BlendShapeKey EyeBlinkLeft = BlendShapeKey.CreateUnknown(nameof(EyeBlinkLeft));
+            public static readonly BlendShapeKey EyeLookUpLeft = BlendShapeKey.CreateUnknown(nameof(EyeLookUpLeft));
+            public static readonly BlendShapeKey EyeLookDownLeft = BlendShapeKey.CreateUnknown(nameof(EyeLookDownLeft));
+            public static readonly BlendShapeKey EyeLookInLeft = BlendShapeKey.CreateUnknown(nameof(EyeLookInLeft));
+            public static readonly BlendShapeKey EyeLookOutLeft = BlendShapeKey.CreateUnknown(nameof(EyeLookOutLeft));
+            public static readonly BlendShapeKey EyeWideLeft = BlendShapeKey.CreateUnknown(nameof(EyeWideLeft));
+            public static readonly BlendShapeKey EyeSquintLeft = BlendShapeKey.CreateUnknown(nameof(EyeSquintLeft));
 
-            public static readonly BlendShapeKey EyeBlinkRight = new BlendShapeKey(nameof(EyeBlinkRight));
-            public static readonly BlendShapeKey EyeLookUpRight = new BlendShapeKey(nameof(EyeLookUpRight));
-            public static readonly BlendShapeKey EyeLookDownRight = new BlendShapeKey(nameof(EyeLookDownRight));
-            public static readonly BlendShapeKey EyeLookInRight = new BlendShapeKey(nameof(EyeLookInRight));
-            public static readonly BlendShapeKey EyeLookOutRight = new BlendShapeKey(nameof(EyeLookOutRight));
-            public static readonly BlendShapeKey EyeWideRight = new BlendShapeKey(nameof(EyeWideRight));
-            public static readonly BlendShapeKey EyeSquintRight = new BlendShapeKey(nameof(EyeSquintRight));
+            public static readonly BlendShapeKey EyeBlinkRight = BlendShapeKey.CreateUnknown(nameof(EyeBlinkRight));
+            public static readonly BlendShapeKey EyeLookUpRight = BlendShapeKey.CreateUnknown(nameof(EyeLookUpRight));
+            public static readonly BlendShapeKey EyeLookDownRight = BlendShapeKey.CreateUnknown(nameof(EyeLookDownRight));
+            public static readonly BlendShapeKey EyeLookInRight = BlendShapeKey.CreateUnknown(nameof(EyeLookInRight));
+            public static readonly BlendShapeKey EyeLookOutRight = BlendShapeKey.CreateUnknown(nameof(EyeLookOutRight));
+            public static readonly BlendShapeKey EyeWideRight = BlendShapeKey.CreateUnknown(nameof(EyeWideRight));
+            public static readonly BlendShapeKey EyeSquintRight = BlendShapeKey.CreateUnknown(nameof(EyeSquintRight));
 
             //口(多い)
-            public static readonly BlendShapeKey MouthLeft = new BlendShapeKey(nameof(MouthLeft));
-            public static readonly BlendShapeKey MouthSmileLeft = new BlendShapeKey(nameof(MouthSmileLeft));
-            public static readonly BlendShapeKey MouthFrownLeft = new BlendShapeKey(nameof(MouthFrownLeft));
-            public static readonly BlendShapeKey MouthPressLeft = new BlendShapeKey(nameof(MouthPressLeft));
-            public static readonly BlendShapeKey MouthUpperUpLeft = new BlendShapeKey(nameof(MouthUpperUpLeft));
-            public static readonly BlendShapeKey MouthLowerDownLeft = new BlendShapeKey(nameof(MouthLowerDownLeft));
-            public static readonly BlendShapeKey MouthStretchLeft = new BlendShapeKey(nameof(MouthStretchLeft));
-            public static readonly BlendShapeKey MouthDimpleLeft = new BlendShapeKey(nameof(MouthDimpleLeft));
+            public static readonly BlendShapeKey MouthLeft = BlendShapeKey.CreateUnknown(nameof(MouthLeft));
+            public static readonly BlendShapeKey MouthSmileLeft = BlendShapeKey.CreateUnknown(nameof(MouthSmileLeft));
+            public static readonly BlendShapeKey MouthFrownLeft = BlendShapeKey.CreateUnknown(nameof(MouthFrownLeft));
+            public static readonly BlendShapeKey MouthPressLeft = BlendShapeKey.CreateUnknown(nameof(MouthPressLeft));
+            public static readonly BlendShapeKey MouthUpperUpLeft = BlendShapeKey.CreateUnknown(nameof(MouthUpperUpLeft));
+            public static readonly BlendShapeKey MouthLowerDownLeft = BlendShapeKey.CreateUnknown(nameof(MouthLowerDownLeft));
+            public static readonly BlendShapeKey MouthStretchLeft = BlendShapeKey.CreateUnknown(nameof(MouthStretchLeft));
+            public static readonly BlendShapeKey MouthDimpleLeft = BlendShapeKey.CreateUnknown(nameof(MouthDimpleLeft));
 
-            public static readonly BlendShapeKey MouthRight = new BlendShapeKey(nameof(MouthRight));
-            public static readonly BlendShapeKey MouthSmileRight = new BlendShapeKey(nameof(MouthSmileRight));
-            public static readonly BlendShapeKey MouthFrownRight = new BlendShapeKey(nameof(MouthFrownRight));
-            public static readonly BlendShapeKey MouthPressRight = new BlendShapeKey(nameof(MouthPressRight));
-            public static readonly BlendShapeKey MouthUpperUpRight = new BlendShapeKey(nameof(MouthUpperUpRight));
-            public static readonly BlendShapeKey MouthLowerDownRight = new BlendShapeKey(nameof(MouthLowerDownRight));
-            public static readonly BlendShapeKey MouthStretchRight = new BlendShapeKey(nameof(MouthStretchRight));
-            public static readonly BlendShapeKey MouthDimpleRight = new BlendShapeKey(nameof(MouthDimpleRight));
+            public static readonly BlendShapeKey MouthRight = BlendShapeKey.CreateUnknown(nameof(MouthRight));
+            public static readonly BlendShapeKey MouthSmileRight = BlendShapeKey.CreateUnknown(nameof(MouthSmileRight));
+            public static readonly BlendShapeKey MouthFrownRight = BlendShapeKey.CreateUnknown(nameof(MouthFrownRight));
+            public static readonly BlendShapeKey MouthPressRight = BlendShapeKey.CreateUnknown(nameof(MouthPressRight));
+            public static readonly BlendShapeKey MouthUpperUpRight = BlendShapeKey.CreateUnknown(nameof(MouthUpperUpRight));
+            public static readonly BlendShapeKey MouthLowerDownRight = BlendShapeKey.CreateUnknown(nameof(MouthLowerDownRight));
+            public static readonly BlendShapeKey MouthStretchRight = BlendShapeKey.CreateUnknown(nameof(MouthStretchRight));
+            public static readonly BlendShapeKey MouthDimpleRight = BlendShapeKey.CreateUnknown(nameof(MouthDimpleRight));
             
-            public static readonly BlendShapeKey MouthClose = new BlendShapeKey(nameof(MouthClose));
-            public static readonly BlendShapeKey MouthFunnel = new BlendShapeKey(nameof(MouthFunnel));
-            public static readonly BlendShapeKey MouthPucker = new BlendShapeKey(nameof(MouthPucker));
-            public static readonly BlendShapeKey MouthShrugUpper = new BlendShapeKey(nameof(MouthShrugUpper));
-            public static readonly BlendShapeKey MouthShrugLower = new BlendShapeKey(nameof(MouthShrugLower));
-            public static readonly BlendShapeKey MouthRollUpper = new BlendShapeKey(nameof(MouthRollUpper));
-            public static readonly BlendShapeKey MouthRollLower = new BlendShapeKey(nameof(MouthRollLower));
+            public static readonly BlendShapeKey MouthClose = BlendShapeKey.CreateUnknown(nameof(MouthClose));
+            public static readonly BlendShapeKey MouthFunnel = BlendShapeKey.CreateUnknown(nameof(MouthFunnel));
+            public static readonly BlendShapeKey MouthPucker = BlendShapeKey.CreateUnknown(nameof(MouthPucker));
+            public static readonly BlendShapeKey MouthShrugUpper = BlendShapeKey.CreateUnknown(nameof(MouthShrugUpper));
+            public static readonly BlendShapeKey MouthShrugLower = BlendShapeKey.CreateUnknown(nameof(MouthShrugLower));
+            public static readonly BlendShapeKey MouthRollUpper = BlendShapeKey.CreateUnknown(nameof(MouthRollUpper));
+            public static readonly BlendShapeKey MouthRollLower = BlendShapeKey.CreateUnknown(nameof(MouthRollLower));
             
             //あご
-            public static readonly BlendShapeKey JawOpen = new BlendShapeKey(nameof(JawOpen));
-            public static readonly BlendShapeKey JawForward = new BlendShapeKey(nameof(JawForward));
-            public static readonly BlendShapeKey JawLeft = new BlendShapeKey(nameof(JawLeft));
-            public static readonly BlendShapeKey JawRight = new BlendShapeKey(nameof(JawRight));
+            public static readonly BlendShapeKey JawOpen = BlendShapeKey.CreateUnknown(nameof(JawOpen));
+            public static readonly BlendShapeKey JawForward = BlendShapeKey.CreateUnknown(nameof(JawForward));
+            public static readonly BlendShapeKey JawLeft = BlendShapeKey.CreateUnknown(nameof(JawLeft));
+            public static readonly BlendShapeKey JawRight = BlendShapeKey.CreateUnknown(nameof(JawRight));
             
             //鼻
-            public static readonly BlendShapeKey NoseSneerLeft = new BlendShapeKey(nameof(NoseSneerLeft));
-            public static readonly BlendShapeKey NoseSneerRight = new BlendShapeKey(nameof(NoseSneerRight));
+            public static readonly BlendShapeKey NoseSneerLeft = BlendShapeKey.CreateUnknown(nameof(NoseSneerLeft));
+            public static readonly BlendShapeKey NoseSneerRight = BlendShapeKey.CreateUnknown(nameof(NoseSneerRight));
 
             //ほお
-            public static readonly BlendShapeKey CheekPuff = new BlendShapeKey(nameof(CheekPuff));
-            public static readonly BlendShapeKey CheekSquintLeft = new BlendShapeKey(nameof(CheekSquintLeft));
-            public static readonly BlendShapeKey CheekSquintRight = new BlendShapeKey(nameof(CheekSquintRight));
+            public static readonly BlendShapeKey CheekPuff = BlendShapeKey.CreateUnknown(nameof(CheekPuff));
+            public static readonly BlendShapeKey CheekSquintLeft = BlendShapeKey.CreateUnknown(nameof(CheekSquintLeft));
+            public static readonly BlendShapeKey CheekSquintRight = BlendShapeKey.CreateUnknown(nameof(CheekSquintRight));
             
             //舌
-            public static readonly BlendShapeKey TongueOut = new BlendShapeKey(nameof(TongueOut));
+            public static readonly BlendShapeKey TongueOut = BlendShapeKey.CreateUnknown(nameof(TongueOut));
             
             //まゆげ
-            public static readonly BlendShapeKey BrowDownLeft = new BlendShapeKey(nameof(BrowDownLeft));
-            public static readonly BlendShapeKey BrowOuterUpLeft = new BlendShapeKey(nameof(BrowOuterUpLeft));
-            public static readonly BlendShapeKey BrowDownRight = new BlendShapeKey(nameof(BrowDownRight));
-            public static readonly BlendShapeKey BrowOuterUpRight = new BlendShapeKey(nameof(BrowOuterUpRight));
-            public static readonly BlendShapeKey BrowInnerUp = new BlendShapeKey(nameof(BrowInnerUp));
+            public static readonly BlendShapeKey BrowDownLeft = BlendShapeKey.CreateUnknown(nameof(BrowDownLeft));
+            public static readonly BlendShapeKey BrowOuterUpLeft = BlendShapeKey.CreateUnknown(nameof(BrowOuterUpLeft));
+            public static readonly BlendShapeKey BrowDownRight = BlendShapeKey.CreateUnknown(nameof(BrowDownRight));
+            public static readonly BlendShapeKey BrowOuterUpRight = BlendShapeKey.CreateUnknown(nameof(BrowOuterUpRight));
+            public static readonly BlendShapeKey BrowInnerUp = BlendShapeKey.CreateUnknown(nameof(BrowInnerUp));
         }
         
         /// <summary> ブレンドシェイプの上書き処理で使うための、リップシンクのブレンドシェイプキー </summary>
@@ -742,11 +742,11 @@ namespace Baku.VMagicMirror.ExternalTracker
             public float E { get; set; }
             public float O { get; set; }
             
-            public static readonly BlendShapeKey AKey = new BlendShapeKey(BlendShapePreset.A);
-            public static readonly BlendShapeKey IKey = new BlendShapeKey(BlendShapePreset.I);
-            public static readonly BlendShapeKey UKey = new BlendShapeKey(BlendShapePreset.U);
-            public static readonly BlendShapeKey EKey = new BlendShapeKey(BlendShapePreset.E);
-            public static readonly BlendShapeKey OKey = new BlendShapeKey(BlendShapePreset.O);
+            public static readonly BlendShapeKey AKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.A); 
+            public static readonly BlendShapeKey IKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.I);
+            public static readonly BlendShapeKey UKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.U);
+            public static readonly BlendShapeKey EKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.E);
+            public static readonly BlendShapeKey OKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.O);
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInitializer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInitializer.cs
@@ -16,34 +16,34 @@ namespace Baku.VMagicMirror
     {
         private static readonly Dictionary<string, BlendShapeKey> _presetKeys = new Dictionary<string, BlendShapeKey>()
         {
-            ["Blink"] = new BlendShapeKey(BlendShapePreset.Blink), 
-            ["Blink_L"] = new BlendShapeKey(BlendShapePreset.Blink_L), 
-            ["Blink_R"] = new BlendShapeKey(BlendShapePreset.Blink_R), 
+            ["Blink"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink), 
+            ["Blink_L"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_L), 
+            ["Blink_R"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_R), 
 
-            ["LookLeft"] = new BlendShapeKey(BlendShapePreset.LookLeft), 
-            ["LookRight"] = new BlendShapeKey(BlendShapePreset.LookRight), 
-            ["LookUp"] = new BlendShapeKey(BlendShapePreset.LookUp), 
-            ["LookDown"] = new BlendShapeKey(BlendShapePreset.LookDown), 
+            ["LookLeft"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.LookLeft), 
+            ["LookRight"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.LookRight), 
+            ["LookUp"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.LookUp), 
+            ["LookDown"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.LookDown), 
 
-            ["A"] = new BlendShapeKey(BlendShapePreset.A), 
-            ["I"] = new BlendShapeKey(BlendShapePreset.I), 
-            ["U"] = new BlendShapeKey(BlendShapePreset.U), 
-            ["E"] = new BlendShapeKey(BlendShapePreset.E), 
-            ["O"] = new BlendShapeKey(BlendShapePreset.O), 
+            ["A"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.A), 
+            ["I"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.I), 
+            ["U"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.U), 
+            ["E"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.E), 
+            ["O"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.O), 
 
-            ["Joy"] = new BlendShapeKey(BlendShapePreset.Joy), 
-            ["Angry"] = new BlendShapeKey(BlendShapePreset.Angry), 
-            ["Sorrow"] = new BlendShapeKey(BlendShapePreset.Sorrow), 
-            ["Fun"] = new BlendShapeKey(BlendShapePreset.Fun),
+            ["Joy"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.Joy), 
+            ["Angry"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.Angry), 
+            ["Sorrow"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.Sorrow), 
+            ["Fun"] = BlendShapeKey.CreateFromPreset(BlendShapePreset.Fun),
         };
 
         private static readonly BlendShapeKey[] _lipSyncKeys = new[]
         {
-            new BlendShapeKey(BlendShapePreset.A),
-            new BlendShapeKey(BlendShapePreset.I),
-            new BlendShapeKey(BlendShapePreset.U),
-            new BlendShapeKey(BlendShapePreset.E),
-            new BlendShapeKey(BlendShapePreset.O),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.A),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.I),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.U),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.E),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.O),
         };
         
         [Inject]
@@ -122,7 +122,7 @@ namespace Baku.VMagicMirror
                 .Select(n =>
                     _presetKeys.ContainsKey(n)
                         ? _presetKeys[n]
-                        : new BlendShapeKey(n)
+                        : BlendShapeKey.CreateUnknown(n)
                 )
                 .ToArray();
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeKeyFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeKeyFactory.cs
@@ -35,7 +35,7 @@ namespace Baku.VMagicMirror
         /// </remarks>
         public static BlendShapeKey CreateFrom(string name) 
             => _presets.ContainsKey(name)
-                ? new BlendShapeKey(_presets[name]) 
-                : new BlendShapeKey(name);
+                ? BlendShapeKey.CreateFromPreset(_presets[name]) 
+                : BlendShapeKey.CreateUnknown(name);
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/DefaultFunBlendShapeModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/DefaultFunBlendShapeModifier.cs
@@ -7,7 +7,7 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class DefaultFunBlendShapeModifier
     {
-        private BlendShapeKey FunKey { get; } = new BlendShapeKey(BlendShapePreset.Fun);
+        private BlendShapeKey FunKey { get; } = BlendShapeKey.CreateFromPreset(BlendShapePreset.Fun);
 
         public float FaceDefaultFunValue { get; set; } = 0.0f;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeDownMotionController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeDownMotionController.cs
@@ -8,8 +8,8 @@ namespace Baku.VMagicMirror
     /// <summary> 瞬きに対して目と眉を下げる処理をするやつ </summary>
     public class EyeDownMotionController : MonoBehaviour
     {
-        private static readonly BlendShapeKey BlinkLKey = new BlendShapeKey(BlendShapePreset.Blink_L);
-        private static readonly BlendShapeKey BlinkRKey = new BlendShapeKey(BlendShapePreset.Blink_R);
+        private static readonly BlendShapeKey BlinkLKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_L);
+        private static readonly BlendShapeKey BlinkRKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_R);
 
         [SerializeField] private float eyeAngleDegreeWhenEyeClosed = 10f;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceControlManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceControlManager.cs
@@ -9,8 +9,8 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class FaceControlManager : MonoBehaviour
     {
-        private static readonly BlendShapeKey BlinkLKey = new BlendShapeKey(BlendShapePreset.Blink_L);
-        private static readonly BlendShapeKey BlinkRKey = new BlendShapeKey(BlendShapePreset.Blink_R);
+        private static readonly BlendShapeKey BlinkLKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_L);
+        private static readonly BlendShapeKey BlinkRKey = BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_R);
 
         //NOTE: まばたき自体は3種類どれかが排他で適用される。複数走っている場合、external > image > autoの優先度で適用する。
         [SerializeField] private ExternalTrackerBlink externalTrackerBlink = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/AnimMorphEasedTarget.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/AnimMorphEasedTarget.cs
@@ -46,20 +46,20 @@ namespace Baku.VMagicMirror
 
         private readonly Dictionary<BlendShapeKey, float> _blendShapeWeights = new Dictionary<BlendShapeKey, float>
         {
-            [new BlendShapeKey(BlendShapePreset.A)] = 0.0f,
-            [new BlendShapeKey(BlendShapePreset.E)] = 0.0f,
-            [new BlendShapeKey(BlendShapePreset.I)] = 0.0f,
-            [new BlendShapeKey(BlendShapePreset.O)] = 0.0f,
-            [new BlendShapeKey(BlendShapePreset.U)] = 0.0f,
+            [BlendShapeKey.CreateFromPreset(BlendShapePreset.A)] = 0.0f,
+            [BlendShapeKey.CreateFromPreset(BlendShapePreset.E)] = 0.0f,
+            [BlendShapeKey.CreateFromPreset(BlendShapePreset.I)] = 0.0f,
+            [BlendShapeKey.CreateFromPreset(BlendShapePreset.O)] = 0.0f,
+            [BlendShapeKey.CreateFromPreset(BlendShapePreset.U)] = 0.0f,
         };
 
         private readonly BlendShapeKey[] _keys = new[]
         {
-            new BlendShapeKey(BlendShapePreset.A),
-            new BlendShapeKey(BlendShapePreset.E),
-            new BlendShapeKey(BlendShapePreset.I),
-            new BlendShapeKey(BlendShapePreset.O),
-            new BlendShapeKey(BlendShapePreset.U),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.A),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.E),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.I),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.O),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.U),
         };
 
         private OVRLipSyncContextBase _context;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncIntegrator.cs
@@ -7,11 +7,11 @@ namespace Baku.VMagicMirror
     /// <summary> PCマイクまたは外部トラッキングのリップシンク情報をVRMに適用する、ちょっと偉いクラス。</summary>
     public class LipSyncIntegrator : MonoBehaviour
     {     
-        private static readonly BlendShapeKey _a = new BlendShapeKey(BlendShapePreset.A);
-        private static readonly BlendShapeKey _i = new BlendShapeKey(BlendShapePreset.I);
-        private static readonly BlendShapeKey _u = new BlendShapeKey(BlendShapePreset.U);
-        private static readonly BlendShapeKey _e = new BlendShapeKey(BlendShapePreset.E);
-        private static readonly BlendShapeKey _o = new BlendShapeKey(BlendShapePreset.O);
+        private static readonly BlendShapeKey _a = BlendShapeKey.CreateFromPreset(BlendShapePreset.A);
+        private static readonly BlendShapeKey _i = BlendShapeKey.CreateFromPreset(BlendShapePreset.I);
+        private static readonly BlendShapeKey _u = BlendShapeKey.CreateFromPreset(BlendShapePreset.U);
+        private static readonly BlendShapeKey _e = BlendShapeKey.CreateFromPreset(BlendShapePreset.E);
+        private static readonly BlendShapeKey _o = BlendShapeKey.CreateFromPreset(BlendShapePreset.O);
         
         [SerializeField] private AnimMorphEasedTarget animMorphEasedTarget = null;
         [SerializeField] private ExternalTrackerLipSync externalTrackerLipSync = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
@@ -16,11 +16,11 @@ namespace Baku.VMagicMirror
     {
         private static readonly BlendShapeKey[] _lipSyncKeys = new []
         {
-            new BlendShapeKey(BlendShapePreset.A),
-            new BlendShapeKey(BlendShapePreset.I),
-            new BlendShapeKey(BlendShapePreset.U),
-            new BlendShapeKey(BlendShapePreset.E),
-            new BlendShapeKey(BlendShapePreset.O),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.A),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.I),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.U),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.E),
+            BlendShapeKey.CreateFromPreset(BlendShapePreset.O),
         };
         
         private BlendShapeKey[] _allBlendShapeKeys = new BlendShapeKey[0];

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
@@ -26,9 +26,7 @@ namespace Baku.VMagicMirror
         private BlendShapeKey[] _allBlendShapeKeys = new BlendShapeKey[0];
 
         private readonly Dictionary<BlendShapeKey, float> _blendShape = new Dictionary<BlendShapeKey, float>();
-
-        private bool _reserveBlendShapeReset = false;
-
+        
         private EyeBonePostProcess _eyeBoneResetter;
         
         [Inject]
@@ -78,7 +76,6 @@ namespace Baku.VMagicMirror
         {
             if (_blendShape.Count > 0)
             {
-                _reserveBlendShapeReset = true;
                 Clear();
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
@@ -5,7 +5,7 @@ namespace Baku.VMagicMirror.Installer
 {
     public class MotionCalculationInstaller : InstallerBase
     {
-        [SerializeField] private FaceAttitudeController faceAttitude;
+        [SerializeField] private FaceAttitudeController faceAttitude = null;
     
         public override void Install(DiContainer container)
         {


### PR DESCRIPTION
#418 

- BlendShapeKeyの初期化方法が変わったのに合わせて修正
- エラー修正の過程で、よく見たらAnyLipSync-VRMを一切使って無いことに気づいたので削除
- ついでにコンパイラ警告の対策
