### PR TITLE
Get Startedのバージョン別説明がいくつか不適切だったのを修正

### DIFF
--- a/docs/pages/english/get_started.md
+++ b/docs/pages/english/get_started.md
@@ -32,14 +32,14 @@ Note that, this video refers older version, so some GUI has changed.
 ### 1. Start and Load Character
 {: .doc-sec1 }
 
-First step depends on the version of VMagicMirror you have.
+First step depends on the version of `VMagicMirror` you have.
 
 Please see one of following sections `1-1. Start v1.9.0 or later version` or `1-2. Start v1.8.2 or older version`.
 
 #### 1-1. Start v1.9.0 or later version
 {: .doc-sec2 }
 
-Newer version of VMagicMirror is distributed with the form of installer (.exe) file, so just run the file to install it.
+Newer version of `VMagicMirror` is distributed with the form of installer (.exe) file, so just run the file to install it. After the installation, launch `VMagicMirror` from shortcut, or search in start menu to launch.
 
 <div class="note-area" markdown="1">
 
@@ -57,7 +57,7 @@ Installer run might be blocked by Windows system. In this case, right click inst
 #### 1-2. Start v1.8.2 or older version
 {: .doc-sec2 }
 
-Unzip the distributed file and start `VMagicMirror.exe`.
+Unzip the distributed file and start `VMagicMirror.exe` in the folder.
 
 <div class="note-area" markdown="1">
 

--- a/docs/pages/japanese/get_started.md
+++ b/docs/pages/japanese/get_started.md
@@ -36,8 +36,10 @@ permalink: /get_started
 #### 1-1. v1.9.0以降のバージョンの場合
 {: .doc-sec2 }
 
-v1.9.0以降ではインストーラー形式でVMagicMirrorを配布しています。
+v1.9.0以降ではインストーラー形式で`VMagicMirror`を配布しています。
 ダウンロードしたインストーラファイルをダブルクリックで実行し、指示に従ってインストールします。
+
+インストール後、スタートメニューやデスクトップショートカット等から`VMagicMirror`を実行します。
 
 <div class="note-area" markdown="1">
 
@@ -57,7 +59,7 @@ v1.9.0以降ではインストーラー形式でVMagicMirrorを配布してい�
 #### 1-2. v1.8.2以前のバージョンの場合
 {: .doc-sec2 }
 
-zipファイルを解凍し、適当なフォルダに配置します。
+zipファイルを解凍し、適当なフォルダに配置したのちフォルダ内の`VMagicMirror.exe`を実行します。
 
 <div class="note-area" markdown="1">
 


### PR DESCRIPTION
- exeが起動するまでの手順として完全でなかったので、説明に抜けがないよう修正
- 「起動するとウィンドウが2個出るよ」、という説明がv1.8.2以前のバージョンのみを指すセクション内に入ってしまっていたのを修正