### PR TITLE
UIからColor変更したときの挙動がおかしいのを修正

### DIFF
--- a/WPF/VMagicMirrorConfig/VMagicMirrorConfig.csproj
+++ b/WPF/VMagicMirrorConfig/VMagicMirrorConfig.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dragablz" Version="0.0.3.223" />
-    <PackageReference Include="MahApps.Metro" Version="2.3.4" />
-    <PackageReference Include="MaterialDesignColors" Version="1.2.7" />
-    <PackageReference Include="MaterialDesignThemes" Version="3.2.0" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.9" />
+    <PackageReference Include="MaterialDesignColors" Version="2.0.3" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.2.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/LightSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/LightSettingViewModel.cs
@@ -15,12 +15,12 @@ namespace Baku.VMagicMirrorConfig
         {
             _model = model;
 
-            _lightColor = Color.FromRgb((byte)model.LightR.Value, (byte)model.LightG.Value, (byte)model.LightB.Value);
+            void UpdateLightColor() => RaisePropertyChanged(nameof(LightColor));
             model.LightR.PropertyChanged += (_, __) => UpdateLightColor();
             model.LightG.PropertyChanged += (_, __) => UpdateLightColor();
             model.LightB.PropertyChanged += (_, __) => UpdateLightColor();
 
-            _bloomColor = Color.FromRgb((byte)model.BloomR.Value, (byte)model.BloomG.Value, (byte)model.BloomB.Value);
+            void UpdateBloomColor() => RaisePropertyChanged(nameof(BloomColor));
             model.BloomR.PropertyChanged += (_, __) => UpdateBloomColor();
             model.BloomG.PropertyChanged += (_, __) => UpdateBloomColor();
             model.BloomB.PropertyChanged += (_, __) => UpdateBloomColor();
@@ -38,10 +38,6 @@ namespace Baku.VMagicMirrorConfig
                 () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetWindSetting)
                 );
             ResetImageQualitySettingCommand = new ActionCommand(ResetImageQuality);
-
-            //最初の時点で不整合しなければ後は何でもOK
-            UpdateLightColor();
-            UpdateBloomColor();
         }
 
         private readonly LightSettingSync _model;
@@ -63,18 +59,14 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<int> LightG => _model.LightG;
         public RProperty<int> LightB => _model.LightB;
 
-        private Color _lightColor;
         public Color LightColor
         {
-            get => _lightColor;
+            get => Color.FromRgb((byte)LightR.Value, (byte)LightG.Value, (byte)LightB.Value);
             set
             {
-                if (SetValue(ref _lightColor, value))
-                {
-                    LightR.Value = value.R;
-                    LightG.Value = value.G;
-                    LightB.Value = value.B;
-                }
+                LightR.Value = value.R;
+                LightG.Value = value.G;
+                LightB.Value = value.B;
             }
         }
 
@@ -105,23 +97,16 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<int> BloomG => _model.BloomG;
         public RProperty<int> BloomB => _model.BloomB;
 
-        private Color _bloomColor;
         public Color BloomColor
         {
-            get => _bloomColor;
+            get => Color.FromRgb((byte)BloomR.Value, (byte)BloomG.Value, (byte)BloomB.Value);
             set
             {
-                if (SetValue(ref _bloomColor, value))
-                {
-                    BloomR.Value = value.R;
-                    BloomG.Value = value.G;
-                    BloomB.Value = value.B;
-                }
+                BloomR.Value = value.R;
+                BloomG.Value = value.G;
+                BloomB.Value = value.B;
             }
         }
-
-        private void UpdateBloomColor()
-            => BloomColor = Color.FromRgb((byte)BloomR.Value, (byte)BloomG.Value, (byte)BloomB.Value);
 
         #endregion
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WindowSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WindowSettingViewModel.cs
@@ -10,8 +10,7 @@ namespace Baku.VMagicMirrorConfig
         {
             _model = model;
 
-            void UpdatePickerColor() =>
-                PickerColor = Color.FromRgb((byte)_model.R.Value, (byte)_model.G.Value, (byte)_model.B.Value);
+            void UpdatePickerColor() => RaisePropertyChanged(nameof(PickerColor));
             _model.R.PropertyChanged += (_, __) => UpdatePickerColor();
             _model.G.PropertyChanged += (_, __) => UpdatePickerColor();
             _model.B.PropertyChanged += (_, __) => UpdatePickerColor();
@@ -39,19 +38,15 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<int> G => _model.G;
         public RProperty<int> B => _model.B;
 
-        private Color _pickerColor;
         /// <summary> ColorPickerに表示する、Alphaを考慮しない背景色を取得、設定します。 </summary>
         public Color PickerColor
         {
-            get => _pickerColor;
+            get => Color.FromRgb((byte)R.Value, (byte)G.Value, (byte)B.Value);
             set
             {
-                if (SetValue(ref _pickerColor, value))
-                {
-                    R.Value = PickerColor.R;
-                    G.Value = PickerColor.G;
-                    B.Value = PickerColor.B;
-                }
+                R.Value = value.R;
+                G.Value = value.G;
+                B.Value = value.B;
             }
         }
 


### PR DESCRIPTION
#587

「ViewModel側のフィールドに別途Colorがあると変更が部分的にロールバックして分かりづらい」みたいな問題があったため、モデル側のRGBのみが正である、という体裁に整え直しました。

これにより、RGBが同時に変更されるような操作時に「Rだけ適用されてG,Bがそのままになってしまう」みたいな問題が起きにくくなりました。