### PR TITLE
Unityバージョンを2020.3.8f1まで引き下げ

### DIFF
--- a/VMagicMirror/ProjectSettings/ProjectVersion.txt
+++ b/VMagicMirror/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.11f1
-m_EditorVersionWithRevision: 2020.3.11f1 (99c7afb366b3)
+m_EditorVersion: 2020.3.8f1
+m_EditorVersionWithRevision: 2020.3.8f1 (507919d4fff5)


### PR DESCRIPTION
#608 の対策です。ダウングレード、やりたくなかった…

- 手トラッキングには支障なし
- 他はバージョン差にそこまでセンシティブではなさそう
- 以前2019→2020に上げたときの差分がコレなので、ダウングレードしても比較的安全そう

https://github.com/malaybaku/VMagicMirror/commit/5e0f7df804b0a6945de297012b60e7c92714adec#diff-76ba6ea85cf42c12a7157c5b73efd2a6a9a7a9f845d595c5f5238b2cd0dd5732