### PR TITLE
Use different thread for message loop

### DIFF
--- a/WPF/VMagicMirrorConfig/Model/InputObserve/MessageLoopThread.cs
+++ b/WPF/VMagicMirrorConfig/Model/InputObserve/MessageLoopThread.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Baku.VMagicMirrorConfig
+{
+    /// <summary>
+    /// 何かのアクションを実行したあとメッセージループで待機できるスレッド
+    /// </summary>
+    public class MessageLoopThread
+    {
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
+        private Action _actStart = () => { };
+        private Action _actEnd = () => { };
+
+        private Thread? _thread = null;
+
+        private readonly object _threadIdLock = new object();
+        private uint _threadId = 0;
+        private uint ThreadId
+        {
+            get { lock (_threadIdLock) return _threadId; }
+            set { lock (_threadIdLock) _threadId = value; }
+        }
+
+        public void Run(Action actStart, Action actEnd)
+        {
+            if (_thread != null)
+            {
+                return;
+            }
+
+            _actStart = actStart;
+            _actEnd = actEnd;
+            
+            _thread = new Thread(() => ThreadWithMessageLoop(_cts.Token));
+            _thread.Start();
+        }
+
+        public void Stop()
+        {
+            _cts.Cancel();
+            WinApi.PostThreadMessage(ThreadId, WinApi.WM_QUIT, IntPtr.Zero, IntPtr.Zero);
+            _thread = null;
+            ThreadId = 0;
+        }
+
+        private void ThreadWithMessageLoop(CancellationToken token)
+        {
+            _actStart();
+            ThreadId = WinApi.GetCurrentThreadId();
+
+            //NOTE: msgPtrにちゃんと領域確保しておかないとGetMessageがキレるので注意
+            var msgPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(WinApi.MSG)));
+            try
+            {
+                WinApi.PeekMessage(msgPtr, IntPtr.Zero, 0, 0, WinApi.PM_NOREMOVE);
+                while (!token.IsCancellationRequested)
+                {
+                    int res = WinApi.GetMessage(msgPtr, IntPtr.Zero, 0, 0);
+                    //NOTE: res == 0, -1は普通起きない
+                    if (token.IsCancellationRequested || res == 0 || res == -1)
+                    {
+                        break;
+                    }
+
+                    //普通ここは通らないはず
+                    LogOutput.Instance.Write("recv input message");
+                    WinApi.TranslateMessage(msgPtr);
+                    WinApi.DispatchMessage(msgPtr);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogOutput.Instance.Write(ex);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(msgPtr);
+                msgPtr = IntPtr.Zero;
+            }
+
+            ThreadId = 0;
+            _actEnd();
+        }
+
+
+        static class WinApi
+        {
+            [DllImport("user32.dll")]
+            public static extern bool PeekMessage(IntPtr lpMsg, IntPtr hWnd, uint filterMin, uint filterMax, uint wRemoveMsg);
+
+            [DllImport("user32.dll")]
+            public static extern int GetMessage(IntPtr lpMsg, IntPtr hWnd, uint filterMin, uint filterMax);
+
+            [DllImport("user32.dll")]
+            public static extern bool TranslateMessage(IntPtr lpMsg);
+
+            [DllImport("user32.dll")]
+            public static extern int DispatchMessage(IntPtr lpMsg);
+
+            [DllImport("kernel32.dll")]
+            public static extern uint GetCurrentThreadId();
+
+            [DllImport("user32.dll")]
+            public static extern bool PostThreadMessage(uint threadId, uint msg, IntPtr wParam, IntPtr lParam);
+
+            public const int PM_NOREMOVE = 0x0000;
+            public const int WM_QUIT = 0x0012;
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct MSG
+            {
+                public IntPtr hwnd;
+                public int message;
+                public IntPtr wParam;
+                public IntPtr lParam;
+                public uint time;
+                public int pt;
+            }
+        }
+    }
+}

--- a/WPF/VMagicMirrorConfig/Model/InputObserve/MouseButtonMessageSender.cs
+++ b/WPF/VMagicMirrorConfig/Model/InputObserve/MouseButtonMessageSender.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Baku.VMagicMirrorConfig
 {
@@ -32,15 +33,13 @@ namespace Baku.VMagicMirrorConfig
 
         private readonly MouseHook _mouseHook = new MouseHook();
         private readonly IMessageSender _sender;
+        private readonly MessageLoopThread _messageLoopThread = new MessageLoopThread();
 
-        public void Start()
-        {
-            _mouseHook.Start();
-        }
+        public void Start() => _messageLoopThread.Run(
+            () => _mouseHook.Start(),
+            () => _mouseHook.Dispose()
+        );
 
-        public void Dispose()
-        {
-            _mouseHook.Dispose();
-        }
+        public void Dispose() => _messageLoopThread.Stop();
     }
 }

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Util/CameraPositionChecker.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Util/CameraPositionChecker.cs
@@ -33,7 +33,7 @@ namespace Baku.VMagicMirrorConfig
                     string data = await _sender.QueryMessageAsync(MessageFactory.Instance.CurrentCameraPosition());
                     _layoutSetting.CameraPosition.SilentSet(data);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     LogOutput.Instance.Write(ex);
                 }


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

related to: #670 

WPFのメインウィンドウのメッセージループでマウスクリックの監視をしていたのをやめて別スレッドに分けました。

なお、このPRで気づいた事として、 #329 の根本原因はUnity側に実装していたメッセージループで`MSG`構造体のアロケーションをしていなかった事ではないか、という仮説が上がっています。

この修正を踏まえるとUnity側にグローバルフックの処理を再び任せられるはずで、基本的にはUnity側に処理を戻したほうが良いです。
