### PR TITLE
FPS半減オプションの追加

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -600,6 +600,12 @@ namespace Baku.VMagicMirror
                 return false;
             }
 
+            //NOTE: ペンタブモードの場合、ペンを持った右手+左手(キーボード上であることが多い)のいずれも降ろさせない。
+            if (right == HandTargetType.PenTablet)
+            {
+                return false;
+            }
+
             bool leftHandIsReady = left != HandTargetType.Keyboard || typing.LeftHandTimeOutReached;
 
             bool rightHandIsReady =

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/TypingHandIKGenerator.cs
@@ -510,7 +510,7 @@ namespace Baku.VMagicMirror.IK
             {
                 _parent = parent;
                 Hand = hand;
-                _data = hand == ReactedHand.Right ? _parent._rightHand : _parent._leftHand;
+                _data = hand == ReactedHand.Right ? _parent._blendedRightHand : _parent._blendedLeftHand;
             }
 
             private readonly TypingHandIKGenerator _parent;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -126,6 +126,7 @@ namespace Baku.VMagicMirror
 
         // Image Quality
         public const string SetImageQuality = nameof(SetImageQuality);
+        public const string SetHalfFpsMode = nameof(SetHalfFpsMode);
 
         // Lighting 
         public const string LightIntensity = nameof(LightIntensity);


### PR DESCRIPTION
#542 の対応PRです。

## メインの改修

issueにコメントしたとおりの方針で改修しました。

- 設定ウィンドウのEffectタブにFPS半減のオン/オフ設定を追加。デフォルトはオフ
- QualityでVery LowまたはLowを選択している場合、上記オプションと無関係にVSync Countが0(syncなし)、かつ30FPS
- QualityがMedium以上の場合、FPS半減がオンならVSync Countが2になり、オフならば1になる

※参考程度にボツにした択も書いておきます。

- FPSが120を超えているのを検出して勝手にVSync Countを上げる → バグると嫌
- Thread.Sleepをうまく使って明示的に60FPSを取りに行く → ティアリングが解決しない

## ついでに行ったfix

- #540 のデグレでキーボード打鍵が止まったときに手を降ろさなくなっていたのを修正しました。
- 上記で修正した手おろしモーションに関し、 #540 で追加したペンタブモーション中に左手がキーボード上にある場合、手を降ろさないようにしました。(ペン側の手を降ろさないようになってるのに合わすためです)