### PR TITLE
remove unused image tag

### DIFF
--- a/docs/pages/english/get_started.md
+++ b/docs/pages/english/get_started.md
@@ -228,7 +228,6 @@ When you are confused where avatar is, press `Reset position` to recover the sit
 
 <div class="row">
 {% include docimg.html file="./images/get_started/img00_130_free_camera_mode.jpg" customclass="col s12 m6" imgclass="fit-doc-img" %}
-{% include docimg.html file="./images/get_started/img00_140_after_free_camera_mode.jpg" customclass="col s12 m6" imgclass="fit-doc-img" %}
 </div>
 
 During this setup you can use `Quick Save` and `Quick Load` buttons to save or load the point of view.

--- a/docs/pages/japanese/get_started.md
+++ b/docs/pages/japanese/get_started.md
@@ -239,7 +239,6 @@ Webブラウザが開くため、指示に従ってアプリ連携を完了し�
 
 <div class="row">
 {% include docimg.html file="./images/get_started/img00_130_free_camera_mode.jpg" customclass="col s12 m6" imgclass="fit-doc-img" %}
-{% include docimg.html file="./images/get_started/img00_140_after_free_camera_mode.jpg" customclass="col s12 m6" imgclass="fit-doc-img" %}
 </div>
 
 また、`クイックセーブ`ボタンで現在の視点を保存したり、`クイックロード`の対応するボタンでロードしたりできます。


### PR DESCRIPTION
Get Startedのフリーカメラモードの項目について、
廃止したつもりの画像の表示行が残ってしまっていたのを削除しました。

