### PR TITLE
タイピング・マウス操作についてタイムアウトで手を下げる

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -463,6 +463,11 @@ namespace Baku.VMagicMirror
         {
             fingerController.Initialize(info.animator);
             
+            //キャラロード前の時点ではHandDownとブレンドされることでIK位置が原点に飛ぶため、それらの値を捨てる
+            MouseMove.ResetHandDownTimeout(true);
+            Typing.ResetLeftHandDownTimeout(true);
+            Typing.ResetRightHandDownTimeout(true);
+            
             //NOTE: 初期姿勢は「トラッキングできてない(はずの)画像ベースハンドトラッキングのやつ」にします。
             //棒立ちサポートをめちゃ適当にやっちゃえ！というのがモチベです
             _imageBaseHand.HasRightHandUpdate = false;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -54,7 +54,6 @@ namespace Baku.VMagicMirror
         private float _rightHandIkChangeCoolDown = 0f;
 
         private bool _enableHidArmMotion = true;
-
         public bool EnableHidArmMotion
         {
             get => _enableHidArmMotion;
@@ -64,6 +63,19 @@ namespace Baku.VMagicMirror
                 MouseMove.EnableUpdate = value;
             }
         }
+
+        private bool _enableHandDownTimeout = true;
+        public bool EnableHandDownTimeout
+        {
+            get => _enableHandDownTimeout;
+            set
+            {
+                _enableHandDownTimeout = value;
+                typing.EnableHandDownTimeout = value;
+                MouseMove.EnableHandDownTimeout = value;
+            }
+        }
+        
 
         public bool UseGamepadForWordToMotion { get; set; } = false;
         
@@ -126,6 +138,9 @@ namespace Baku.VMagicMirror
             Presentation = new PresentationHandIKGenerator(this, vrmLoadable, cam);
             _imageBaseHand = new ImageBaseHandIkGenerator(this, handTracker, imageBaseHandSetting, vrmLoadable);
             _downHand = new AlwaysDownHandIkGenerator(this, vrmLoadable);
+
+            MouseMove.DownHand = _downHand;
+            typing.DownHand = _downHand;
         }
 
         //NOTE: 初めて手がキーボードから離れるまではnull

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -17,7 +17,8 @@ namespace Baku.VMagicMirror
         private const float HandIkTypeChangeCoolDown = 0.3f;
 
         //この時間だけ入力がなかったらマウスやキーボードの操作をしている手を下ろしてもいいよ、という秒数
-        public const float AutoHandDownDuration = 5.5f;
+        //たぶん無いと思うけど、何かの周期とピッタリ合うと嫌なのでてきとーに小数値を載せてます
+        public const float AutoHandDownDuration = 15.5f;
         
         //NOTE: 1.2秒かけて下ろし、0.25秒で戻す、という目安の速度感。戻すほうがスピーディなことに注意
         public const float HandDownBlendSpeed = 1f / 2f;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -20,8 +20,8 @@ namespace Baku.VMagicMirror
         public const float AutoHandDownDuration = 5.5f;
         
         //NOTE: 1.2秒かけて下ろし、0.25秒で戻す、という目安の速度感。戻すほうがスピーディなことに注意
-        public const float HandDownBlendSpeed = 1f / 1.2f;
-        public const float HandUpBlendSpeed = 1f / 0.25f;
+        public const float HandDownBlendSpeed = 1f / 2f;
+        public const float HandUpBlendSpeed = 1f / 0.4f;
 
         [SerializeField] private TypingHandIKGenerator typing = null;
         public TypingHandIKGenerator Typing => typing;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -16,6 +16,13 @@ namespace Baku.VMagicMirror
         private const float HandIkToggleDuration = 0.25f;
         private const float HandIkTypeChangeCoolDown = 0.3f;
 
+        //この時間だけ入力がなかったらマウスやキーボードの操作をしている手を下ろしてもいいよ、という秒数
+        public const float AutoHandDownDuration = 5.5f;
+        
+        //NOTE: 1.2秒かけて下ろし、0.25秒で戻す、という目安の速度感。戻すほうがスピーディなことに注意
+        public const float HandDownBlendSpeed = 1f / 1.2f;
+        public const float HandUpBlendSpeed = 1f / 0.25f;
+
         [SerializeField] private TypingHandIKGenerator typing = null;
         public TypingHandIKGenerator Typing => typing;
 
@@ -175,10 +182,18 @@ namespace Baku.VMagicMirror
             if (hand == ReactedHand.Left)
             {
                 SetLeftHandIk(HandTargetType.Keyboard);
+                if (_leftTargetType == HandTargetType.Keyboard)
+                {
+                    typing.ResetLeftHandDownTimeout(false);
+                }
             }
             else if (hand == ReactedHand.Right)
             {
                 SetRightHandIk(HandTargetType.Keyboard);
+                if (_rightTargetType == HandTargetType.Keyboard)
+                {
+                    typing.ResetRightHandDownTimeout(false);
+                }
             }
 
             if (!AlwaysHandDownMode)
@@ -208,10 +223,18 @@ namespace Baku.VMagicMirror
             if (hand == ReactedHand.Left)
             {
                 SetLeftHandIk(HandTargetType.Keyboard);
+                if (_leftTargetType == HandTargetType.Keyboard)
+                {
+                    typing.ResetLeftHandDownTimeout(false);
+                }
             }
             else if (hand == ReactedHand.Right)
             {
                 SetRightHandIk(HandTargetType.Keyboard);
+                if (_rightTargetType == HandTargetType.Keyboard)
+                {
+                    typing.ResetRightHandDownTimeout(false);
+                }
             }
 
             if (!AlwaysHandDownMode)
@@ -241,6 +264,7 @@ namespace Baku.VMagicMirror
             if (_rightTargetType == HandTargetType.Mouse)
             {
                 _particleStore.RequestMouseMoveParticle(MouseMove.ReferenceTouchpadPosition);
+                MouseMove.ResetHandDownTimeout(false);
             }
         }
 
@@ -256,6 +280,7 @@ namespace Baku.VMagicMirror
                 if (_rightTargetType == HandTargetType.Mouse)
                 {
                     _particleStore.RequestMouseClickParticle();
+                    MouseMove.ResetHandDownTimeout(false);
                 }
             }
         }
@@ -584,6 +609,11 @@ namespace Baku.VMagicMirror
                 gamepadFinger.GripLeftHand();
             }
 
+            if (targetType == HandTargetType.Keyboard)
+            {
+                typing.ResetLeftHandDownTimeout(true);
+            }
+            
             if (targetType == HandTargetType.ImageBaseHand)
             {
                 _imageBaseHand.InitializeHandPosture(ReactedHand.Left, _prevLeftHand);
@@ -635,6 +665,16 @@ namespace Baku.VMagicMirror
                 fingerController.ReleaseRightHandTyping();
             }
 
+            if (targetType == HandTargetType.Keyboard)
+            {
+                typing.ResetRightHandDownTimeout(true);
+            }
+            
+            if (targetType == HandTargetType.Mouse)
+            {
+                MouseMove.ResetHandDownTimeout(true);
+            }
+
             if (prevType == HandTargetType.Gamepad)
             {
                 gamepadFinger.ReleaseRightHand();
@@ -643,7 +683,7 @@ namespace Baku.VMagicMirror
             {
                 gamepadFinger.GripRightHand();
             }
-
+            
             //ブレンディングをきれいにするために直前で手があった位置を拾って渡してあげる
             if (targetType == HandTargetType.ImageBaseHand)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/MouseMoveHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/MouseMoveHandIKGenerator.cs
@@ -129,6 +129,7 @@ namespace Baku.VMagicMirror
             _noInputCount = 0;
             if (refreshIkImmediate)
             {
+                _handBlendRate = 1f;
                 _blendedRightHand.Position = _rightHand.Position;
                 _blendedRightHand.Rotation = _rightHand.Rotation;
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/MouseMoveHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/MouseMoveHandIKGenerator.cs
@@ -21,10 +21,16 @@ namespace Baku.VMagicMirror
         
         /// <summary> 直近で参照したタッチパッドのワールド座標。 </summary>
         public Vector3 ReferenceTouchpadPosition { get; private set; }
+
+        /// <summary> 一定時間入力がないとき手降ろし姿勢に遷移すべきかどうか </summary>
+        public bool EnableHandDownTimeout { get; set; } = true;
         
         private readonly TouchPadProvider _touchPad;
 
         private Vector3 YOffsetAlwaysVec => YOffset * Vector3.up;
+
+        //NOTE: HandIkIntegratorから初期化で入れてもらう
+        public AlwaysDownHandIkGenerator DownHand { get; set; }
 
         private Vector3 _targetPosition = Vector3.zero;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
@@ -192,6 +192,7 @@ namespace Baku.VMagicMirror
             _leftHandNoInputCount = 0f;
             if (refreshIkImmediate)
             {
+                _leftHandBlendRate = 1f;
                 _blendedLeftHand.Position = _leftHand.Position;
                 _blendedLeftHand.Rotation = _leftHand.Rotation;
             }
@@ -202,6 +203,7 @@ namespace Baku.VMagicMirror
             _rightHandNoInputCount = 0f;
             if (refreshIkImmediate)
             {
+                _rightHandBlendRate = 1f;
                 _blendedRightHand.Position = _rightHand.Position;
                 _blendedRightHand.Rotation = _rightHand.Rotation;
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using UnityEngine;
 using Zenject;
 
@@ -8,10 +9,12 @@ namespace Baku.VMagicMirror
     public class TypingHandIKGenerator : MonoBehaviour
     {
         private readonly IKDataRecord _leftHand = new IKDataRecord();
-        public IIKGenerator LeftHand => _leftHand;
+        private readonly IKDataRecord _blendedLeftHand = new IKDataRecord();
+        public IIKGenerator LeftHand => _blendedLeftHand;
 
         private readonly IKDataRecord _rightHand = new IKDataRecord();
-        public IIKGenerator RightHand => _rightHand;
+        private readonly IKDataRecord _blendedRightHand = new IKDataRecord();
+        public IIKGenerator RightHand => _blendedRightHand;
 
         //手を正面方向に向くよう補正するファクター。1に近いほど手が正面向きになる
         private const float WristForwardFactor = 0.5f;
@@ -75,6 +78,18 @@ namespace Baku.VMagicMirror
         //左右それぞれの手について、現在押し下げている直近のキー
         private string _leftCurrentKey = "";
         private string _rightCurrentKey = "";
+
+        //入力(キーの上げ下げ)がない時間のカウント。
+        private float _leftHandNoInputCount = 0f;
+        private float _rightHandNoInputCount = 0f;
+
+        //この値で手下げ姿勢と手上げ姿勢をブレンドする。
+        private float _leftHandBlendRate = 1f;
+        private float _rightHandBlendRate = 1f;
+
+        //NOTE: こう書いた方がDRY原則っぽくなるので一応。
+        private const float HandDownBlendSpeed = HandIKIntegrator.HandDownBlendSpeed;
+        private const float HandUpBlendSpeed = HandIKIntegrator.HandUpBlendSpeed;
 
         [Inject]
         public void Initialize(KeyboardProvider provider)
@@ -142,7 +157,6 @@ namespace Baku.VMagicMirror
             }
         }
         
-
         public (ReactedHand, Vector3) KeyUp(string key, bool isLeftHandOnlyMode)
         {
             if (key != _leftCurrentKey && key != _rightCurrentKey)
@@ -171,7 +185,104 @@ namespace Baku.VMagicMirror
                 return (ReactedHand.Right, keyData.position);
             }
         }
-        
+
+
+        public void ResetLeftHandDownTimeout(bool refreshIkImmediate)
+        {
+            _leftHandNoInputCount = 0f;
+            if (refreshIkImmediate)
+            {
+                _blendedLeftHand.Position = _leftHand.Position;
+                _blendedLeftHand.Rotation = _leftHand.Rotation;
+            }
+        }
+
+        public void ResetRightHandDownTimeout(bool refreshIkImmediate)
+        {
+            _rightHandNoInputCount = 0f;
+            if (refreshIkImmediate)
+            {
+                _blendedRightHand.Position = _rightHand.Position;
+                _blendedRightHand.Rotation = _rightHand.Rotation;
+            }
+        }
+
+        private void Update()
+        {
+            UpdateLeft();
+            UpdateRight();
+            
+            void UpdateLeft()
+            {
+                _leftHandNoInputCount += Time.deltaTime;
+                if (_leftHandNoInputCount > HandIKIntegrator.AutoHandDownDuration)
+                {
+                    _leftHandBlendRate = Mathf.Max(0f, _leftHandBlendRate - HandDownBlendSpeed * Time.deltaTime);
+                }
+                else
+                {
+                    _leftHandBlendRate = Mathf.Min(1f, _leftHandBlendRate + HandUpBlendSpeed * Time.deltaTime);
+                }
+
+                //NOTE: 多くの場合ブレンド計算しないほうが計算が軽い
+                if (_leftHandBlendRate > 0.999f)
+                {
+                    _blendedLeftHand.Position = _leftHand.Position;
+                    _blendedLeftHand.Rotation = _leftHand.Rotation;
+                }
+                else if (_leftHandBlendRate < 0.001f)
+                {
+                    _blendedLeftHand.Position = DownHand.LeftHand.Position;
+                    _blendedLeftHand.Rotation = DownHand.LeftHand.Rotation;
+                }
+                else
+                {
+                    var rate = Mathf.SmoothStep(0, 1, _leftHandBlendRate);
+                    _blendedLeftHand.Position = Vector3.Lerp(
+                        DownHand.LeftHand.Position, _leftHand.Position, rate
+                        );
+                    _blendedLeftHand.Rotation = Quaternion.Slerp(
+                        DownHand.LeftHand.Rotation, _leftHand.Rotation, rate
+                        );
+                }
+            }
+            
+            void UpdateRight()
+            {                
+                _rightHandNoInputCount += Time.deltaTime;
+                if (_rightHandNoInputCount > HandIKIntegrator.AutoHandDownDuration)
+                {
+                    _rightHandBlendRate = Mathf.Max(0f, _rightHandBlendRate - HandDownBlendSpeed * Time.deltaTime);
+                }
+                else
+                {
+                    _rightHandBlendRate = Mathf.Min(1f, _rightHandBlendRate + HandUpBlendSpeed * Time.deltaTime);
+                }
+
+                //NOTE: 多くの場合ブレンド計算しないほうが計算が軽い
+                if (_rightHandBlendRate > 0.999f)
+                {
+                    _blendedRightHand.Position = _rightHand.Position;
+                    _blendedRightHand.Rotation = _rightHand.Rotation;
+                }
+                else if (_rightHandBlendRate < 0.001f)
+                {
+                    _blendedRightHand.Position = DownHand.RightHand.Position;
+                    _blendedRightHand.Rotation = DownHand.RightHand.Rotation;
+                }
+                else
+                {
+                    var rate = Mathf.SmoothStep(0, 1, _rightHandBlendRate);
+                    _blendedRightHand.Position = Vector3.Lerp(
+                        DownHand.RightHand.Position, _rightHand.Position, rate
+                        );
+                    _blendedRightHand.Rotation = Quaternion.Slerp(
+                        DownHand.RightHand.Rotation, _rightHand.Rotation, rate
+                        );
+                }
+            }
+        }
+
         private IEnumerator KeyDownRoutine(IKTargets target, Vector3 targetPos)
         {
             bool isLeftHand = (target == IKTargets.LHand);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
@@ -16,6 +16,9 @@ namespace Baku.VMagicMirror
         //手を正面方向に向くよう補正するファクター。1に近いほど手が正面向きになる
         private const float WristForwardFactor = 0.5f;
 
+        //NOTE: HandIkIntegratorから初期化で入れてもらう
+        public AlwaysDownHandIkGenerator DownHand { get; set; } 
+
         #region settings (WPFから飛んでくる想定のもの)
 
         /// <summary>手首から指先までの距離[m]。キーボードを打ってる位置をそれらしく補正するために使う。</summary>
@@ -26,6 +29,9 @@ namespace Baku.VMagicMirror
 
         /// <summary>打鍵直後のキーボードに対する手のY方向オフセット[m]。</summary>
         public float YOffsetAfterKeyDown { get; set; } = 0.02f;
+
+        /// <summary> 一定時間タイピングしなかった場合に手降ろし姿勢に遷移すべきかどうか </summary>
+        public bool EnableHandDownTimeout { get; set; } = true;
 
         #endregion
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Receiver/MotionSettingReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Receiver/MotionSettingReceiver.cs
@@ -36,6 +36,10 @@ namespace Baku.VMagicMirror
                 message => handIkIntegrator.AlwaysHandDownMode = message.ToBoolean()
                 );
             receiver.AssignCommandHandler(
+                VmmCommands.EnableTypingHandDownTimeout,
+                message => handIkIntegrator.EnableHandDownTimeout = message.ToBoolean()
+                );
+            receiver.AssignCommandHandler(
                 VmmCommands.LengthFromWristToTip,
                 message => SetLengthFromWristToTip(message.ParseAsCentimeter())
                 );

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -49,6 +49,7 @@ namespace Baku.VMagicMirror
         // Motion, Arm
         public const string EnableHidRandomTyping = nameof(EnableHidRandomTyping);
         public const string EnableShoulderMotionModify = nameof(EnableShoulderMotionModify);
+        public const string EnableTypingHandDownTimeout = nameof(EnableTypingHandDownTimeout);
         public const string SetWaistWidth = nameof(SetWaistWidth);
         public const string SetElbowCloseStrength = nameof(SetElbowCloseStrength);
         public const string EnableFpsAssumedRightHand = nameof(EnableFpsAssumedRightHand);


### PR DESCRIPTION
#476 

- 「つねに手下げモード」がある事を考慮し、タイムアウトを気持ち長め(15秒)にしてます。
    - 短いパターンだと5秒くらいが妥当ですが、これは「常に手下げモード」でカバーされたUXのはずなのでケアしません。
- コントローラについては手下げしません 