### PR TITLE
ステレオのマイクで正しくリップシンク出来るようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ sysinfo.txt
 /VMagicMirror/Assets/MeshUtility/
 /VMagicMirror/Assets/MiscAssets/
 /VMagicMirror/Assets/uWindowCapture/
+/VMagicMirror/Assets/NuGet/
+/VMagicMirror/Assets/NuGetPackages/
 
 /VMagicMirror/Assets/AniLipSync-VRM.meta
 /VMagicMirror/Assets/OpenCVforUnity.meta
@@ -91,6 +93,8 @@ sysinfo.txt
 /VMagicMirror/Assets/MiscAssets.meta
 /VMagicMirror/Assets/uWindowCapture.meta
 /VMagicMirror/uWindowCapture.log
+/VMagicMirror/Assets/NuGet.meta
+/VMagicMirror/Assets/NuGetPackages.meta
 
 # Assets to ignore (from BOOTH)
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ Unity 2020.3系でUnityプロジェクト(本レポジトリの`VMagicMirror`フ
 * [Fly,Baby. ver1.2](https://nanakorobi-hi.booth.pm/items/1629266)
 * [LaserLightShader](https://noriben.booth.pm/items/2141514)
 * [VMagicMirror_MotionExporter](https://github.com/malaybaku/VMagicMirror_MotionExporter)
+* [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity)
 
 FinalIK, Dlib FaceLandmark Detector, OpenCV for Unityの3つは有償アセットであることに注意してください。
+
+[NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity)は[NAudio](https://github.com/naudio/NAudio)を導入するために使用しています。
 
 "Fly,Baby." および "LaserLightShader"はBOOTHで販売されているアセットで、ビルドに必須ではありませんが、もし導入しない場合、タイピング演出が一部動かなくなります。
 

--- a/README_en.md
+++ b/README_en.md
@@ -80,8 +80,11 @@ Maintainer's environment is as following.
 * [Fly,Baby. ver1.2](https://nanakorobi-hi.booth.pm/items/1629266)
 * [LaserLightShader](https://noriben.booth.pm/items/2141514)
 * [VMagicMirror_MotionExporter](https://github.com/malaybaku/VMagicMirror_MotionExporter)
+* [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity)
 
 Should be noted that `FinalIK`, `Dlib FaceLandmark Detector`, and `OpenCV for Unity` are paid assets.
+
+[NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity) is necessary to import [NAudio](https://github.com/naudio/NAudio).
 
 "Fly,Baby." and "LaserLightShader" are available on BOOTH, and they are optional. If you do not introduce them, some of typing effects will not work correctly.
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
@@ -53,7 +53,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   blendShapeInitializer: {fileID: 7797473119978373343}
-  lipSyncContext: {fileID: 3748904030990320927}
+  lipSyncContext: {fileID: 8501418776315766171}
   lipSyncIntegrator: {fileID: 6125060425342205146}
   autoBlink: {fileID: 2335327280039312852}
 --- !u!114 &3748028266611161169
@@ -121,8 +121,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1655d29d03fb30b4fb5fc956ffc2db19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  vroidDefaultBlendShapeAvatar: {fileID: 11400000, guid: cc041bf064933304d942a9e7bc39a2b5,
-    type: 2}
 --- !u!114 &6241239198292537160
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -256,7 +254,6 @@ MonoBehaviour:
   headRotBlinkProbability: 0.6
   eyeRotBlinkSpeedThreshold: 18
   eyeRotBlinkProbability: 0.8
-  lipSyncContext: {fileID: 3748904030990320927}
   lipSyncVisemeThreshold: 0.2
   lipSyncOnCountThreshold: 10
   lipSyncOffCountThreshold: 2
@@ -332,7 +329,7 @@ GameObject:
   - component: {fileID: 6125060425342205146}
   - component: {fileID: 3748028265945039283}
   - component: {fileID: 5008622417410694531}
-  - component: {fileID: 3748904030990320927}
+  - component: {fileID: 8501418776315766171}
   m_Layer: 0
   m_Name: MouthController
   m_TagString: Untagged
@@ -529,7 +526,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bsMin: 0.15
   bsMax: 0.6
---- !u!114 &3748904030990320927
+--- !u!114 &8501418776315766171
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -538,7 +535,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3748904030990320353}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1e11b3103e37dbd4ab4a720515e75d1a, type: 3}
+  m_Script: {fileID: 11500000, guid: a59b24c8725f3124b96c84d8ff8f0ff4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   audioSource: {fileID: 0}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncReceiver.cs
@@ -10,7 +10,7 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class LipSyncReceiver : MonoBehaviour
     {
-        private DeviceSelectableLipSyncContext _lipSyncContext;
+        private VmmLipSyncContextBase _lipSyncContext;
         private AnimMorphEasedTarget _animMorphEasedTarget;
         private LipSyncIntegrator _lipSyncIntegrator;
         
@@ -55,7 +55,7 @@ namespace Baku.VMagicMirror
         
         private void Start()
         {
-            _lipSyncContext = GetComponent<DeviceSelectableLipSyncContext>();
+            _lipSyncContext = GetComponent<VmmLipSyncContextBase>();
             _animMorphEasedTarget = GetComponent<AnimMorphEasedTarget>();
             _lipSyncIntegrator = GetComponent<LipSyncIntegrator>();
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncReceiver.cs
@@ -49,7 +49,9 @@ namespace Baku.VMagicMirror
             );
             receiver.AssignQueryHandler(
                 VmmQueries.MicrophoneDeviceNames,
-                query => query.Result = DeviceNames.CreateDeviceNamesJson(Microphone.devices)
+                query => query.Result = DeviceNames.CreateDeviceNamesJson(
+                    _lipSyncContext.GetAvailableDeviceNames()
+                    )
             );
         }
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
@@ -42,7 +42,7 @@ namespace Baku.VMagicMirror
             IMessageReceiver receiver,
             IVRMLoadable vrmLoadable,
             FaceTracker faceTracker,
-            DeviceSelectableLipSyncContext lipSync
+            VmmLipSyncContextBase lipSyncContext
             )
         {
             _faceTracker = faceTracker;
@@ -51,7 +51,7 @@ namespace Baku.VMagicMirror
                 VmmCommands.EnableVoiceBasedMotion,
                 command => _operationEnabled = command.ToBoolean());
 
-            _voiceOnOffParser = new VoiceOnOffParser(lipSync)
+            _voiceOnOffParser = new VoiceOnOffParser(lipSyncContext)
             {
                 //そこそこちゃんと喋ってないと検出しない、という設定のつもり
                 VisemeThreshold = 0.2f,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Unity.Mathematics;
 using UnityEngine;
 using Zenject;
 
@@ -13,48 +12,15 @@ namespace Baku.VMagicMirror
         //この回数だけマイク音声の読み取り位置が変化しない状態が継続した場合、自動でマイクの再起動を試みる
         private const int PositionStopCountLimit = 120;
 
-        //この値(dB)から+50dBまでの範囲を0 ~ 50のレベル情報として通知する。適正音量の目安になる値。
-        private const int BottomVolumeDb = -38;
-
-        //ボリューム情報は数フレームに1回送ればいいよね、という値
-        private const int SendVolumeLevelSkip = 2;
-        //ボリュームが急に下がった場合は実際の値ではなく、直前フレームからこのdB値だけ落とした値をWPFに通知する
-        private const int LevelDecreasePerRefresh = 1;
-        
         private readonly float[] _processBuffer = new float[1024];
         private readonly float[] _microphoneBuffer = new float[LengthSeconds * SamplingFrequency];
         
-        private IMessageSender _sender;
-        private bool _sendMicrophoneVolumeLevel = false;
-        private int _volumeLevelSendCount = 0;
-        //ボリューム値を記憶する。よくある「ガッと上がってスーッと下がる」をやるために必要。
-        private int _currentVolumeLevel = 0;
-        
+        private bool _isRecording;
         private AudioClip _clip;
         private int _head = 0;
 
         private int _prevPosition = -1;
         private int _positionNotMovedCount = 0;
-
-        private int _sensitivity = 0;
-        
-        private float _sensitivityFactor = 1f;
-        /// <summary> マイク感度を[dB]単位で取得、設定します。 </summary>
-        public override int Sensitivity
-        {
-            get => _sensitivity;
-            set
-            {
-                if (_sensitivity == value)
-                {
-                    return;
-                }
-                _sensitivity = value;
-                _sensitivityFactor = Mathf.Pow(10f, Sensitivity * 0.1f);
-            }
-        }
-
-        public bool IsRecording { get; private set; } = false;
 
         private string _deviceName = "";
         public override string DeviceName => _deviceName;
@@ -64,23 +30,12 @@ namespace Baku.VMagicMirror
         [Inject]
         public void Initialize(IMessageReceiver receiver, IMessageSender sender)
         {
-            receiver.AssignCommandHandler(
-                VmmCommands.SetMicrophoneVolumeVisibility,
-                message =>
-                {
-                    _sendMicrophoneVolumeLevel = bool.TryParse(message.Content, out var v) && v;
-                    if (!_sendMicrophoneVolumeLevel)
-                    {
-                        _volumeLevelSendCount = 0;
-                        _currentVolumeLevel = 0;
-                    }
-                });
-            _sender = sender;
+            InitializeMessageIo(receiver, sender);
         }
         
         public override void StartRecording(string deviceName)
         {
-            if (IsRecording || !Microphone.devices.Contains(deviceName))
+            if (_isRecording || !Microphone.devices.Contains(deviceName))
             {
                 return;
             }
@@ -91,23 +46,23 @@ namespace Baku.VMagicMirror
                 _microphoneBuffer[i] = 0;
             }
             _clip = Microphone.Start(deviceName, true, LengthSeconds, SamplingFrequency);
-            IsRecording = true;
+            _isRecording = true;
             _deviceName = deviceName;
         }
 
         public override void StopRecording()
         {
-            if (IsRecording)
+            if (_isRecording)
             {
                 Microphone.End(DeviceName);
-                IsRecording = false;
+                _isRecording = false;
                 _deviceName = "";
             }
         }
 
         private void Update()
         {
-            if (!IsRecording)
+            if (!_isRecording)
             {
                 return;
             }
@@ -151,17 +106,8 @@ namespace Baku.VMagicMirror
                     Array.Copy(_microphoneBuffer, _head, _processBuffer, 0, _processBuffer.Length);
                 }
 
-                ApplySensitivityToProcessBuffer();
-                if (_sendMicrophoneVolumeLevel)
-                {
-                    _volumeLevelSendCount++;
-                    if (_volumeLevelSendCount >= SendVolumeLevelSkip)
-                    {
-                        _volumeLevelSendCount = 0;
-                        UpdateVolumeLevelOnBuffer();
-                        _sender.SendCommand(MessageFactory.Instance.MicrophoneVolumeLevel(_currentVolumeLevel));
-                    }
-                }
+                ApplySensitivityToProcessBuffer(_processBuffer);
+                SendVolumeLevelIfNeeded(_processBuffer);
                 OVRLipSync.ProcessFrame(Context, _processBuffer, Frame);
 
                 _head += _processBuffer.Length;
@@ -176,7 +122,7 @@ namespace Baku.VMagicMirror
         private void RestartMicrophone()
         {
             Microphone.End(DeviceName);
-            IsRecording = false;
+            _isRecording = false;
             if (Microphone.devices.Contains(DeviceName))
             {
                 Debug.Log("Restart Microphone Success: " + DeviceName);
@@ -187,42 +133,6 @@ namespace Baku.VMagicMirror
                 Debug.Log("Restart Microphone Failed: " + DeviceName);
             }
         }
-        
-        //マイク感度が0dB以外の場合、値を調整します。
-        private void ApplySensitivityToProcessBuffer()
-        {
-            if (Sensitivity == 0)
-            {
-                return;
-            }
-            
-            //ここ遅かったらヤダな～というポイント
-            for (int i = 0; i < _processBuffer.Length; i++)
-            {
-                //NOTE: clampしないでもOVRLipSyncは動くのでclampしないでいい
-                _processBuffer[i] *= _sensitivityFactor;
-            }
-        }
 
-        //バッファに載ってる音に対してゲインを0 ~ 50の数値に変換したものを計算してデータを更新する。
-        private void UpdateVolumeLevelOnBuffer()
-        {
-            //NOTE: この方法はちょっと桁落ちとかのリスクあるんだけど、そんなにシビアな計算じゃないのでザツにやる
-            float sum = 0;
-            for (int i = 0; i < _processBuffer.Length; i++)
-            {
-                sum += _processBuffer[i] * _processBuffer[i];
-            }
-            
-            float mean = sum / _processBuffer.Length;
-            float meanDb = Mathf.Log10(mean) * 10f;
-            int rawResult = Mathf.Clamp((int)(meanDb - BottomVolumeDb), 0, 50);
-            _currentVolumeLevel = Mathf.Max(rawResult, _currentVolumeLevel - LevelDecreasePerRefresh);
-        }
-
-        static int GetDataLength(int bufferLength, int head, int tail) 
-            => (head < tail) 
-                ? (tail - head) 
-                : (bufferLength - head + tail);
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
@@ -5,7 +5,7 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
-    public class DeviceSelectableLipSyncContext : VmmLipSyncContextBase // OVRLipSyncContextBase
+    public class DeviceSelectableLipSyncContext : VmmLipSyncContextBase
     {
         private const int SamplingFrequency = 48000;
         private const int LengthSeconds = 1;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/DeviceSelectableLipSyncContext.cs
@@ -6,7 +6,7 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
-    public class DeviceSelectableLipSyncContext : OVRLipSyncContextBase
+    public class DeviceSelectableLipSyncContext : VmmLipSyncContextBase // OVRLipSyncContextBase
     {
         private const int SamplingFrequency = 48000;
         private const int LengthSeconds = 1;
@@ -40,7 +40,7 @@ namespace Baku.VMagicMirror
         
         private float _sensitivityFactor = 1f;
         /// <summary> マイク感度を[dB]単位で取得、設定します。 </summary>
-        public int Sensitivity
+        public override int Sensitivity
         {
             get => _sensitivity;
             set
@@ -55,8 +55,12 @@ namespace Baku.VMagicMirror
         }
 
         public bool IsRecording { get; private set; } = false;
-        public string DeviceName { get; private set; } = "";
 
+        private string _deviceName = "";
+        public override string DeviceName => _deviceName;
+
+        public override string[] GetAvailableDeviceNames() => Microphone.devices;
+        
         [Inject]
         public void Initialize(IMessageReceiver receiver, IMessageSender sender)
         {
@@ -74,7 +78,7 @@ namespace Baku.VMagicMirror
             _sender = sender;
         }
         
-        public void StartRecording(string deviceName)
+        public override void StartRecording(string deviceName)
         {
             if (IsRecording || !Microphone.devices.Contains(deviceName))
             {
@@ -88,16 +92,16 @@ namespace Baku.VMagicMirror
             }
             _clip = Microphone.Start(deviceName, true, LengthSeconds, SamplingFrequency);
             IsRecording = true;
-            DeviceName = deviceName;
+            _deviceName = deviceName;
         }
 
-        public void StopRecording()
+        public override void StopRecording()
         {
             if (IsRecording)
             {
                 Microphone.End(DeviceName);
                 IsRecording = false;
-                DeviceName = "";
+                _deviceName = "";
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs
@@ -1,0 +1,189 @@
+using System;
+using NAudio.Wave;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    public class NAudioLipSyncContext : VmmLipSyncContextBase
+    {
+        //ほぼ全ての環境でアップサンプリングになる
+        private const int SampleRate = 48000;
+        //byte[]がこの長さになると0.5sec分のバッファになる
+        private const int BufferLength = 96000;
+        private WaveInEvent _waveIn = null;
+        private string _deviceName = "";
+        public override string DeviceName => _deviceName;
+
+        private int _processBufferIndex = 0;
+        private readonly float[] _processBuffer = new float[1024];
+
+        //NOTE: 1秒分のリングバッファにしたうえで音に対するズレは許容する
+        private readonly object _bufferLock = new object();
+        private int _writeIndex = 0;
+        private int _readIndex = 0;
+        private readonly byte[] _buffer = new byte[BufferLength];
+        private readonly byte[] _bufferOnRead = new byte[BufferLength];
+
+        [Inject]
+        public void Initialize(IMessageReceiver receiver, IMessageSender sender)
+            => InitializeMessageIo(receiver, sender);
+        
+        private void Update()
+        {
+            if (_waveIn == null)
+            {
+                return;
+            }
+
+            int writeIndex = 0;
+            lock (_bufferLock)
+            {
+                //読み込んでもProcessFrameする分量じゃない = 放置
+                if (GetDataLength(BufferLength, _readIndex, _writeIndex) < _processBuffer.Length * 2)
+                {
+                    return;
+                }
+
+                //ちょっと贅沢だが、lockしてる行を狭くしたいのでガッとコピーしてしまう
+                Array.Copy(_buffer, _bufferOnRead, _buffer.Length);
+                writeIndex = _writeIndex;
+            }
+            ReadBuffer(writeIndex);
+        }
+        
+        public override string[] GetAvailableDeviceNames()
+        {
+            var count = WaveInEvent.DeviceCount;
+            var result = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = WaveInEvent.GetCapabilities(i).ProductName;
+            }
+            return result;
+        }
+
+        public override void StopRecording()
+        {
+            if (_waveIn != null)
+            {
+                _waveIn.DataAvailable -= OnDataAvailable;
+            }
+            _waveIn?.StopRecording();
+            _waveIn?.Dispose();
+            _waveIn = null;
+
+            //このタイミングでlock必須にはなりにくいが念のため。
+            lock (_bufferLock)
+            {
+                _writeIndex = 0;
+                _readIndex = 0;
+            }
+            _deviceName = "";
+        }
+
+        public override void StartRecording(string microphoneName)
+        {
+            if (_deviceName == microphoneName)
+            {
+                return;
+            }
+            
+            StopRecording();
+            int deviceNumber = FindDeviceNumber(microphoneName);
+            if (deviceNumber < 0)
+            {
+                LogOutput.Instance.Write("Microphone with specified name was not detected: " + microphoneName);
+                return;
+            }
+
+            _waveIn = new WaveInEvent()
+            {
+                DeviceNumber = deviceNumber,
+                //0.4secのバッファ: これだけあれば足りるはず…
+                BufferMilliseconds = 16,
+                NumberOfBuffers = 25,
+                WaveFormat = new WaveFormat(SampleRate, 2),
+            };
+            _waveIn.DataAvailable += OnDataAvailable;
+            _waveIn.StartRecording();
+        }
+
+        private void OnDataAvailable(object sender, WaveInEventArgs e)
+        {
+            lock (_bufferLock)
+            {
+                WriteBuffer(e.Buffer, e.BytesRecorded);
+            }
+        }
+
+        private void WriteBuffer(byte[] data, int length)
+        {
+            if (length > _buffer.Length)
+            {
+                //コード上はこうならない想定だが一応。
+                Array.Copy(data, _buffer, _buffer.Length);
+                _writeIndex = 0;
+
+            }
+            else if (_writeIndex + length <= _buffer.Length)
+            {
+                //普通に書ききれる
+                Array.Copy(data, 0, _buffer, _writeIndex, length);
+                _writeIndex += length;
+            }
+            else
+            {
+                //端をまたぐ
+                var tailLength = _buffer.Length - _writeIndex;
+                Array.Copy(data, 0, _buffer, _writeIndex, tailLength);
+                Array.Copy(data, tailLength, _buffer, 0, length - tailLength);
+                _writeIndex = length - tailLength;
+            }
+        }
+
+        private void ReadBuffer(int writeIndex)
+        {
+            //NOTE: どうせbytes -> float変換が挟まるのでもっさりやる。
+            //呼び出し時点で_readIndexもwriteIndexも4の倍数なことが前提になっている点にも注意
+            while (_readIndex != writeIndex)
+            {
+                float c1 = BitConverter.ToSingle(_bufferOnRead, _readIndex);
+                _readIndex += 2;
+                if (_readIndex >= _bufferOnRead.Length)
+                {
+                    _readIndex = 0;
+                }
+                
+                float c2 = BitConverter.ToSingle(_bufferOnRead, _readIndex);
+                _readIndex += 2;
+                if (_readIndex >= _bufferOnRead.Length)
+                {
+                    _readIndex = 0;
+                }
+
+                _processBuffer[_processBufferIndex] = 0.5f * (c1 + c2);
+                _processBufferIndex++;
+                if (_processBufferIndex >= _processBuffer.Length)
+                {
+                    ApplySensitivityToProcessBuffer(_processBuffer);
+                    SendVolumeLevelIfNeeded(_processBuffer);
+                    OVRLipSync.ProcessFrame(Context, _processBuffer, Frame);
+                    _processBufferIndex = 0;
+                }
+            }
+        }
+        
+        private static int FindDeviceNumber(string microphoneName)
+        {
+            int count = WaveInEvent.DeviceCount;
+            for (int i = 0; i < count; i++)
+            {
+                if (WaveInEvent.GetCapabilities(i).ProductName == microphoneName)
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a59b24c8725f3124b96c84d8ff8f0ff4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VmmLipSyncContextBase.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VmmLipSyncContextBase.cs
@@ -1,0 +1,24 @@
+namespace Baku.VMagicMirror
+{
+    public abstract class VmmLipSyncContextBase : OVRLipSyncContextBase
+    {
+        /// <summary>
+        /// [dB]単位で感度を受け取る
+        /// </summary>
+        public virtual int Sensitivity { get; set; }
+        
+        public abstract void StopRecording();
+        public abstract void StartRecording(string microphoneName);
+        
+        /// <summary>
+        /// 現在録音をしていれば録音に使っているデバイス名、そうでなければ空文字列を返します。
+        /// </summary>
+        public abstract string DeviceName { get; }
+
+        /// <summary>
+        /// 利用可能なマイク名の一覧を返します。 
+        /// </summary>
+        /// <returns></returns>
+        public abstract string[] GetAvailableDeviceNames();
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VmmLipSyncContextBase.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VmmLipSyncContextBase.cs
@@ -1,11 +1,41 @@
+using UnityEngine;
+
 namespace Baku.VMagicMirror
 {
     public abstract class VmmLipSyncContextBase : OVRLipSyncContextBase
     {
-        /// <summary>
-        /// [dB]単位で感度を受け取る
-        /// </summary>
-        public virtual int Sensitivity { get; set; }
+        //この値(dB)から+50dBまでの範囲を0 ~ 50のレベル情報として通知する。適正音量の目安になる値。
+        private const int BottomVolumeDb = -38;
+        
+        //ボリューム情報は数フレームに1回送ればいいよね、という値
+        private const int SendVolumeLevelSkip = 2;
+        //ボリュームが急に下がった場合は実際の値ではなく、直前フレームからこのdB値だけ落とした値をWPFに通知する
+        private const int LevelDecreasePerRefresh = 1;
+        
+        private bool _sendMicrophoneVolumeLevel = false;
+        private int _volumeLevelSendCount = 0;
+        //ボリューム値を記憶する。よくある「ガッと上がってスーッと下がる」をやるために必要。
+        private int _currentVolumeLevel = 0;
+        private int _sensitivity = 0;
+        
+        private float _sensitivityFactor = 1f;
+        /// <summary> マイク感度を[dB]単位で取得、設定します。 </summary>
+        public int Sensitivity
+        {
+            get => _sensitivity;
+            set
+            {
+                if (_sensitivity == value)
+                {
+                    return;
+                }
+                _sensitivity = value;
+                _sensitivityFactor = Mathf.Pow(10f, Sensitivity * 0.1f);
+            }
+        }
+        
+        private IMessageSender _sender;
+        
         
         public abstract void StopRecording();
         public abstract void StartRecording(string microphoneName);
@@ -14,11 +44,81 @@ namespace Baku.VMagicMirror
         /// 現在録音をしていれば録音に使っているデバイス名、そうでなければ空文字列を返します。
         /// </summary>
         public abstract string DeviceName { get; }
-
+        
         /// <summary>
         /// 利用可能なマイク名の一覧を返します。 
         /// </summary>
         /// <returns></returns>
         public abstract string[] GetAvailableDeviceNames();
+
+        protected void InitializeMessageIo(IMessageReceiver receiver, IMessageSender sender)
+        {
+            receiver.AssignCommandHandler(
+                VmmCommands.SetMicrophoneVolumeVisibility,
+                message =>
+                {
+                    _sendMicrophoneVolumeLevel = bool.TryParse(message.Content, out var v) && v;
+                    if (!_sendMicrophoneVolumeLevel)
+                    {
+                        _volumeLevelSendCount = 0;
+                        _currentVolumeLevel = 0;
+                    }
+                });
+            _sender = sender;            
+        }
+
+        protected void SendVolumeLevelIfNeeded(float[] buffer)
+        {
+            if (!_sendMicrophoneVolumeLevel)
+            {
+                return;
+            }
+            
+            _volumeLevelSendCount++;
+            if (_volumeLevelSendCount >= SendVolumeLevelSkip)
+            {
+                _volumeLevelSendCount = 0;
+                UpdateVolumeLevel(buffer);
+                _sender.SendCommand(MessageFactory.Instance.MicrophoneVolumeLevel(_currentVolumeLevel));
+            }
+        }
+        
+                
+        //マイク感度が0dB以外の場合、値を調整します。
+        protected void ApplySensitivityToProcessBuffer(float[] buffer)
+        {
+            if (Sensitivity == 0)
+            {
+                return;
+            }
+            
+            //ここ遅かったらヤダな～というポイント
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                //NOTE: clampしないでもOVRLipSyncは動くのでclampしないでいい
+                buffer[i] *= _sensitivityFactor;
+            }
+        }
+
+        //バッファに載ってる音に対してゲインを0 ~ 50の数値に変換したものを計算してデータを更新する。
+        private void UpdateVolumeLevel(float[] buffer)
+        {
+            //NOTE: この方法はちょっと桁落ちとかのリスクあるんだけど、そんなにシビアな計算じゃないのでザツにやる
+            float sum = 0;
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                sum += buffer[i] * buffer[i];
+            }
+            
+            float mean = sum / buffer.Length;
+            float meanDb = Mathf.Log10(mean) * 10f;
+            int rawResult = Mathf.Clamp((int)(meanDb - BottomVolumeDb), 0, 50);
+            _currentVolumeLevel = Mathf.Max(rawResult, _currentVolumeLevel - LevelDecreasePerRefresh);
+        }
+
+        protected static int GetDataLength(int bufferLength, int head, int tail) 
+            => (head < tail) 
+                ? (tail - head) 
+                : (bufferLength - head + tail);
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VmmLipSyncContextBase.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VmmLipSyncContextBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea066d29df674fe439741d005d6696cf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VoiceOnOffParser.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/VoiceOnOffParser.cs
@@ -5,11 +5,11 @@ namespace Baku.VMagicMirror
     /// <summary> リップシンクの音量レベルベースで喋ってる/喋ってないを判断する処理 </summary>
     public class VoiceOnOffParser
     {
-        public VoiceOnOffParser(OVRLipSyncContextBase lipSync)
+        public VoiceOnOffParser(VmmLipSyncContextBase lipSync)
         {
             _lipSync = lipSync;
         }
-        private readonly OVRLipSyncContextBase _lipSync = null;
+        private readonly VmmLipSyncContextBase _lipSync = null;
 
         // Visemeのなかでこのしきい値を超える値が一つでもあれば、発声中だと判定する
         public float VisemeThreshold { get; set; }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/FaceControlInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/FaceControlInstaller.cs
@@ -7,14 +7,14 @@ namespace Baku.VMagicMirror.Installer
     public class FaceControlInstaller : InstallerBase
     {
         [SerializeField] private BlendShapeInitializer blendShapeInitializer = null;
-        [SerializeField] private DeviceSelectableLipSyncContext lipSyncContext = null;
+        [SerializeField] private VmmLipSyncContextBase lipSyncContext = null;
         [SerializeField] private LipSyncIntegrator lipSyncIntegrator = null;
         [SerializeField] private VRMAutoBlink autoBlink = null;
 
         public override void Install(DiContainer container)
         {
             container.BindInstance(blendShapeInitializer).AsCached();
-            container.BindInstance(lipSyncContext).AsCached();
+            container.Bind<VmmLipSyncContextBase>().FromInstance(lipSyncContext).AsCached();
             container.BindInstance(lipSyncIntegrator).AsCached();
             container.BindInstance(autoBlink).AsCached();
         }

--- a/VMagicMirror/Assets/NuGet.config
+++ b/VMagicMirror/Assets/NuGet.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+       <clear/>
+       <add key="NuGet" value="http://www.nuget.org/api/v2/" />
+    </packageSources>
+    <disabledPackageSources />
+    <activePackageSource>
+       <add key="All" value="(Aggregate source)" />
+    </activePackageSource>
+    <config>
+       <add key="repositoryPath" value="./NuGetPackages" />
+       <add key="DefaultPushSource" value="http://www.nuget.org/api/v2/" />
+    </config>
+</configuration>

--- a/VMagicMirror/Assets/NuGet.config.meta
+++ b/VMagicMirror/Assets/NuGet.config.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: a01abf278409d95488d33d27fe683f54
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/packages.config
+++ b/VMagicMirror/Assets/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NAudio" version="2.0.1" />
+  <package id="NAudio.Asio" version="2.0.0" />
+  <package id="NAudio.Core" version="2.0.0" />
+  <package id="NAudio.Midi" version="2.0.1" />
+  <package id="NAudio.Wasapi" version="2.0.0" />
+  <package id="NAudio.WinForms" version="2.0.1" />
+  <package id="NAudio.WinMM" version="2.0.1" />
+</packages>

--- a/VMagicMirror/Assets/packages.config.meta
+++ b/VMagicMirror/Assets/packages.config.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 5ace9cf82530f024387d9c128454d055
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
@@ -42,6 +42,10 @@ SharpDX: https://github.com/sharpdx/SharpDX
 libfacedetection.train: https://github.com/ShiqiYu/libfacedetection.train
 
 uWindowCapture: https://github.com/hecomi/uWindowCapture
+
+NuGetForUnity: https://github.com/GlitchEnzo/NuGetForUnity
+
+NAudio: https://github.com/naudio/NAudio
         
 OpenCV: https://opencv.org/
 
@@ -408,6 +412,30 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.        
 
         
+        NuGetForUnity
+
+MIT License
+
+Copyright (c) 2018 Patrick McCarthy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+        NAudio
+        
+Copyright 2020 Mark Heath
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
         OpenCV
 
 By downloading, copying, installing or using the software you agree to this license.

--- a/docs/credit_license.md
+++ b/docs/credit_license.md
@@ -64,6 +64,10 @@ In VMagicMirror, the materials are replaced for the visual consistency.
 
 [libfacedetection.train](https://github.com/ShiqiYu/libfacedetection.train)
 
+[NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity)
+
+[NAudio](https://github.com/naudio/NAudio)
+
 [OpenCV](https://opencv.org/)
 
 [UnityCam(UnityCaptureFilter)](https://github.com/mrayy/UnityCam)
@@ -486,6 +490,30 @@ SOFTWARE.
 The MIT License (MIT)
 
 Copyright (c) 2018 hecomi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#### NuGetForUnity
+
+MIT License
+
+Copyright (c) 2018 Patrick McCarthy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#### NAudio
+
+Copyright 2020 Mark Heath
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
#640 

2ch扱いで録音してチャネルの平均を使うようになる。

- 大半のユーザーから見た挙動は変化しない
- ステレオチャネルのマイクにだけ影響する = バイノーラルマイクで片方から喋ってるときの挙動が従来より正しくなる
- パフォーマンスはそんなに影響ないはず
    - バッファをちょっと取りすぎてる可能性はある。
    - バッファコピーの回数を減らしたほうがCPU負荷が下がる可能性はあるが、今回はあまり最適化してない
