### PR TITLE
アクセサリフォルダが何故かない場合にフォルダを開こうとしてもクラッシュしない

### DIFF
--- a/WPF/VMagicMirrorConfig/ViewModel/Accessory/AccessorySettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/Accessory/AccessorySettingViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 
 namespace Baku.VMagicMirrorConfig
@@ -51,10 +52,13 @@ namespace Baku.VMagicMirrorConfig
 
         private void OpenAccessoryFolder()
         {
-            Process.Start(new ProcessStartInfo(SpecialFilePath.AccessoryFileDir)
+            if (Directory.Exists(SpecialFilePath.AccessoryFileDir))
             {
-                UseShellExecute = true,
-            });
+                Process.Start(new ProcessStartInfo(SpecialFilePath.AccessoryFileDir)
+                {
+                    UseShellExecute = true,
+                });
+            }
         }
 
         private void ReloadFiles() => _model.RefreshFiles();


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

fixed #686 

アクセサリフォルダが(ユーザーの誤操作などで)削除された場合にWPFからそれを開こうとしたとき、単に何も起きないようにすることで、クラッシュを防ぎます。

フォルダの自動生成までは行いません(次に起動したときに生成されるし、もともと珍しいケースなため)。

## How to confirm

アプリケーション開始後、わざとAccessoryフォルダを別名に変更してから「アクセサリー」タブの「フォルダを開く」を押し、クラッシュしないこと

## Note

none
