### PR TITLE
VRMロード時にペンが利用可能なモデルかどうかをWPFに通知する

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
@@ -40,9 +40,12 @@ namespace Baku.VMagicMirror
         
         private TweenerCore<Vector3, Vector3, VectorOptions> _tweener;
 
+        private IMessageSender _sender;
+
         [Inject]
-        public void Initialize(IMessageReceiver receiver, IVRMLoadable vrmLoadable)
+        public void Initialize(IMessageReceiver receiver, IMessageSender sender, IVRMLoadable vrmLoadable)
         {
+            _sender = sender;
             receiver.AssignCommandHandler(
                 VmmCommands.SetPenVisibility,
                 message => SetDeviceVisibility(message.ToBoolean())
@@ -55,6 +58,7 @@ namespace Baku.VMagicMirror
                 _rightThumbIntermediate = info.animator.GetBoneTransform(HumanBodyBones.RightThumbDistal);
                 _hasValidFinger = (_rightIndexProximal != null && _rightThumbIntermediate != null);
                 _hasModel = true;
+                _sender.SendCommand(MessageFactory.Instance.SetModelDoesNotSupportPen(!_hasValidFinger));
             };
 
             vrmLoadable.VrmDisposing += () =>
@@ -64,6 +68,8 @@ namespace Baku.VMagicMirror
                 _rightWrist = null;
                 _rightIndexProximal = null;
                 _rightThumbIntermediate = null;
+                //モデルがロードされてないならサポート外警告は不要、とする。分かりやすいので
+                _sender.SendCommand(MessageFactory.Instance.SetModelDoesNotSupportPen(false));
             };
 
             penMesh.enabled = false;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
@@ -46,6 +46,9 @@ namespace Baku.VMagicMirror
         public Message ExTrackerSetIFacialMocapTroubleMessage(string message) => WithArg(message);
 
         public Message SetHandTrackingResult(string json) => WithArg(json);
+
+        //普通falseになるようにするため、ちょっと変な言い回しにしてます
+        public Message SetModelDoesNotSupportPen(bool doesNotSupport) => WithArg($"{doesNotSupport}");
         
         #region VRoid
 


### PR DESCRIPTION
https://github.com/malaybaku/VMagicMirror/issues/633

UIの表示判定に必要な情報を送りつける処理です
