### PR TITLE
Accessory option to attach to world coord

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -214,8 +214,11 @@ namespace Baku.VMagicMirror
 
             if (!_attachBones.TryGetValue(ItemLayout.AttachTarget, out var bone))
             {
-                //普通ここは通らない
-                return;
+                // ワールド固定の場合、ここを通過してSetParent(null)が呼ばれることでワールドに固定される
+                if (ItemLayout.AttachTarget != AccessoryAttachTarget.World)
+                {
+                    return;
+                }
             }
             
             if (ItemLayout.UseBillboardMode)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
@@ -14,6 +14,7 @@ namespace Baku.VMagicMirror
         LeftHand = 3,
         Chest = 4,
         Waist = 5,
+        World = 6,
     }
 
     [Serializable]

--- a/WPF/VMagicMirrorConfig/Model/Entity/AccessorySetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/AccessorySetting.cs
@@ -8,6 +8,7 @@
         LeftHand = 3,
         Chest = 4,
         Waist = 5,
+        World = 6,
     }
 
     public class AccessorySetting : SettingEntityBase


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [ ] Bug fix
- [ ] Add new feature
- [x] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

#702 

アクセサリーの配置先に「ワールド」を追加しました。

このオプションはアクセサリーの中心的なユースケースではありませんが、机などの3Dオブジェクトを配置したい場合に有効です。

Add `World` attach option for accessory feature.

Though the option is rather an additional use case, it is useful for users who want to place fixed object like table.

## How to confirm

Checked that 3D model is fixed on world coord in editor play mode.

