### PR TITLE
アーケードスティックで指の割当が不適切だったのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ArcadeStickFingerController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ArcadeStickFingerController.cs
@@ -95,11 +95,12 @@ namespace Baku.VMagicMirror
                     return FingerConsts.RightIndex;
                 case GamepadKey.Y:
                     return FingerConsts.RightMiddle;
-                case GamepadKey.LShoulder:
-                case GamepadKey.LTrigger:
-                    return FingerConsts.RightRing;
+                //RとLに注意: アーケードスティックはRが左側、Lが右側にある
                 case GamepadKey.RShoulder:
                 case GamepadKey.RTrigger:
+                    return FingerConsts.RightRing;
+                case GamepadKey.LShoulder:
+                case GamepadKey.LTrigger:
                     return FingerConsts.RightLittle;
                 default:
                     return -1;


### PR DESCRIPTION
#595 

#574 ではprefab上のボタン配置しか修正しておらず指の割り当てが直っていなかった、というのを修正してます