### PR TITLE
Neutralブレンドシェイプとかのサポート

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 2344319939732251227}
   - component: {fileID: 5187863769921554747}
   - component: {fileID: 6241239198292537160}
+  - component: {fileID: 6186883453983643772}
   m_Layer: 0
   m_Name: FaceController
   m_TagString: Untagged
@@ -137,6 +138,19 @@ MonoBehaviour:
   eyes: {fileID: 3748028266611161169}
   perfectSync: {fileID: 5187863769921554747}
   faceSwitch: {fileID: 8701057551241780110}
+  neutralClipSettings: {fileID: 6186883453983643772}
+--- !u!114 &6186883453983643772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3748028266611161173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bd1898a983ab3f4bbfbdf6b73895499, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3748028267383499195
 GameObject:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Core/CoreLogics.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Core/CoreLogics.prefab
@@ -31,6 +31,7 @@ Transform:
   - {fileID: 4403582645890784493}
   - {fileID: 4403582645735969391}
   - {fileID: 5952249983603830923}
+  - {fileID: 7502228934553232097}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -125,6 +126,66 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 410006747659649862, guid: 48e4e24e48cf43543ab508e6a42a1591,
     type: 3}
   m_PrefabInstance: {fileID: 6280833885169497037}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6638005332231117493
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 914461298883566549}
+    m_Modifications:
+    - target: {fileID: 3748028266611161169, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: faceTracker
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028266611161170, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: faceTracker
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028266611161173, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: m_Name
+      value: FaceControlLogics
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028267383499193, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: faceTracker
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3748028267383499193, guid: bc880b587a9f08e498a8c6de1fcf4650,
+        type: 3}
+      propertyPath: wordToMotion
+      value: 
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bc880b587a9f08e498a8c6de1fcf4650, type: 3}
+--- !u!4 &7502228934553232097 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
+    type: 3}
+  m_PrefabInstance: {fileID: 6638005332231117493}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7675864263786506646
 PrefabInstance:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -223,12 +223,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 341389b6ae6ed4246b3a21c4b359912b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &858847041 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 914461298883566549, guid: 8089eb7a4f09ec147961c4ed8f093c27,
-    type: 3}
-  m_PrefabInstance: {fileID: 4403582645463997422}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &935302418 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7220499518765536739, guid: a0e0d039c3aebf041adced68e3830d55,
@@ -329,18 +323,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fea24974c6c68c74597dc46bd6bf070e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1963776212 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7427902273662735822, guid: 1e7e415b712b9b041be3596ae23c356e,
-    type: 3}
-  m_PrefabInstance: {fileID: 7427902272773229850}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bf54680fc9289344eaf680af61075aeb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1993346254 stripped
@@ -582,80 +564,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: db37e7d2ac7b4834ca3f30211993c5de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &3748028267628364063
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 858847041}
-    m_Modifications:
-    - target: {fileID: 3748028266611161169, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: faceTracker
-      value: 
-      objectReference: {fileID: 1335587171}
-    - target: {fileID: 3748028266611161170, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: faceTracker
-      value: 
-      objectReference: {fileID: 1335587171}
-    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028266611161172, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028266611161173, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: m_Name
-      value: FaceControlLogics
-      objectReference: {fileID: 0}
-    - target: {fileID: 3748028267383499193, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: faceTracker
-      value: 
-      objectReference: {fileID: 1335587171}
-    - target: {fileID: 3748028267383499193, guid: bc880b587a9f08e498a8c6de1fcf4650,
-        type: 3}
-      propertyPath: wordToMotion
-      value: 
-      objectReference: {fileID: 1963776212}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bc880b587a9f08e498a8c6de1fcf4650, type: 3}
 --- !u!114 &3748028267628364064 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5395904245375780253, guid: bc880b587a9f08e498a8c6de1fcf4650,
+  m_CorrespondingSourceObject: {fileID: 1656468128809197352, guid: 8089eb7a4f09ec147961c4ed8f093c27,
     type: 3}
-  m_PrefabInstance: {fileID: 3748028267628364063}
+  m_PrefabInstance: {fileID: 4403582645463997422}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
@@ -14,6 +14,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private FaceControlManager eyes = null;
         [SerializeField] private ExternalTrackerPerfectSync perfectSync = null;
         [SerializeField] private ExternalTrackerFaceSwitchApplier faceSwitch = null;
+        [SerializeField] private NeutralClipSettings neutralClipSettings = null;
         
         private ExternalTrackerDataSource _exTracker = null;
         private BlendShapeInitializer _initializer = null;
@@ -90,6 +91,8 @@ namespace Baku.VMagicMirror
                     _wtmBlendShape.Accumulate(_blendShape);
                     lipSync.Accumulate(_blendShape);
                 }
+                
+                neutralClipSettings.ApplyOffsetClip(_blendShape);
                 return;
             }
             
@@ -118,6 +121,8 @@ namespace Baku.VMagicMirror
                     faceSwitch.Accumulate(_blendShape);
                     lipSync.Accumulate(_blendShape);
                 }
+
+                neutralClipSettings.ApplyOffsetClip(_blendShape);
                 return;
             }
             
@@ -143,6 +148,8 @@ namespace Baku.VMagicMirror
                     lipSync.Accumulate(_blendShape);
                 }
 
+                neutralClipSettings.ApplyNeutralClip(_blendShape);
+                neutralClipSettings.ApplyOffsetClip(_blendShape);
                 return;
             }
             
@@ -153,6 +160,9 @@ namespace Baku.VMagicMirror
             _initializer.InitializeBlendShapes();
             eyes.Accumulate(_blendShape);
             lipSync.Accumulate(_blendShape);
+            
+            neutralClipSettings.ApplyNeutralClip(_blendShape);
+            neutralClipSettings.ApplyOffsetClip(_blendShape);
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs
@@ -1,0 +1,62 @@
+﻿using UnityEngine;
+using VRM;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// デフォルト表情関連の設定を保持して適用するクラスです。
+    /// とくにPresetのNeutralクリップについて、実態(VMCとかがやってる)に即して任意で有効化できるようにするのが狙いです。
+    /// </summary>
+    public class NeutralClipSettings : MonoBehaviour
+    {
+        [Inject]
+        public void Initialize(IVRMLoadable vrmLoadable, IMessageReceiver receiver)
+        {
+            receiver.AssignCommandHandler(
+                VmmCommands.FaceNeutralClip,
+                c =>
+                {
+                    HasValidNeutralClipKey = !string.IsNullOrWhiteSpace(c.Content);
+                    if (HasValidNeutralClipKey)
+                    {
+                        NeutralClipKey = BlendShapeKeyFactory.CreateFrom(c.Content);
+                    }
+                });
+
+            receiver.AssignCommandHandler(
+                VmmCommands.FaceOffsetClip,
+                c =>
+                {
+                    HasValidOffsetClipKey = !string.IsNullOrWhiteSpace(c.Content);
+                    if (HasValidOffsetClipKey)
+                    {
+                        OffsetClipKey = BlendShapeKeyFactory.CreateFrom(c.Content);
+                    }
+                });
+        }
+        
+        public void ApplyNeutralClip(VRMBlendShapeProxy proxy) 
+        {
+            if (HasValidNeutralClipKey)
+            {
+                proxy.AccumulateValue(NeutralClipKey, 1f);
+            }
+        }
+
+        public void ApplyOffsetClip(VRMBlendShapeProxy proxy)
+        {
+            if (HasValidOffsetClipKey)
+            {
+                proxy.AccumulateValue(OffsetClipKey, 1f);
+            }
+        }
+
+        private bool HasValidNeutralClipKey = false;
+        private BlendShapeKey NeutralClipKey;
+
+        private bool HasValidOffsetClipKey = false;
+        private BlendShapeKey OffsetClipKey;
+        
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bd1898a983ab3f4bbfbdf6b73895499
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -76,6 +76,8 @@ namespace Baku.VMagicMirror
         public const string CalibrateFace = nameof(CalibrateFace);
         public const string SetCalibrateFaceData = nameof(SetCalibrateFaceData);
         public const string FaceDefaultFun = nameof(FaceDefaultFun);
+        public const string FaceNeutralClip = nameof(FaceNeutralClip);
+        public const string FaceOffsetClip = nameof(FaceOffsetClip);
 
         // Motion, Mouth
         public const string EnableLipSync = nameof(EnableLipSync);


### PR DESCRIPTION
#492 

仕様:

- Neutralブレンドシェイプ: 
    - ふだんBlink系のブレンドシェイプとともに、適用率1で適用される。
    - パーフェクトシンク中も適用される。
    - Word to MotionかFace Switchが有効な場合、適用されない。
    - Neutralをこの用途のためにセットアップしてる人がNeutralを入れる、というのがメインの想定用途。
- Offsetブレンドシェイプ:
    - モデルのロード中はつねに適用される。
    - 体型がブレンドシェイプで調整できる、みたいなモデルで使う。Neutralはここには入れない。
    - Neutralよりも使用頻度は低い想定
