### PR TITLE
キーボードの右側にDeformerが効かなくなっていたのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/Keyboard.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/Keyboard.prefab
@@ -184,8 +184,6 @@ MonoBehaviour:
   deformerElements:
   - component: {fileID: 3905114142533524313}
     active: 1
-  - component: {fileID: 7101327344086615180}
-    active: 1
   customBounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
@@ -202,6 +200,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rightHandMeshRenderer: {fileID: 8836747988117461312}
+  rightHandMeshMagnetDeformer: {fileID: 7101327344086615180}
 --- !u!1 &2203339930315778652
 GameObject:
   m_ObjectHideFlags: 0
@@ -214,6 +213,7 @@ GameObject:
   - component: {fileID: 3247404649506311938}
   - component: {fileID: 8836747988117461312}
   - component: {fileID: 7101327344086615180}
+  - component: {fileID: 7167361394568199743}
   m_Layer: 0
   m_Name: Keyboard_RightSide
   m_TagString: Untagged
@@ -298,3 +298,33 @@ MonoBehaviour:
   factor: 0
   falloff: 0.5
   center: {fileID: 0}
+--- !u!114 &7167361394568199743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2203339930315778652}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85212d1b13358614ca54e74ba56f93ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assignOriginalMeshOnDisable: 1
+  updateMode: 0
+  normalsRecalculation: 0
+  boundsRecalculation: 0
+  colliderRecalculation: 0
+  meshCollider: {fileID: 0}
+  data:
+    OriginalMesh: {fileID: 0}
+    Target:
+      meshFilter: {fileID: 3247404649506311938}
+      skinnedMeshRenderer: {fileID: 0}
+    initialized: 0
+  deformerElements:
+  - component: {fileID: 7101327344086615180}
+    active: 1
+  customBounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/PenTablet.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/PenTablet.prefab
@@ -142,7 +142,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   update: 1
-  factor: 0
+  factor: 1
   falloff: 0.5
   center: {fileID: 8074230364789003342}
 --- !u!114 &6206299127056181281

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceVisibilityBase.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceVisibilityBase.cs
@@ -39,13 +39,25 @@ namespace Baku.VMagicMirror
         {
         }
 
+        /// <summary>
+        /// Deformerの値をDOTweenで更新しているとき呼ばれます。0-1の範囲の値で、0は表示、1は非表示です。
+        /// </summary>
+        /// <param name="v"></param>
+        protected virtual void OnSetMagnetDeformerValue(float v)
+        {
+        }
+
         public void SetVisibility(bool visible)
         {
             _latestVisibility = visible;
             DOTween
                 .To(
                     () => _deformer.Factor, 
-                    v => _deformer.Factor = v, 
+                    v =>
+                    {
+                        _deformer.Factor = v;
+                        OnSetMagnetDeformerValue(v);
+                    }, 
                     visible ? 0.0f : 1.0f, 
                     0.5f)
                 .SetEase(Ease.OutCubic)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceVisibilityBase.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceVisibilityBase.cs
@@ -16,6 +16,11 @@ namespace Baku.VMagicMirror
         private bool _latestVisibility = true;
         public bool IsVisible => _latestVisibility;
 
+        /// <summary>
+        /// <see cref="OnStart"/>以降で参照可能な、メインのレンダラーを取得します。
+        /// </summary>
+        protected Renderer MainRenderer => _renderer;
+
         private void Start()
         {
             _deformer = GetComponent<MagnetDeformer>();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/KeyboardVisibility.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/KeyboardVisibility.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Deform;
+using UnityEngine;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -11,11 +12,17 @@ namespace Baku.VMagicMirror
     {
         //NOTE: MeshRendererは
         [SerializeField] private MeshRenderer rightHandMeshRenderer = null;
+        [SerializeField] private MagnetDeformer rightHandMeshMagnetDeformer = null;
         private KeyboardAndMouseMotionModes _motionModes = KeyboardAndMouseMotionModes.KeyboardAndTouchPad;
 
         protected override void OnRendererEnableUpdated(bool enable)
         {
             rightHandMeshRenderer.enabled = enable;
+        }
+
+        protected override void OnSetMagnetDeformerValue(float v)
+        {
+            rightHandMeshMagnetDeformer.Factor = v;
         }
 
         [Inject]

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenTabletVisibility.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenTabletVisibility.cs
@@ -4,6 +4,8 @@
     {
         protected override void OnStart()
         {
+            //NOTE: 明示的に非表示にすることで、起動直後に見えてしまうのを防ぐ
+            MainRenderer.enabled = false;
             SetVisibility(false);
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/MidiInput/MidiControllerVisibility.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/MidiInput/MidiControllerVisibility.cs
@@ -35,6 +35,15 @@ namespace Baku.VMagicMirror
             {
                 deformable.AddDeformer(_deformer);
             }
+            
+            //NOTE: 1フレーム目のRenderの時点でMIDIコンを非表示にするため、直接Rendererを切る
+            _renderer.enabled = false;
+            foreach (var knob in _knobRenderers)
+            {
+                knob.enabled = false;
+            }
+            
+            //Deformerのアニメーションを効かせるため、こっちはこっちでやる
             SetVisibility(false);
         }
 


### PR DESCRIPTION
### メイン

#554 : cd0951e

### ついで

起動直後の「MIDIコンとペンタブのメッシュが映ってから非表示アニメーションが走る」というシーケンスを修正し、初回のレンダリング時点で表示されない(=これらのメッシュは初期状態を明示的に非表示にする)ようにしました。


facf7f0