### PR TITLE
Support IPv6 in iFacialMocap communication

### DIFF
--- a/WPF/VMagicMirrorConfig/Model/LocalUtil/NetworkEnvironmentUtils.cs
+++ b/WPF/VMagicMirrorConfig/Model/LocalUtil/NetworkEnvironmentUtils.cs
@@ -9,17 +9,25 @@ namespace Baku.VMagicMirrorConfig
     static class NetworkEnvironmentUtils
     {
         private static readonly UdpClient _udpClient = new UdpClient();
+        private static readonly UdpClient _udpClientIpv6 = new UdpClient(AddressFamily.InterNetworkV6);
 
         /// <summary>
         /// IPv4のローカルアドレスっぽいものを取得します。
         /// </summary>
         /// <returns></returns>
-        public static string GetLocalIpAddressAsString()
+        public static string GetLocalIpv4AddressAsString() => GetLocalAddressString(AddressFamily.InterNetwork);
+
+        /// <summary>
+        /// IPv6のローカルアドレスっぽいものを取得します。
+        /// </summary>
+        /// <returns></returns>
+        public static string GetLocalIpv6AddressAsString() => GetLocalAddressString(AddressFamily.InterNetworkV6);
+
+        private static string GetLocalAddressString(AddressFamily family)
         {
             var host = Dns.GetHostEntry(Dns.GetHostName());
-            //空ではないIPv4アドレスをてきとーに拾うだけ。これで十分じゃない場合は…多分それは人類には難しいやつ…
             return host.AddressList
-                .Where(ip => ip.AddressFamily == AddressFamily.InterNetwork)
+                .Where(ip => ip.AddressFamily == family)
                 .Select(ip => ip.ToString())
                 .Where(s => !string.IsNullOrEmpty(s))
                 .FirstOrDefault()
@@ -41,7 +49,20 @@ namespace Baku.VMagicMirrorConfig
             }
 
             var data = Encoding.UTF8.GetBytes("iFacialMocap_sahuasouryya9218sauhuiayeta91555dy3719");
-            _udpClient.Send(data, data.Length, new IPEndPoint(address, 49983));
+            switch(address.AddressFamily)
+            {
+                case AddressFamily.InterNetwork:
+                    _udpClient.Send(data, data.Length, new IPEndPoint(address, 49983));
+                    break;
+                case AddressFamily.InterNetworkV6:
+                    _udpClientIpv6.Send(data, data.Length, new IPEndPoint(address, 49983));
+                    break;
+                default:
+                    var indication = MessageIndication.InvalidIpAddress();
+                    await MessageBoxWrapper.Instance.ShowAsync(indication.Title, indication.Content, MessageBoxWrapper.MessageBoxStyle.OK);
+                    break;
+            }
+
         }
     }
 }


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [ ] Bug fix
- [ ] Add new feature
- [x] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

#699 

iFacialMocapとの通信がIPv6アドレスでも利用できるようにしました。

これは一部のLANでIPv4が無効なケースに配慮した対策です。

## How to confirm

自宅LAN環境でiPadの(iFacialMocapではなく「設定」アプリで見られる)IPv6アドレスを確認しておいた状態で、毎回iFacialMocapを再起動しながら以下をチェックする。

- WPFのGUIでIPv4のアドレスを指定して接続を試みると接続に成功し、外部トラッキングが動作すること
    - かつ、このときUnity側のログで、IPv4用のUdpClientが使われるのが確認できること
- WPFのGUIでIPv6のアドレスを指定して同様にすると、やはり接続成功して外部トラッキングが動作すること
    - かつ、このときUnity側のログで、IPv6用のUdpClientが使われるのが確認できること

## Note 

このPRの前の状態では以下のようになってました。

- WPF: 接続試行時にIPv6のアドレスを入力して「Connect」をするとクラッシュしてしまう(UdpClientがIPv4のみを前提にしていたため)
- Unity: IPv4のUDPしか受信できないため、どうにかiFacialMocapにPCのIPv6アドレスを投げても受信できなかった
