### PR TITLE
モーション/FaceSwitchの実行中のみアクセサリーを表示するオプションを追加

### DIFF
--- a/Batches/create_installer.cmd
+++ b/Batches/create_installer.cmd
@@ -2,7 +2,7 @@
 REM %1 full/standard (default: full)
 REM %2 prod/dev (default: prod)
 REM %3 app version (e.g. "v1.2.3")
-REM example: `create_installer prod full v2.0.0`
+REM example: `create_installer full prod v2.0.0`
 
 set ISCC_EXE="%ProgramFiles(x86)%\Inno Setup 6\ISCC.exe"
 cd %~dp0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/WordToMotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/WordToMotionController.prefab
@@ -118,6 +118,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1b81e378298a4e444855e13feaf3b35e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  wordToMotionManager: {fileID: 7427902273662735822}
   blendShape: {fileID: 7427902273662735816}
 --- !u!114 &7427902273662735822
 MonoBehaviour:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -26,7 +26,7 @@ namespace Baku.VMagicMirror
         public string FileId => _file?.FileId ?? "";
 
         private AccessoryFile _file = null;
-        private AccessoryFileActions _fileActions = null;
+        private IAccessoryFileActions _fileActions = null;
         private Camera _cam = null;
 
         private Animator _animator = null;
@@ -136,7 +136,10 @@ namespace Baku.VMagicMirror
 
         private void Update()
         {
-            _fileActions.Update(Time.deltaTime);
+            if (ShouldBeVisible)
+            {
+                _fileActions.Update(Time.deltaTime);
+            }
         }
         
         private void LateUpdate()
@@ -195,6 +198,7 @@ namespace Baku.VMagicMirror
 
         private void SetVisibility(bool visible)
         {
+            _fileActions?.OnVisibilityChanged(visible);
             if (_file == null || !visible)
             {
                 imageRenderer.gameObject.SetActive(false);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -357,7 +357,8 @@ namespace Baku.VMagicMirror
             }
 
             transformControl.global = request.WorldCoordinate;
-            var visible = ShouldBeVisible;
+            //NOTE: 表情やモーションに付随して一瞬表示されるような状態に対しては位置編集UIは出さない
+            var visible = ItemLayout.IsVisible;
             transformControl.mode = visible ? request.Mode : TransformControl.TransformMode.None;
 
             if (!visible)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -28,8 +28,8 @@ namespace Baku.VMagicMirror
             IVRMLoadable vrmLoader,
             IMessageReceiver receiver,
             IMessageSender sender, 
+            ExternalTrackerDataSource externalTrackerDataSource,
             DeviceTransformController deviceTransformController,
-            FaceSwitchExtractor faceSwitchExtractor,
             WordToMotionManager wordToMotionManager
             )
         {
@@ -74,12 +74,13 @@ namespace Baku.VMagicMirror
                 c => ResetAccessoryLayout(c.Content)
                 );
 
-            deviceTransformController.ControlRequested
-                .Subscribe(ControlItemsTransform)
+            externalTrackerDataSource.ActiveFaceSwitchItem
+                .Select(a => a.AccessoryName)
+                .Subscribe(UpdateFaceSwitchStatus)
                 .AddTo(this);
 
-            faceSwitchExtractor.AccessoryVisibilityRequest
-                .Subscribe(UpdateFaceSwitchStatus)
+            deviceTransformController.ControlRequested
+                .Subscribe(ControlItemsTransform)
                 .AddTo(this);
 
             wordToMotionManager.AccessoryVisibilityRequest

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -90,7 +90,6 @@ namespace Baku.VMagicMirror
 
         private void UpdateFaceSwitchStatus(string fileId)
         {
-            Debug.Log($"UpdateFaceSwitchStatus, {fileId}");
             foreach (var item in _items)
             {
                 item.VisibleByFaceSwitch = item.FileId == fileId;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Baku.VMagicMirror.ExternalTracker;
 using UniRx;
 using UnityEngine;
 using Zenject;
@@ -27,7 +28,9 @@ namespace Baku.VMagicMirror
             IVRMLoadable vrmLoader,
             IMessageReceiver receiver,
             IMessageSender sender, 
-            DeviceTransformController deviceTransformController
+            DeviceTransformController deviceTransformController,
+            FaceSwitchExtractor faceSwitchExtractor,
+            WordToMotionManager wordToMotionManager
             )
         {
             _cam = cam;
@@ -74,6 +77,32 @@ namespace Baku.VMagicMirror
             deviceTransformController.ControlRequested
                 .Subscribe(ControlItemsTransform)
                 .AddTo(this);
+
+            faceSwitchExtractor.AccessoryVisibilityRequest
+                .Subscribe(UpdateFaceSwitchStatus)
+                .AddTo(this);
+
+            wordToMotionManager.AccessoryVisibilityRequest
+                .Subscribe(UpdateWordToMotionStatus)
+                .AddTo(this);
+        }
+
+        private void UpdateFaceSwitchStatus(string fileId)
+        {
+            Debug.Log($"UpdateFaceSwitchStatus, {fileId}");
+            foreach (var item in _items)
+            {
+                item.VisibleByFaceSwitch = item.FileId == fileId;
+            }
+        }
+
+        //NOTE: previewでも実際のモーションでも同じ所を叩かせる
+        private void UpdateWordToMotionStatus(string fileId)
+        {
+            foreach (var item in _items)
+            {
+                item.VisibleByWordToMotion = item.FileId == fileId;
+            }
         }
 
         private void Start()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace Baku.VMagicMirror
 {
-    public class AnimatableImage : IDisposable
+    public class AnimatableImage : IDisposable, IAccessoryFileActions
     {
         //NOTE: Texture2D[] を渡すほうがきれいかもしれん
         public AnimatableImage(byte[][] binaries)
@@ -90,6 +90,21 @@ namespace Baku.VMagicMirror
             else
             {
                 FramePerSecond = layout.FramePerSecond;
+            }
+        }
+
+        public void OnVisibilityChanged(bool isVisible)
+        {
+            if (isVisible)
+            {
+                return;
+            }
+
+            _timeCount = 0f;
+            _imageIndex = 0;
+            if (Renderer != null)
+            {
+                Renderer.material.mainTexture = CurrentTexture;
             }
         }
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public interface IAccessoryFileActions
+    {
+        void Dispose();
+        void Update(float deltaTime);
+        void UpdateLayout(AccessoryItemLayout layout);
+        //NOTE: isVisibleが切り替わってなくても呼ばれる事がある(現行実装では冗長に呼び出しても基本無害なので…)
+        void OnVisibilityChanged(bool isVisible);
+    }
+
+    public abstract class AccessoryFileActionsBase : IAccessoryFileActions
+    {
+        public virtual void Dispose() { }
+        public virtual void Update(float deltaTime) { }
+        public virtual void UpdateLayout(AccessoryItemLayout layout) { }
+        public virtual void OnVisibilityChanged(bool isVisible) { }
+    }
+    
+    public class ImageAccessoryActions : AccessoryFileActionsBase
+    {
+        public ImageAccessoryActions(Texture2D texture)
+        {
+            _texture = texture;
+        }
+        private Texture2D _texture;
+
+        public override void Dispose()
+        {
+            if (_texture != null)
+            {
+                Object.Destroy(_texture);                    
+            }
+            _texture = null;
+        }
+    }
+        
+    public class GlbFileAccessoryActions : AccessoryFileActionsBase
+    {
+        public GlbFileAccessoryActions(UniGLTF.ImporterContext context)
+        {
+            _context = context;
+        }
+        private UniGLTF.ImporterContext _context;
+        public override void Dispose()
+        {
+            _context?.Dispose();
+            _context = null;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61782a435b6cd5e43a530372608b3309
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/Models/MotionRequest.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/Models/MotionRequest.cs
@@ -37,6 +37,11 @@ namespace Baku.VMagicMirror
         /// </summary>
         public bool PreferLipSync;
 
+        /// <summary>
+        /// モーション実行中のみアクセサリを表示したい場合、そのアクセサリーのFileId
+        /// </summary>
+        public string AccessoryName;
+
         //NOTE: 辞書にしないでこのまま使う手も無くはないです
         
         public BlendShapeValues BlendShapeValues = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionManager.cs
@@ -5,8 +5,7 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
-    //TODO: noddingとshakingをどうにか特別扱いして起動させたい…
-    
+    //TODO: GODじゃなくなってほしすぎる
     //NOTE: このクラスが(半分神になっちゃうのが気に入らんが)やること
     // - プレビューのon/off : プレビューがオンの場合、プレビューが全てに優先する
     // - プレビューではないワードベースモーションのon/off :
@@ -90,6 +89,7 @@ namespace Baku.VMagicMirror
                     _blendShape.KeepLipSync = false;
                     StopPreviewBuiltInMotion();
                     StopPreviewCustomMotion();
+                    _accessoryVisibilityRequest.Value = "";
                 }
             }
         }
@@ -102,6 +102,11 @@ namespace Baku.VMagicMirror
 
         /// <summary>プレビュー動作の内容。</summary>
         public MotionRequest PreviewRequest { get; set; }
+        
+        private readonly ReactiveProperty<string> _accessoryVisibilityRequest 
+            = new ReactiveProperty<string>("");
+        /// <summary> 表示してほしいアクセサリーのFileIdか、または空文字 </summary>
+        public IReadOnlyReactiveProperty<string> AccessoryVisibilityRequest => _accessoryVisibilityRequest;
 
         private HeadMotionClipPlayer _headMotionClipPlayer = null;
         private WordToMotionMapper _mapper = null;
@@ -310,7 +315,13 @@ namespace Baku.VMagicMirror
 
             if (EnablePreview && PreviewRequest != null)
             {
+                _accessoryVisibilityRequest.Value = PreviewRequest.AccessoryName;
                 ApplyPreviewBlendShape();
+            }
+
+            if (!EnablePreview && IsPlayingMotion && _currentMotionRequest != null)
+            {
+                _accessoryVisibilityRequest.Value = _currentMotionRequest.AccessoryName;
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionManager.cs
@@ -319,9 +319,11 @@ namespace Baku.VMagicMirror
                 ApplyPreviewBlendShape();
             }
 
-            if (!EnablePreview && IsPlayingMotion && _currentMotionRequest != null)
+            if (!EnablePreview)
             {
-                _accessoryVisibilityRequest.Value = _currentMotionRequest.AccessoryName;
+                _accessoryVisibilityRequest.Value = (IsPlayingMotion || IsPlayingBlendShape) && _currentMotionRequest != null 
+                    ? _currentMotionRequest.AccessoryName
+                    : "";
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/ExternalTrackerDataSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/ExternalTrackerDataSource.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using UnityEngine;
 using Zenject;
 using Baku.VMagicMirror.ExternalTracker.iFacialMocap;
+using UniRx;
 
 namespace Baku.VMagicMirror.ExternalTracker
 {
@@ -98,9 +99,9 @@ namespace Baku.VMagicMirror.ExternalTracker
                 _faceSwitchKeepCount -= Time.deltaTime;
             }
             
-            if (_faceSwitchKeepCount <= 0 && FaceSwitchClipName != _faceSwitchExtractor.ClipName)
+            if (_faceSwitchKeepCount <= 0 && !ActiveFaceSwitchItem.Equals(_faceSwitchExtractor.ActiveItem))
             {
-                _faceSwitchClipName = _faceSwitchExtractor.ClipName;
+                _activeFaceSwitchItem.Value = _faceSwitchExtractor.ActiveItem;
                 _faceSwitchKeepCount = FaceSwitchMinimumKeepDuration;
             }
 
@@ -127,7 +128,7 @@ namespace Baku.VMagicMirror.ExternalTracker
             {
                 _faceSwitchExtractor.Update(CurrentSource);
                 _config.FaceSwitchActive = !string.IsNullOrEmpty(FaceSwitchClipName);
-                _config.FaceSwitchRequestStopLipSync = _config.FaceSwitchActive && !_faceSwitchExtractor.KeepLipSync;
+                _config.FaceSwitchRequestStopLipSync = _config.FaceSwitchActive && !_activeFaceSwitchItem.Value.KeepLipSync;
             }
         }
 
@@ -333,14 +334,17 @@ namespace Baku.VMagicMirror.ExternalTracker
                     return result;
                 }
             }
-        } 
-        
-        private string _faceSwitchClipName = "";
+        }
+
+        private readonly ReactiveProperty<ActiveFaceSwitchItem> _activeFaceSwitchItem =
+            new ReactiveProperty<ActiveFaceSwitchItem>();
+        public IReadOnlyReactiveProperty<ActiveFaceSwitchItem> ActiveFaceSwitchItem => _activeFaceSwitchItem;
+
         /// <summary> FaceSwitch機能で指定されたブレンドシェイプがあればその名称を取得し、なければ空文字を取得します。 </summary>
-        public string FaceSwitchClipName => Connected ? _faceSwitchClipName : "";
+        public string FaceSwitchClipName => Connected ? _activeFaceSwitchItem.Value.ClipName : "";
         
-        public bool KeepLipSyncForFaceSwitch =>
-            !string.IsNullOrEmpty(FaceSwitchClipName) && _faceSwitchExtractor.KeepLipSync;
+        public bool KeepLipSyncForFaceSwitch => 
+            !string.IsNullOrEmpty(_activeFaceSwitchItem.Value.ClipName) && _activeFaceSwitchItem.Value.KeepLipSync;
 
         #endregion
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/ExternalTrackerDataSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/ExternalTrackerDataSource.cs
@@ -43,6 +43,7 @@ namespace Baku.VMagicMirror.ExternalTracker
         //ソースが「なし」のときに便宜的に割り当てるための、常に顔が中央にあり、無表情であるとみなせるような顔トラッキングデータ
         private readonly EmptyExternalTrackSourceProvider _emptyProvider = new EmptyExternalTrackSourceProvider();
         private readonly FaceSwitchExtractor _faceSwitchExtractor = new FaceSwitchExtractor();
+        public FaceSwitchExtractor FaceSwitchExtractor => _faceSwitchExtractor;
 
         private IExternalTrackSourceProvider _currentProvider = null;
         private IExternalTrackSourceProvider CurrentProvider => _currentProvider ?? _emptyProvider;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/FaceSwitch/FaceSwitchData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/FaceSwitch/FaceSwitchData.cs
@@ -45,6 +45,7 @@ namespace Baku.VMagicMirror.ExternalTracker
         public int threshold;
         public string clipName;
         public bool keepLipSync;
+        public string accessoryName;
     }
     
     public static class FaceSwitchKeys

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/FaceSwitch/FaceSwitchExtractor.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/FaceSwitch/FaceSwitchExtractor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using UniRx;
 
 namespace Baku.VMagicMirror.ExternalTracker
 {
@@ -7,13 +8,16 @@ namespace Baku.VMagicMirror.ExternalTracker
     /// </summary>
     public class FaceSwitchExtractor
     {
-
-
         /// <summary> FaceSwitch的にはこの値だと嬉しいな～というブレンドシェイプ名 </summary>
         public string ClipName { get; private set; } = "";
 
         /// <summary> FaceSwitch的にリップシンクを続行する/しないの判定値 </summary>
         public bool KeepLipSync { get; private set; } = false;
+
+        private readonly ReactiveProperty<string> _accessoryVisibilityRequest 
+            = new ReactiveProperty<string>("");
+        /// <summary> 表示してほしいアクセサリーのFileIdか、または空文字 </summary>
+        public IReadOnlyReactiveProperty<string> AccessoryVisibilityRequest => _accessoryVisibilityRequest;
 
         private string[] _avatarBlendShapeNames = new string[0];
         /// <summary> 現在ロードされているアバターの全ブレンドシェイプ名 </summary>
@@ -39,7 +43,6 @@ namespace Baku.VMagicMirror.ExternalTracker
                 RefreshItemsToCheck();
             }
         }
-
 
         //ロードされたアバターと設定を突き合わせた結果得られる、確認すべき条件セットの一覧
         private FaceSwitchItem[] _itemsToCheck = new FaceSwitchItem[0];
@@ -72,6 +75,7 @@ namespace Baku.VMagicMirror.ExternalTracker
                 {
                     ClipName = _itemsToCheck[i].clipName;
                     KeepLipSync = _itemsToCheck[i].keepLipSync;
+                    _accessoryVisibilityRequest.Value = _itemsToCheck[i].accessoryName;
                     return;
                 }
             }
@@ -79,6 +83,7 @@ namespace Baku.VMagicMirror.ExternalTracker
             //一つも該当しない場合
             ClipName = "";
             KeepLipSync = false;
+            _accessoryVisibilityRequest.Value = "";
         }
 
         //NOTE: このキーはWPF側が決め打ちしてるやつです

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MonitoringInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MonitoringInstaller.cs
@@ -26,6 +26,7 @@ namespace Baku.VMagicMirror.Installer
             container.BindInstance(faceTracker);
             container.BindInstance(handTracker);
             container.BindInstance(externalTracker);
+            container.BindInstance(externalTracker.FaceSwitchExtractor);
             container.BindInstance(gamepadListener);
             container.BindInstance(midiInputObserver);
             //container.BindInstance(openCvFacePose);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/WordToMotionInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/WordToMotionInstaller.cs
@@ -5,10 +5,12 @@ namespace Baku.VMagicMirror.Installer
 {
     public class WordToMotionInstaller : InstallerBase
     {
+        [SerializeField] private WordToMotionManager wordToMotionManager = null;
         [SerializeField] private WordToMotionBlendShape blendShape = null;
     
         public override void Install(DiContainer container)
         {
+            container.BindInstance(wordToMotionManager).AsCached();
             container.BindInstance(blendShape).AsCached();
         }
     }

--- a/WPF/VMagicMirrorConfig/Localizations/Chinese_Simplified.xaml
+++ b/WPF/VMagicMirrorConfig/Localizations/Chinese_Simplified.xaml
@@ -350,7 +350,7 @@
     
     <sys:String x:Key="WordToMotion_Motion_Custom_Label">动作</sys:String>
     <sys:String x:Key="WordToMotion_Motion_Custom_Hint">动作选择</sys:String>
-    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">使用方法（打开网页）</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">使用方法</sys:String>
     <sys:String x:Key="WordToMotion_Motion_Custom_Doctor">判断动作数据</sys:String>
 
     <sys:String x:Key="WordToMotion_Face_Header">表情</sys:String>

--- a/WPF/VMagicMirrorConfig/Model/MessageData/ExternalTrackerFaceSwitchItem.cs
+++ b/WPF/VMagicMirrorConfig/Model/MessageData/ExternalTrackerFaceSwitchItem.cs
@@ -44,6 +44,11 @@ namespace Baku.VMagicMirrorConfig
         /// VRMのミニマム仕様的には全部falseにすべきで、特別にセットアップしたモデルでのみtrueにすることができる。
         /// </remarks>
         public bool KeepLipSync { get; set; } = false;
+
+        /// <summary>
+        /// 条件を満たしているときのみ表示するアクセサリーがある場合、その名前。何もしない場合は空文字。
+        /// </summary>
+        public string AccessoryName { get; set; } = "";
     }
 
     /// <summary> 表情スイッチアイテムの一覧です。 </summary>
@@ -141,6 +146,11 @@ namespace Baku.VMagicMirrorConfig
                         result.Items[i].ClipName = (string?)clipName ?? "";
                         result.Items[i].KeepLipSync = (bool)keepLipSync;
                     }
+
+                    if (items[i]["accessoryName"] is JValue accessoryName)
+                    {
+                        result.Items[i].AccessoryName = (string?)accessoryName ?? "";
+                    }
                 }
             }
             return result;
@@ -158,6 +168,7 @@ namespace Baku.VMagicMirrorConfig
                     ["threshold"] = Items[i].ThresholdPercent,
                     ["clipName"] = Items[i].ClipName,
                     ["keepLipSync"] = Items[i].KeepLipSync,
+                    ["accessoryName"] = Items[i].AccessoryName,
                 });
             }
 

--- a/WPF/VMagicMirrorConfig/Model/MessageData/MotionRequest.cs
+++ b/WPF/VMagicMirrorConfig/Model/MessageData/MotionRequest.cs
@@ -23,6 +23,8 @@ namespace Baku.VMagicMirrorConfig
 
         public string CustomMotionClipName { get; set; } = "";
 
+        public string AccessoryName { get; set; } = "";
+
         public float DurationWhenOnlyBlendShape { get; set; } = 3.0f;
 
         /// <summary>

--- a/WPF/VMagicMirrorConfig/Model/SettingSync/AccessorySettingSync.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingSync/AccessorySettingSync.cs
@@ -19,6 +19,14 @@ namespace Baku.VMagicMirrorConfig
         public event Action<AccessoryItemSetting>? ItemUpdated;
 
         /// <summary>
+        /// アイテムの名前が変化したかもしれない場合に発火します。
+        /// </summary>
+        /// <remarks>
+        /// このイベントのハンドラは表示への適用以外の処理を行ってはいけません(=ハンドラからmodel側の処理を叩くのはNG)
+        /// </remarks>
+        public event Action<AccessoryItemSetting>? ItemNameMaybeChanged;
+
+        /// <summary>
         /// <see cref="RefreshFiles"/>が呼び出されてアイテムがリロードされると発火します。
         /// </summary>
         public event Action? ItemRefreshed;
@@ -42,6 +50,9 @@ namespace Baku.VMagicMirrorConfig
             var json = JsonConvert.SerializeObject(item);
             SendMessage(MessageFactory.Instance.SetSingleAccessoryLayout(json));  
         }
+
+        public void NotifyItemNameMaybeChanged(AccessoryItemSetting item)
+            => ItemNameMaybeChanged?.Invoke(item);
 
         /// <summary>
         /// アクセサリのフォルダを読み込み直すことで、明示的にアクセサリ一覧を更新します。

--- a/WPF/VMagicMirrorConfig/Model/SettingSync/RootSettingSync.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingSync/RootSettingSync.cs
@@ -23,7 +23,7 @@ namespace Baku.VMagicMirrorConfig
             WordToMotion = new WordToMotionSettingSync(sender, receiver);
             ExternalTracker = new ExternalTrackerSettingSync(sender);
             Automation = new AutomationSettingSync(sender);
-            Accessory = new AccessorySettingSync(sender, receiver);
+            Accessory = new AccessorySettingModel(sender, receiver);
 
             //NOTE; LanguageSelectorとの二重管理っぽくて若干アレだがこのままで行く
             //初期値Defaultを入れることで、起動直後にPCのカルチャベースで言語を指定しなきゃダメかどうか判別する
@@ -75,7 +75,7 @@ namespace Baku.VMagicMirrorConfig
         public ExternalTrackerSettingSync ExternalTracker { get; }
 
         public AutomationSettingSync Automation { get; }
-        public AccessorySettingSync Accessory { get; }
+        public AccessorySettingModel Accessory { get; }
 
         public void InitializeAvailableLanguage(string[] languageNames)
         {

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -100,6 +100,8 @@ During this mode, following features are disabled.
     <sys:String x:Key="ExTracker_FaceSwitch">Face Switch</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_Instruction" xml:space="preserve">Activates seleceted BlendShape by making specific face expression.
 Check "Keep LipSync" to make the lipsync continue.</sys:String>
+    <sys:String x:Key="ExTracker_FaceSwitch_ShowAccessoryOption">Show Accessory Option</sys:String>
+    <sys:String x:Key="ExTracker_FaceSwitch_AccessoryLabel">Accessory:</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_KeepLipSync">Keep LipSync</sys:String>
 
     <!-- ExTracker FaceSwitch Trigger -->

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -410,14 +410,18 @@ Please test by typing "joy".</sys:String>
 
     <sys:String x:Key="WordToMotion_BodyMotion_Header">Body Motion</sys:String>
     <sys:String x:Key="WordToMotion_MotionType_None">None</sys:String>
-    <sys:String x:Key="WordToMotion_MotionType_BuiltIn">Built-In Motion</sys:String>
-    <sys:String x:Key="WordToMotion_MotionType_Custom">Custom Motion</sys:String>
+    <sys:String x:Key="WordToMotion_MotionType_BuiltIn">Built-In</sys:String>
+    <sys:String x:Key="WordToMotion_MotionType_Custom">Custom</sys:String>
     <sys:String x:Key="WordToMotion_Motion_BuiltIn_Label">Motion</sys:String>
     <sys:String x:Key="WordToMotion_Motion_BuiltIn_Hint">Choose Motion</sys:String>
     <sys:String x:Key="WordToMotion_Motion_Custom_Label">Motion</sys:String>
     <sys:String x:Key="WordToMotion_Motion_Custom_Hint">Choose Motion</sys:String>
-    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">How to Use (open web)</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">Usage...</sys:String>
     <sys:String x:Key="WordToMotion_Motion_Custom_Doctor">Check Motion Data Validity</sys:String>
+
+    <sys:String x:Key="WordToMotion_Accessory_Header">Accessory</sys:String>
+    <sys:String x:Key="WordToMotion_Accessory_Placeholder">Choose Accessory</sys:String>
+    <sys:String x:Key="WordToMotion_Accessory_Notice">Item is visible during motion.</sys:String>
 
     <sys:String x:Key="WordToMotion_Face_Header">Face Expression</sys:String>
     <sys:String x:Key="WordToMotion_Face_Enable">Enable Face Expression</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -100,6 +100,8 @@
     <sys:String x:Key="ExTracker_FaceSwitch">表情スイッチ</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_Instruction" xml:space="preserve">顔をはっきりと特定の表情にすることでアバターの表情を切り替えます。
 「リップシンクを続行」をオンにすると、表情を切り替えたままリップシンクを動かせます。</sys:String>
+    <sys:String x:Key="ExTracker_FaceSwitch_ShowAccessoryOption">アクセサリーオプションを表示</sys:String>
+    <sys:String x:Key="ExTracker_FaceSwitch_AccessoryLabel">アクセサリー:</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_KeepLipSync">リップシンクを続行</sys:String>
 
     

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -419,9 +419,13 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     
     <sys:String x:Key="WordToMotion_Motion_Custom_Label">モーション</sys:String>
     <sys:String x:Key="WordToMotion_Motion_Custom_Hint">モーションを選択</sys:String>
-    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">使い方 (Webページを開きます)</sys:String>
+    <sys:String x:Key="WordToMotion_Motion_Custom_HowTo">使い方...</sys:String>
     <sys:String x:Key="WordToMotion_Motion_Custom_Doctor">モーションデータを診断</sys:String>
 
+    <sys:String x:Key="WordToMotion_Accessory_Header">アクセサリー</sys:String>
+    <sys:String x:Key="WordToMotion_Accessory_Placeholder">アクセサリーを選択</sys:String>
+    <sys:String x:Key="WordToMotion_Accessory_Notice">*モーション実行中のみ表示されます</sys:String>
+    
     <sys:String x:Key="WordToMotion_Face_Header">表情</sys:String>
     <sys:String x:Key="WordToMotion_Face_Enable">表情の動作を有効化</sys:String>
     <sys:String x:Key="WordToMotion_Face_Duration">(全身モーションが「なし」の場合) 表情の変化時間 [sec]</sys:String>

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/ExternalTrackerPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/ExternalTrackerPanel.xaml
@@ -230,6 +230,12 @@
                     <TextBlock Margin="15,5"
                                Text="{DynamicResource ExTracker_FaceSwitch_Instruction}"/>
 
+                    <CheckBox Margin="15,5" 
+                              VerticalContentAlignment="Center"
+                              Content="{DynamicResource ExTracker_FaceSwitch_ShowAccessoryOption}" 
+                              IsChecked="{Binding ShowAccessoryOption.Value}"
+                              />
+
                     <TextBlock Width="100"
                                Margin="15,15,15,5"
                                HorizontalAlignment="Right"

--- a/WPF/VMagicMirrorConfig/View/ExternalTrackerParts/ExternalTrackerFaceSwitchITemplateItem.xaml
+++ b/WPF/VMagicMirrorConfig/View/ExternalTrackerParts/ExternalTrackerFaceSwitchITemplateItem.xaml
@@ -18,6 +18,10 @@
             <ColumnDefinition/>
             <ColumnDefinition Width="100"/>
         </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
         <!--Style="{StaticResource MaterialDesignFilledComboBox}"-->
         <ComboBox Grid.Column="0"
                   Style="{StaticResource MaterialDesignComboBox}"
@@ -61,5 +65,23 @@
                     Margin="0" 
                     IsChecked="{Binding KeepLipSync}"
                     />
+
+        <TextBlock Grid.Row="1"
+                   Grid.Column="1"
+                   Text="{DynamicResource ExTracker_FaceSwitch_AccessoryLabel}"
+                   Visibility="{Binding ShowAccessoryOption.Value, 
+                                        Converter={StaticResource BooleanToVisibilityConverter}}"
+                   />
+        <ComboBox Grid.Row="1"
+                  Grid.Column="2" 
+                  Margin="5,0"
+                  ItemsSource="{Binding AvailableAccessoryNames}"
+                  DisplayMemberPath="DisplayName.Value"
+                  SelectedValuePath="FileId"
+                  SelectedValue="{Binding AccessoryName}"
+                  Visibility="{Binding ShowAccessoryOption.Value, 
+                                       Converter={StaticResource BooleanToVisibilityConverter}}"
+                  >
+        </ComboBox>
     </Grid>
 </UserControl>

--- a/WPF/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
+++ b/WPF/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
@@ -163,7 +163,12 @@
                            />
 
                 <ComboBox Margin="10,0"
-                          md:HintAssist.Hint="{DynamicResource WordToMotion_Accessory_Placeholder}" />
+                          md:HintAssist.Hint="{DynamicResource WordToMotion_Accessory_Placeholder}"
+                          ItemsSource="{Binding AvailableAccessoryNames}"
+                          DisplayMemberPath="DisplayName"
+                          SelectedValuePath="FileId"
+                          SelectedValue="{Binding AccessoryName}"
+                          />
 
                 <TextBlock Text="{DynamicResource WordToMotion_Accessory_Notice}"
                            TextAlignment="Left"

--- a/WPF/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
+++ b/WPF/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
@@ -43,6 +43,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="250"/>
@@ -89,19 +90,20 @@
                            />
 
                 <RadioButton Content="{DynamicResource WordToMotion_MotionType_None}"
-                             Margin="0,10"
+                             Margin="0,5"
                              VerticalContentAlignment="Center"
                              IsChecked="{Binding IsMotionTypeNone}"
                              />
 
                 <RadioButton Content="{DynamicResource WordToMotion_MotionType_BuiltIn}"
-                             Margin="0,10,0,5"
+                             Margin="0,5"
                              VerticalContentAlignment="Center"
                              IsChecked="{Binding IsMotionTypeBuiltInClip}"
                              />
 
                 <DockPanel LastChildFill="True"
-                           Margin="5">
+                           Margin="5"
+                           >
                     <TextBlock Text="{DynamicResource WordToMotion_Motion_BuiltIn_Label}" />
                     <ComboBox ItemsSource="{Binding AvailableBuiltInClipNames}"
                               SelectedItem="{Binding BuiltInClipName}"
@@ -111,15 +113,26 @@
                               />
                 </DockPanel>
 
+                <Grid Margin="0,5">
+                    <RadioButton Content="{DynamicResource WordToMotion_MotionType_Custom}"
+                                 VerticalContentAlignment="Center"
+                                 IsChecked="{Binding IsMotionTypeCustom}"
+                                 />
+                    <Button Style="{StaticResource MaterialDesignOutlinedButton}"
+                        Content="{DynamicResource WordToMotion_Motion_Custom_HowTo}"
+                        Command="{Binding OpenWordToMotionCustomHowToCommand}"
+                        Margin="0"
+                        Width="NaN"
+                        HorizontalAlignment="Right"
+                        />
 
-                <RadioButton Content="{DynamicResource WordToMotion_MotionType_Custom}"
-                             Margin="0,20,0,5"
-                             VerticalContentAlignment="Center"
-                             IsChecked="{Binding IsMotionTypeCustom}"
-                             />
+                </Grid>
+
+
                                 
                 <DockPanel LastChildFill="True"
-                           Margin="5">
+                           Margin="5"
+                           >
                     <TextBlock Text="{DynamicResource WordToMotion_Motion_Custom_Label}" />
                     <ComboBox ItemsSource="{Binding AvailableCustomMotionClipNames}"
                               SelectedItem="{Binding CustomMotionClipName}"
@@ -129,13 +142,6 @@
                               />
                 </DockPanel>
 
-                <Button Style="{StaticResource MaterialDesignOutlinedButton}"
-                        Content="{DynamicResource WordToMotion_Motion_Custom_HowTo}"
-                        Command="{Binding OpenWordToMotionCustomHowToCommand}"
-                        Margin="10,0"
-                        Width="NaN"
-                        HorizontalAlignment="Left"
-                        />
                 <!-- 診断機能を検討してIPCまではも用意したものの、まだ仕組みがきちんとしてないので一旦隠します -->
                 <!--<Button Style="{StaticResource MaterialDesignRaisedButton}"
                         Content="{DynamicResource WordToMotion_Motion_Custom_Doctor}"
@@ -146,8 +152,30 @@
         </Border>
 
         <Border Style="{StaticResource SectionBorder}"
+                Grid.Row="2" Grid.Column="0"
+                Margin="8" Padding="10"
+                >
+            <StackPanel>
+                <TextBlock Style="{StaticResource HeaderText}"
+                           Text="アクセサリ" 
+                           TextAlignment="Left"
+                           Margin="5"
+                           />
+
+                <ComboBox Margin="10,0"
+                          md:HintAssist.Hint="{DynamicResource WordToMotion_Accessory_Placeholder}" />
+
+                <TextBlock Text="{DynamicResource WordToMotion_Accessory_Notice}"
+                           TextAlignment="Left"
+                           Margin="10,5,0,0"
+                           />
+            </StackPanel>
+        </Border>
+
+
+        <Border Style="{StaticResource SectionBorder}"
                 Grid.Row="0" Grid.Column="1"
-                Grid.RowSpan="2"
+                Grid.RowSpan="3"
                 VerticalAlignment="Stretch" 
                 Margin="8"
                 Padding="10"
@@ -307,12 +335,12 @@
             </Grid>
         </Border>
         
-        <CheckBox Grid.Row="2" Grid.Column="0"
+        <CheckBox Grid.Row="3" Grid.Column="0"
                   Content="{DynamicResource WordToMotion_EnablePreview}"
                   IsChecked="{Binding EnablePreview.Value}"
                   />
 
-        <StackPanel Grid.Row="2" Grid.Column="1"
+        <StackPanel Grid.Row="3" Grid.Column="1"
                     Margin="0,0,5,5"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"

--- a/WPF/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
+++ b/WPF/VMagicMirrorConfig/View/Windows/WordToMotionItemEditWindow.xaml
@@ -165,7 +165,7 @@
                 <ComboBox Margin="10,0"
                           md:HintAssist.Hint="{DynamicResource WordToMotion_Accessory_Placeholder}"
                           ItemsSource="{Binding AvailableAccessoryNames}"
-                          DisplayMemberPath="DisplayName"
+                          DisplayMemberPath="DisplayName.Value"
                           SelectedValuePath="FileId"
                           SelectedValue="{Binding AccessoryName}"
                           />

--- a/WPF/VMagicMirrorConfig/ViewModel/Accessory/AccessorySettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/Accessory/AccessorySettingViewModel.cs
@@ -8,7 +8,7 @@ namespace Baku.VMagicMirrorConfig
 {
     public class AccessorySettingViewModel : ViewModelBase
     {
-        internal AccessorySettingViewModel(AccessorySettingSync model, LayoutSettingSync layoutModel)
+        internal AccessorySettingViewModel(AccessorySettingModel model, LayoutSettingSync layoutModel)
         {
             Items = new ReadOnlyObservableCollection<AccessoryItemViewModel>(_items);
             _model = model;
@@ -22,7 +22,7 @@ namespace Baku.VMagicMirrorConfig
             OpenAccessoryTipsUrlCommand = new ActionCommand(OpenAccessoryTipsUrl);
         }
 
-        private readonly AccessorySettingSync _model;
+        private readonly AccessorySettingModel _model;
         private readonly LayoutSettingSync _layoutModel;
 
         private readonly ObservableCollection<AccessoryItemViewModel> _items 
@@ -80,7 +80,7 @@ namespace Baku.VMagicMirrorConfig
         }
 
 
-        internal AccessoryItemViewModel(AccessorySettingSync model, int index)
+        internal AccessoryItemViewModel(AccessorySettingModel model, int index)
         {
             _model = model;
             _item = model.Items.Items[index];
@@ -155,7 +155,7 @@ namespace Baku.VMagicMirrorConfig
             });
         }
 
-        private readonly AccessorySettingSync _model;
+        private readonly AccessorySettingModel _model;
         private readonly AccessoryItemSetting _item;
         private readonly AccessoryFile? _file;
 

--- a/WPF/VMagicMirrorConfig/ViewModel/Accessory/AccessorySettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/Accessory/AccessorySettingViewModel.cs
@@ -93,6 +93,8 @@ namespace Baku.VMagicMirrorConfig
             {
                 _item.Name = v;
                 UpdateItemFromUi();
+                //NOTE: ここだけは高頻度に発火するのを許す
+                _model.NotifyItemNameMaybeChanged(_item);
             });
             IsVisible = new RProperty<bool>(_item.IsVisible, v =>
             {

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/ExternalTrackerViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/ExternalTrackerViewModel.cs
@@ -16,12 +16,15 @@ namespace Baku.VMagicMirrorConfig
         internal ExternalTrackerViewModel(
             ExternalTrackerSettingSync model,
             MotionSettingSync motionModel,
+            AccessorySettingModel accessoryModel,
             IMessageSender sender, 
             IMessageReceiver receiver
             ) : base(sender)
         {
             _model = model;
             _motionModel = motionModel;
+
+            AvailableAccessoryNames = new AccessoryItemNamesViewModel(accessoryModel);
 
             //この辺はModel/VMの接続とかコマンド周りの設定
             UpdateTrackSourceType();
@@ -228,6 +231,9 @@ namespace Baku.VMagicMirrorConfig
 
         #region 表情スイッチのやつ
 
+        //UI表示の同期のためだけに使う値で、Modelとは関係ない
+        public RProperty<bool> ShowAccessoryOption { get; } = new RProperty<bool>(false);
+
         /// <summary>
         /// 子要素になってる<see cref="ExternalTrackerFaceSwitchItemViewModel"/>から呼び出すことで、
         /// 現在の設定を保存した状態にします。
@@ -240,6 +246,9 @@ namespace Baku.VMagicMirrorConfig
 
         /// <summary> Face Switch機能で表示可能なブレンドシェイプ名の一覧です。 </summary>
         public ReadOnlyObservableCollection<string> BlendShapeNames => _blendShapeNameStore.BlendShapeNames;
+
+        /// <summary> Face Switchで連動させるアクセサリ名の選択肢の一覧です。 </summary>
+        public AccessoryItemNamesViewModel AvailableAccessoryNames { get; }
 
         /// <summary>
         /// 個別のFace Switchで使っているブレンドシェイプ名が変わったとき呼び出すことで、

--- a/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -50,7 +50,8 @@ namespace Baku.VMagicMirrorConfig
             LightSetting = new LightSettingViewModel(Model.Light, MessageSender);
             WordToMotionSetting = new WordToMotionSettingViewModel(
                 Model.WordToMotion, Model.Layout, Model.Accessory, MessageSender, MessageIo.Receiver);
-            ExternalTrackerSetting = new ExternalTrackerViewModel(Model.ExternalTracker, Model.Motion, MessageSender, MessageIo.Receiver);
+            ExternalTrackerSetting = new ExternalTrackerViewModel(
+                Model.ExternalTracker, Model.Motion, Model.Accessory, MessageSender, MessageIo.Receiver);
             AccessorySetting = new AccessorySettingViewModel(Model.Accessory, Model.Layout);
             SettingIo = new SettingIoViewModel(Model, Model.Automation, SaveFileManager, MessageSender);
             //オートメーションの配線: 1つしかないのでザツにやる。OC<T>をいじる関係でUIスレッド必須なことに注意

--- a/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -48,7 +48,8 @@ namespace Baku.VMagicMirrorConfig
             GamepadSetting = new GamepadSettingViewModel(Model.Gamepad, MessageSender);
             LayoutSetting = new LayoutSettingViewModel(Model.Layout, Model.Gamepad, MessageSender, MessageIo.Receiver);
             LightSetting = new LightSettingViewModel(Model.Light, MessageSender);
-            WordToMotionSetting = new WordToMotionSettingViewModel(Model.WordToMotion, Model.Layout, MessageSender, MessageIo.Receiver);
+            WordToMotionSetting = new WordToMotionSettingViewModel(
+                Model.WordToMotion, Model.Layout, Model.Accessory, MessageSender, MessageIo.Receiver);
             ExternalTrackerSetting = new ExternalTrackerViewModel(Model.ExternalTracker, Model.Motion, MessageSender, MessageIo.Receiver);
             AccessorySetting = new AccessorySettingViewModel(Model.Accessory, Model.Layout);
             SettingIo = new SettingIoViewModel(Model, Model.Automation, SaveFileManager, MessageSender);

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/AccessoryItemNameViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/AccessoryItemNameViewModel.cs
@@ -1,0 +1,19 @@
+﻿namespace Baku.VMagicMirrorConfig
+{
+    public class AccessoryItemNameViewModel : ViewModelBase
+    {
+        public AccessoryItemNameViewModel(string fileId, string displayName)
+        {
+            FileId = fileId;
+            DisplayName = displayName;
+        }
+
+        public string FileId { get; }
+
+        //NOTE: 実装の都合上ViewModelが発生してからなくなるまでの間は表示名が不変なので、単に値を持っておけばOK
+        public string DisplayName { get; }
+
+        public static AccessoryItemNameViewModel None { get; }
+            = new AccessoryItemNameViewModel("", "(None)");
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/AccessoryItemNameViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/AccessoryItemNameViewModel.cs
@@ -20,6 +20,7 @@ namespace Baku.VMagicMirrorConfig
             OnItemRefreshed();
 
             _model.ItemUpdated += OnItemUpdated;
+            _model.ItemNameMaybeChanged += OnItemUpdated;
             _model.ItemRefreshed += OnItemRefreshed;
             _model.ItemReloaded += OnItemRefreshed;            
         }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/AccessoryItemNameViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/AccessoryItemNameViewModel.cs
@@ -1,17 +1,109 @@
-﻿namespace Baku.VMagicMirrorConfig
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Baku.VMagicMirrorConfig
 {
+    /// <summary>
+    /// アプリの起動時から終了時までアイテム名の一覧に追従したうえで、
+    /// 選択肢の冒頭に「なし」の選択肢が追加されているようなViewModel.
+    /// ComboBoxで使えるように作られている
+    /// </summary>
+    public class AccessoryItemNamesViewModel
+    {
+        internal AccessoryItemNamesViewModel(AccessorySettingModel model)
+        {
+            _model = model;
+            Items = new ReadOnlyObservableCollection<AccessoryItemNameViewModel>(_items);
+            _items.Add(AccessoryItemNameViewModel.None);
+            OnItemRefreshed();
+
+            _model.ItemUpdated += OnItemUpdated;
+            _model.ItemRefreshed += OnItemRefreshed;
+            _model.ItemReloaded += OnItemRefreshed;            
+        }
+
+        private readonly AccessorySettingModel _model;
+
+        private readonly ObservableCollection<AccessoryItemNameViewModel> _items
+            = new ObservableCollection<AccessoryItemNameViewModel>();
+
+        public ReadOnlyObservableCollection<AccessoryItemNameViewModel> Items { get; }
+
+        private void OnItemRefreshed()
+        {
+            //TODO: 変化しないアイテムについてはインスタンスを維持しつつDisplayNameをあわせる
+            //消えたり増えたアイテムに対しては素朴に要素を増減する
+
+            var itemToRemove = new List<AccessoryItemNameViewModel>();
+            var itemToAdd = new List<AccessoryItemSetting>();
+
+            //既存要素の更新+足りないものチェック
+            foreach (var item in _model.Items.Items)
+            {
+                if (_items.FirstOrDefault(i => i.FileId == item.FileId) is { } target)
+                {
+                    target.DisplayName.Value = item.Name;
+                }
+                else
+                {
+                    itemToAdd.Add(item);
+                }
+            }
+
+            //余計なもの削除 + 足りないもの追加: 冒頭の空要素は削除しないことに注意
+            foreach (var item in _items.Skip(1))
+            {
+                if (!_model.Items.Items.Any(i => i.FileId == item.FileId))
+                {
+                    itemToRemove.Add(item);
+                }
+            }
+
+            foreach (var item in itemToRemove)
+            {
+                _items.Remove(item);
+            }
+
+            foreach (var item in itemToAdd)
+            {
+                _items.Add(new AccessoryItemNameViewModel(item.FileId, item.Name));
+            }
+
+            //ModelのItemsを正として並び順を揃える: 冒頭に空要素を置いているぶんインデックスがずれることに注意
+            for(int i = 0; i < _model.Items.Items.Length; i++)
+            {
+                var fileId = _model.Items.Items[i].FileId;
+                var item = _items.First(i => i.FileId == fileId);
+                var currentIndex = _items.IndexOf(item);
+                if (currentIndex != i + 1)
+                {
+                    _items.Move(currentIndex, i + 1);
+                }
+            }
+        }
+
+        private void OnItemUpdated(AccessoryItemSetting item)
+        {
+            if (_items.FirstOrDefault(i => i.FileId == item.FileId) is { } target)
+            {
+                target.DisplayName.Value = item.Name;
+            }
+        }
+    }
+
     public class AccessoryItemNameViewModel : ViewModelBase
     {
         public AccessoryItemNameViewModel(string fileId, string displayName)
         {
             FileId = fileId;
-            DisplayName = displayName;
+            DisplayName.Value = displayName;
         }
 
         public string FileId { get; }
 
-        //NOTE: 実装の都合上ViewModelが発生してからなくなるまでの間は表示名が不変なので、単に値を持っておけばOK
-        public string DisplayName { get; }
+        public RProperty<string> DisplayName { get; } = new RProperty<string>("");
 
         public static AccessoryItemNameViewModel None { get; }
             = new AccessoryItemNameViewModel("", "(None)");

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/FaceSwitchViewModels.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/FaceSwitchViewModels.cs
@@ -26,6 +26,8 @@ namespace Baku.VMagicMirrorConfig
 
         #region 保存しないでよい値
 
+        public RProperty<bool> ShowAccessoryOption => _parent.ShowAccessoryOption;
+
         /// <summary> 
         /// "この表情のパラメタがN%以上になったら"みたいなしきい値の取りうる値。
         /// 細かく設定できる意味がないので10%刻みです。
@@ -35,7 +37,11 @@ namespace Baku.VMagicMirrorConfig
             .Select(i => new ThresholdItem(i * 10, $"{i * 10}%"))
             .ToArray();
 
-        public ReadOnlyObservableCollection<string> BlendShapeNames => _parent.BlendShapeNames;
+        public ReadOnlyObservableCollection<string> BlendShapeNames 
+            => _parent.BlendShapeNames;
+
+        public ReadOnlyObservableCollection<AccessoryItemNameViewModel> AvailableAccessoryNames 
+            => _parent.AvailableAccessoryNames.Items;
 
         private string _instruction = "";
         public string Instruction
@@ -85,6 +91,21 @@ namespace Baku.VMagicMirrorConfig
                 if (_model.KeepLipSync != value)
                 {
                     _model.KeepLipSync = value;
+                    RaisePropertyChanged();
+                    _parent.SaveFaceSwitchSetting();
+                }
+            }
+        }
+
+        public string AccessoryName
+        {
+            get => _model.AccessoryName;
+            set
+            {
+                if (_model.AccessoryName != value)
+                {
+                    LogOutput.Instance.Write($"Accessory Name Updated, from={_model.AccessoryName}, to={value}");
+                    _model.AccessoryName = value;
                     RaisePropertyChanged();
                     _parent.SaveFaceSwitchSetting();
                 }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/WordToMotionItemViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/WordToMotionItemViewModel.cs
@@ -6,7 +6,11 @@ namespace Baku.VMagicMirrorConfig
 {
     public class WordToMotionItemViewModel : ViewModelBase
     {
-        public WordToMotionItemViewModel(WordToMotionSettingViewModel parent, MotionRequest model)
+        internal WordToMotionItemViewModel(
+            WordToMotionSettingViewModel parent, 
+            MotionRequest model,
+            AccessorySettingSync accessoryModel
+            )
         {
             _parent = parent;
             MotionRequest = model;
@@ -18,6 +22,11 @@ namespace Baku.VMagicMirrorConfig
                 new ReadOnlyObservableCollection<BlendShapeItemViewModel>(_blendShapeItems);
             ExtraBlendShapeItems =
                 new ReadOnlyObservableCollection<BlendShapeItemViewModel>(_extraBlendShapeItems);
+
+            AvailableAccessoryNames = new[] { AccessoryItemNameViewModel.None }
+                .Concat(accessoryModel.Items.Items
+                    .Select(item => new AccessoryItemNameViewModel(item.FileId, item.Name)))
+                .ToArray();
 
             LoadFromModel(model);
         }
@@ -184,6 +193,13 @@ namespace Baku.VMagicMirrorConfig
             set => SetValue(ref _customMotionClipName, value);
         }
 
+        private string _accessoryName = "";
+        public string AccessoryName
+        {
+            get => _accessoryName;
+            set => SetValue(ref _accessoryName, value);
+        }
+
         private bool _useBlendShape = false;
         /// <summary>このアイテムがブレンドシェイプの変更要求を含んでいるかどうかを取得、設定します。</summary>
         public bool UseBlendShape
@@ -221,6 +237,10 @@ namespace Baku.VMagicMirrorConfig
         public ReadOnlyObservableCollection<BlendShapeItemViewModel> ExtraBlendShapeItems { get; }
         private ObservableCollection<BlendShapeItemViewModel> _extraBlendShapeItems
             = new ObservableCollection<BlendShapeItemViewModel>();
+
+
+        //NOTE: 編集UIが出ている間は内容は不変
+        public AccessoryItemNameViewModel[] AvailableAccessoryNames { get; }
 
         #region Commands
 
@@ -276,6 +296,7 @@ namespace Baku.VMagicMirrorConfig
 
             model.BuiltInAnimationClipName = BuiltInClipName;
             model.CustomMotionClipName = CustomMotionClipName;
+            model.AccessoryName = AccessoryName;
             model.UseBlendShape = UseBlendShape;
             model.HoldBlendShape = HoldBlendShape;
             model.PreferLipSync = PreferLipSync;
@@ -323,6 +344,7 @@ namespace Baku.VMagicMirrorConfig
 
             BuiltInClipName = model.BuiltInAnimationClipName;
             CustomMotionClipName = model.CustomMotionClipName;
+            AccessoryName = model.AccessoryName;
 
             UseBlendShape = model.UseBlendShape;
             HoldBlendShape = model.HoldBlendShape;

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/WordToMotionItemViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/WordToMotionItemViewModel.cs
@@ -6,11 +6,7 @@ namespace Baku.VMagicMirrorConfig
 {
     public class WordToMotionItemViewModel : ViewModelBase
     {
-        internal WordToMotionItemViewModel(
-            WordToMotionSettingViewModel parent, 
-            MotionRequest model,
-            AccessorySettingSync accessoryModel
-            )
+        internal WordToMotionItemViewModel(WordToMotionSettingViewModel parent, MotionRequest model)
         {
             _parent = parent;
             MotionRequest = model;
@@ -22,11 +18,6 @@ namespace Baku.VMagicMirrorConfig
                 new ReadOnlyObservableCollection<BlendShapeItemViewModel>(_blendShapeItems);
             ExtraBlendShapeItems =
                 new ReadOnlyObservableCollection<BlendShapeItemViewModel>(_extraBlendShapeItems);
-
-            AvailableAccessoryNames = new[] { AccessoryItemNameViewModel.None }
-                .Concat(accessoryModel.Items.Items
-                    .Select(item => new AccessoryItemNameViewModel(item.FileId, item.Name)))
-                .ToArray();
 
             LoadFromModel(model);
         }
@@ -239,8 +230,8 @@ namespace Baku.VMagicMirrorConfig
             = new ObservableCollection<BlendShapeItemViewModel>();
 
 
-        //NOTE: 編集UIが出ている間は内容は不変
-        public AccessoryItemNameViewModel[] AvailableAccessoryNames { get; }
+        public ReadOnlyObservableCollection<AccessoryItemNameViewModel> AvailableAccessoryNames
+            => _parent.AvailableAccessoryNames.Items;
 
         #region Commands
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WordToMotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WordToMotionSettingViewModel.cs
@@ -10,10 +10,12 @@ namespace Baku.VMagicMirrorConfig
         internal WordToMotionSettingViewModel(
             WordToMotionSettingSync model,
             LayoutSettingSync layoutModel,
+            AccessorySettingSync accessoryModel,
             IMessageSender sender, IMessageReceiver receiver) : base(sender)
         {
             _model = model;
             _layoutModel = layoutModel;
+            _accessoryModel = accessoryModel;
             Items = new ReadOnlyObservableCollection<WordToMotionItemViewModel>(_items);
             CustomMotionClipNames = new ReadOnlyObservableCollection<string>(_customMotionClipNames);
             Devices = WordToMotionDeviceItem.LoadAvailableItems();
@@ -65,6 +67,7 @@ namespace Baku.VMagicMirrorConfig
 
         private readonly WordToMotionSettingSync _model;
         private readonly LayoutSettingSync _layoutModel;
+        private readonly AccessorySettingSync _accessoryModel;
         private WordToMotionItemViewModel? _dialogItem;
 
         /// <summary>直近で読み込んだモデルに指定されている、VRM標準以外のブレンドシェイプ名の一覧を取得します。</summary>
@@ -196,7 +199,7 @@ namespace Baku.VMagicMirrorConfig
                     }
                 }
 
-                _items.Add(new WordToMotionItemViewModel(this, item));
+                _items.Add(new WordToMotionItemViewModel(this, item, _accessoryModel));
             }
         }
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WordToMotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WordToMotionSettingViewModel.cs
@@ -10,7 +10,7 @@ namespace Baku.VMagicMirrorConfig
         internal WordToMotionSettingViewModel(
             WordToMotionSettingSync model,
             LayoutSettingSync layoutModel,
-            AccessorySettingSync accessoryModel,
+            AccessorySettingModel accessoryModel,
             IMessageSender sender, IMessageReceiver receiver) : base(sender)
         {
             _model = model;
@@ -19,6 +19,7 @@ namespace Baku.VMagicMirrorConfig
             Items = new ReadOnlyObservableCollection<WordToMotionItemViewModel>(_items);
             CustomMotionClipNames = new ReadOnlyObservableCollection<string>(_customMotionClipNames);
             Devices = WordToMotionDeviceItem.LoadAvailableItems();
+            AvailableAccessoryNames = new AccessoryItemNamesViewModel(accessoryModel);
 
             AddNewItemCommand = new ActionCommand(() => model.AddNewItem());
             OpenKeyAssignmentEditorCommand = new ActionCommand(() => OpenKeyAssignmentEditor());
@@ -67,11 +68,13 @@ namespace Baku.VMagicMirrorConfig
 
         private readonly WordToMotionSettingSync _model;
         private readonly LayoutSettingSync _layoutModel;
-        private readonly AccessorySettingSync _accessoryModel;
+        private readonly AccessorySettingModel _accessoryModel;
         private WordToMotionItemViewModel? _dialogItem;
 
         /// <summary>直近で読み込んだモデルに指定されている、VRM標準以外のブレンドシェイプ名の一覧を取得します。</summary>
         public IReadOnlyList<string> LatestAvaterExtraClipNames => _latestAvaterExtraClipNames;
+
+        public AccessoryItemNamesViewModel AvailableAccessoryNames { get; }
 
         private string[] _latestAvaterExtraClipNames = new string[0];
 
@@ -199,7 +202,7 @@ namespace Baku.VMagicMirrorConfig
                     }
                 }
 
-                _items.Add(new WordToMotionItemViewModel(this, item, _accessoryModel));
+                _items.Add(new WordToMotionItemViewModel(this, item));
             }
         }
 


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [ ] Bug fix
- [x] Add new feature
- [x] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

ref: #722 

妥協している挙動

- Word to Motionと組み合わせた場合、モーションの終了よりもやや早めに(=モーションのブレンディングの開始時点で)アクセサリーが非表示になる

## How to confirm

基本機能:

- Word to Motionでアクセサリーが指定されたアイテムをプレビュー表示した場合、それが表示される
- Word to Motionでプレビューではない形で何かのアイテムを実行した場合、アクセサリーが指定されていると表示される
    - とくに、表情のみ/モーションのみのアイテムのいずれでもアクセサリーが表示される
- Face Switchで`アクセサリーオプションを表示`をチェックして、表情に付随したアクセサリーが出るように選択してから実際にその表情にすると表示される
    - ここで、表情自体が`(何もしない)`になっていてアクセサリーだけ指定した場合も表示される

基本以外: 

- 連番画像アクセサリーについて、非表示にして再表示すると0枚目からアニメーションが開始し直す
- アクセサリータブでアクセサリーの表示名を変更すると、FaceSwitchのアクセサリー名選択欄にただちに反映される
- フリーレイアウトモードのとき、Face Switchなどで表示したアクセサリーに対してはギズモが表示されず、アクセサリータブで表示をオンにした場合だけギズモが表示される
