### PR TITLE
Fix link to hand tracking (english)

### DIFF
--- a/docs/pages/english/docs/hand_tracking.md
+++ b/docs/pages/english/docs/hand_tracking.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Hand Tracking
-permalink: /en/docs/using_hand_tracking
+permalink: /en/docs/hand_tracking
 lang_prefix: /en/
 ---
 


### PR DESCRIPTION
英語版ハンドトラッキングページのパーマリンクが間違ってました…