### PR TITLE
ウィンドウ不透明時にOBSで透明チャネル込みっぽい描画になっていたのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
@@ -382,7 +382,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
-  m_BackGroundColor: {r: 0, g: 1, b: 0, a: 0}
+  m_BackGroundColor: {r: 0, g: 1, b: 0, a: 1}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0


### PR DESCRIPTION
恐らくWPF側のリファクタでデグレってたと見られるので、それの修正です…

…が、本来WPF側の変更影響は受けなさそうな箇所だったので謎…