### PR TITLE
ウィンドウ背景色を変更したときウィンドウサイズがキープされるようにする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -332,17 +332,14 @@ namespace Baku.VMagicMirror
         
         private void ForceWindowResizeEvent()
         {
-            //NOTE: リサイズ処理は「ズラしてから元に戻す」方式で呼ぶと透過→不透過の切り替え時に画像が歪むのを防げるため、
-            //わざと2回呼ぶようにしてます
             if (!GetWindowRect(GetUnityWindowHandle(), out var rect))
             {
                 return;
             }
 
+            //明示的に同じウィンドウサイズで再初期化することで、画像が歪むのを防ぐ
             int cx = rect.right - rect.left;
             int cy = rect.bottom - rect.top;
-            
-            RefreshWindowSize(cx - 1, cy - 1);
             RefreshWindowSize(cx, cy);
         }
         


### PR DESCRIPTION
#662 のfix

理屈は良く分からないが

- Unity 2020系で挙動が変わったか、あるいはWindows 10の挙動が変わったとの組み合わさってなにか起きた可能性も(かなり低いが一応)ありそう
- 2回リサイズを呼び出したとき、1回目の結果だけが残る事があるように見えた

という感じだったため、1回だけ呼ぶ方式に修正。

従来のbug fixにも配慮しつつ、以下を確認。

- 背景色をいじってもウィンドウが縮まない
- 透過のオンオフを何度か繰り返してウィンドウサイズがおかしくならない、かつモデルの縦横が歪まない
- 透過オンの設定何回か再起動したとき、ウィンドウサイズがおかしくならない、かつモデルの縦横が歪まない
