### PR TITLE
Add twist body motion option

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
@@ -28,7 +28,7 @@ namespace Baku.VMagicMirror
         }
 
         [Inject]
-        public void Initialize(IVRMLoadable vrmLoadable)
+        public void Initialize(IVRMLoadable vrmLoadable, IMessageReceiver receiver)
         {
             vrmLoadable.VrmLoaded += info =>
             {
@@ -47,6 +47,15 @@ namespace Baku.VMagicMirror
                 _neck = null;
                 SetZeroTarget();
             };
+            
+            receiver.AssignCommandHandler(
+                VmmCommands.EnableTwistBodyMotion,
+                c =>
+                {
+                    var enableTwistBodyMotion = c.ToBoolean();
+                    _roll.EnableTwistMotion = enableTwistBodyMotion;
+                    _yaw.EnableTwistMotion = enableTwistBodyMotion;
+                });
         }
 
         private void Update()
@@ -57,7 +66,7 @@ namespace Baku.VMagicMirror
 
             BodyLeanSuggest = Quaternion.Euler(
                 _pitch.PitchAngleDegree,
-                _yaw.YawAngleDegree, 
+                _yaw.YawAngleDegree,
                 _roll.RollAngleDegree
                 );
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceRollToBodyRoll.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceRollToBodyRoll.cs
@@ -8,7 +8,7 @@ namespace Baku.VMagicMirror
     public sealed class FaceRollToBodyRoll
     {
         //最終的に胴体ロールは頭ロールの何倍であるべきか、という値
-        private const float GoalRate = 0.1f;
+        private float GoalRate => EnableTwistMotion ? -0.05f : 0.1f;
 
         //ゴールに持ってくときの速度基準にする時定数っぽいやつ
         private const float TimeFactor = 0.3f;
@@ -17,13 +17,17 @@ namespace Baku.VMagicMirror
         private const float SpeedDumpFactor = 0.95f;
 
         //ゴール回転値に持っていくとき、スピードをどのくらい素早く適用するか
-        private const float SpeedLerpFactor = 18.0f;
+        private float SpeedLerpFactor => EnableTwistMotion ? 24f : 18f;
+        
+        public bool EnableTwistMotion { get; set; }
         
         private float _speedDegreePerSec = 0;
         public float RollAngleDegree { get; private set; }
 
         //NOTE: この値はフィルタされてない生のやつ
         public float RawTargetAngle { get; private set; }
+
+        public float FactoredRawTargetAngle => RawTargetAngle * GoalRate;
 
         public void UpdateSuggestAngle()
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceYawToBodyYaw.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceYawToBodyYaw.cs
@@ -7,14 +7,17 @@ namespace Baku.VMagicMirror
     /// </summary>
     public sealed class FaceYawToBodyYaw
     {
-        //最終的に胴体ヨーは頭ヨーの何倍であるべきか、という値
-        private const float GoalRate = 0.3f;
         //ゴールに持ってくときの速度基準にする時定数っぽいやつ
         private const float TimeFactor = 0.15f;
         //ゴール回転値に持ってくとき、スピードに掛けるダンピング項
         private const float SpeedDumpFactor = 0.98f;
+
+        //最終的に胴体ヨーは頭ヨーの何倍であるべきか、という値
+        private float GoalRate => EnableTwistMotion ? -0.2f : 0.3f;
         //ゴール回転値に持っていくとき、スピードをどのくらい素早く適用するか
-        private const float SpeedLerpFactor = 12.0f;
+        private float SpeedLerpFactor => EnableTwistMotion ? 18f : 12f;
+        
+        public bool EnableTwistMotion { get; set; }
         
         private float _speedDegreePerSec = 0;
         public float YawAngleDegree { get; private set; }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -59,6 +59,7 @@ namespace Baku.VMagicMirror
         
         // Motion, Body
         public const string EnableNoHandTrackMode = nameof(EnableNoHandTrackMode);
+        public const string EnableTwistBodyMotion = nameof(EnableTwistBodyMotion);
         public const string EnableBodyLeanZ = nameof(EnableBodyLeanZ);
 
         // Motion, Face

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -18,6 +18,8 @@
 
         public bool EnableNoHandTrackMode { get; set; } = false;
 
+        public bool EnableTwistBodyMotion { get; set; } = false;
+
         #endregion
 
         #region Face

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -68,6 +68,7 @@ namespace Baku.VMagicMirrorConfig
         #region モーション
 
         public Message EnableNoHandTrackMode(bool enable) => WithArg($"{enable}");
+        public Message EnableTwistBodyMotion(bool enable) => WithArg($"{enable}");
 
         public Message LengthFromWristToTip(int lengthCentimeter) => WithArg($"{lengthCentimeter}");
 

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace Baku.VMagicMirrorConfig
@@ -17,6 +16,12 @@ namespace Baku.VMagicMirrorConfig
 
         private static Message WithArg(string content, [CallerMemberName] string command = "")
             => new Message(command, content);
+
+        private static Message WithArg(bool content, [CallerMemberName] string command = "")
+            => WithArg(content.ToString(), command);
+
+        private static Message WithArg(int content, [CallerMemberName] string command = "")
+            => WithArg(content.ToString(), command);
 
         public Message Language(string langName) => WithArg(langName);
 
@@ -44,10 +49,10 @@ namespace Baku.VMagicMirrorConfig
 
         public Message Chromakey(int a, int r, int g, int b) => WithArg($"{a},{r},{g},{b}");
 
-        public Message WindowFrameVisibility(bool v) => WithArg($"{v}");
-        public Message IgnoreMouse(bool v) => WithArg($"{v}");
-        public Message TopMost(bool v) => WithArg($"{v}");
-        public Message WindowDraggable(bool v) => WithArg($"{v}");
+        public Message WindowFrameVisibility(bool v) => WithArg(v);
+        public Message IgnoreMouse(bool v) => WithArg(v);
+        public Message TopMost(bool v) => WithArg(v);
+        public Message WindowDraggable(bool v) => WithArg(v);
 
         /// <summary>
         /// NOTE: 空文字列なら背景画像を外す処理をやる。
@@ -59,61 +64,61 @@ namespace Baku.VMagicMirrorConfig
         public Message MoveWindow(int x, int y) => WithArg($"{x},{y}");
         public Message ResetWindowSize() => NoArg();
 
-        public Message SetWholeWindowTransparencyLevel(int level) => WithArg($"{level}");
+        public Message SetWholeWindowTransparencyLevel(int level) => WithArg(level);
 
-        public Message SetAlphaValueOnTransparent(int alpha) => WithArg($"{alpha}");
+        public Message SetAlphaValueOnTransparent(int alpha) => WithArg(alpha);
 
         #endregion
 
         #region モーション
 
-        public Message EnableNoHandTrackMode(bool enable) => WithArg($"{enable}");
-        public Message EnableTwistBodyMotion(bool enable) => WithArg($"{enable}");
+        public Message EnableNoHandTrackMode(bool enable) => WithArg(enable);
+        public Message EnableTwistBodyMotion(bool enable) => WithArg(enable);
 
-        public Message LengthFromWristToTip(int lengthCentimeter) => WithArg($"{lengthCentimeter}");
+        public Message LengthFromWristToTip(int lengthCentimeter) => WithArg(lengthCentimeter);
 
-        public Message HandYOffsetBasic(int offsetCentimeter) => WithArg($"{offsetCentimeter}");
-        public Message HandYOffsetAfterKeyDown(int offsetCentimeter) => WithArg($"{offsetCentimeter}");
+        public Message HandYOffsetBasic(int offsetCentimeter) => WithArg(offsetCentimeter);
+        public Message HandYOffsetAfterKeyDown(int offsetCentimeter) => WithArg(offsetCentimeter);
 
-        public Message EnableHidRandomTyping(bool enable) => WithArg($"{enable}");
-        public Message EnableShoulderMotionModify(bool enable) => WithArg($"{enable}");
-        public Message EnableTypingHandDownTimeout(bool enable) => WithArg($"{enable}");
-        public Message SetWaistWidth(int waistWidthCentimeter) => WithArg($"{waistWidthCentimeter}");
-        public Message SetElbowCloseStrength(int strengthPercent) => WithArg($"{strengthPercent}");
+        public Message EnableHidRandomTyping(bool enable) => WithArg(enable);
+        public Message EnableShoulderMotionModify(bool enable) => WithArg(enable);
+        public Message EnableTypingHandDownTimeout(bool enable) => WithArg(enable);
+        public Message SetWaistWidth(int waistWidthCentimeter) => WithArg(waistWidthCentimeter);
+        public Message SetElbowCloseStrength(int strengthPercent) => WithArg(strengthPercent);
 
-        public Message EnableFpsAssumedRightHand(bool enable) => WithArg($"{enable}");
-        public Message PresentationArmRadiusMin(int radiusMinCentimeter) => WithArg($"{radiusMinCentimeter}");
+        public Message EnableFpsAssumedRightHand(bool enable) => WithArg(enable);
+        public Message PresentationArmRadiusMin(int radiusMinCentimeter) => WithArg(radiusMinCentimeter);
 
-        public Message SetKeyboardAndMouseMotionMode(int modeIndex) => WithArg($"{modeIndex}");
-        public Message SetGamepadMotionMode(int modeIndex) => WithArg($"{modeIndex}");
+        public Message SetKeyboardAndMouseMotionMode(int modeIndex) => WithArg(modeIndex);
+        public Message SetGamepadMotionMode(int modeIndex) => WithArg(modeIndex);
 
-        public Message EnableWaitMotion(bool enable) => WithArg($"{enable}");
-        public Message WaitMotionScale(int scalePercent) => WithArg($"{scalePercent}");
-        public Message WaitMotionPeriod(int periodSec) => WithArg($"{periodSec}");
+        public Message EnableWaitMotion(bool enable) => WithArg(enable);
+        public Message WaitMotionScale(int scalePercent) => WithArg(scalePercent);
+        public Message WaitMotionPeriod(int periodSec) => WithArg(periodSec);
 
         public Message CalibrateFace() => NoArg();
         public Message SetCalibrateFaceData(string data) => WithArg(data);
 
-        public Message EnableFaceTracking(bool enable) => WithArg($"{enable}");
+        public Message EnableFaceTracking(bool enable) => WithArg(enable);
         public Message SetCameraDeviceName(string deviceName) => WithArg(deviceName);
-        public Message AutoBlinkDuringFaceTracking(bool enable) => WithArg($"{enable}");
-        public Message EnableBodyLeanZ(bool enable) => WithArg($"{enable}");
-        public Message EnableLipSyncBasedBlinkAdjust(bool enable) => WithArg($"{enable}");
-        public Message EnableHeadRotationBasedBlinkAdjust(bool enable) => WithArg($"{enable}");
-        public Message EnableVoiceBasedMotion(bool enable) => WithArg($"{enable}");
+        public Message AutoBlinkDuringFaceTracking(bool enable) => WithArg(enable);
+        public Message EnableBodyLeanZ(bool enable) => WithArg(enable);
+        public Message EnableLipSyncBasedBlinkAdjust(bool enable) => WithArg(enable);
+        public Message EnableHeadRotationBasedBlinkAdjust(bool enable) => WithArg(enable);
+        public Message EnableVoiceBasedMotion(bool enable) => WithArg(enable);
         //NOTE: falseのほうが普通だよ、という状態にするため、disable云々というやや面倒な言い方になってる事に注意
-        public Message DisableFaceTrackingHorizontalFlip(bool disable) => WithArg($"{disable}");
+        public Message DisableFaceTrackingHorizontalFlip(bool disable) => WithArg(disable);
 
-        public Message EnableImageBasedHandTracking(bool enable) => WithArg($"{enable}");
-        public Message ShowEffectDuringHandTracking(bool enable) => WithArg($"{enable}");
+        public Message EnableImageBasedHandTracking(bool enable) => WithArg(enable);
+        public Message ShowEffectDuringHandTracking(bool enable) => WithArg(enable);
         //Faceと同じく、disableという言い回しに注意
-        public Message DisableHandTrackingHorizontalFlip(bool disable) => WithArg($"{disable}");
-        public Message EnableSendHandTrackingResult(bool enable) => WithArg($"{enable}");
+        public Message DisableHandTrackingHorizontalFlip(bool disable) => WithArg(disable);
+        public Message EnableSendHandTrackingResult(bool enable) => WithArg(enable);
 
 
-        public Message EnableWebCamHighPowerMode(bool enable) => WithArg($"{enable}");
+        public Message EnableWebCamHighPowerMode(bool enable) => WithArg(enable);
 
-        public Message FaceDefaultFun(int percentage) => WithArg($"{percentage}");
+        public Message FaceDefaultFun(int percentage) => WithArg(percentage);
         public Message FaceNeutralClip(string clipName) => WithArg(clipName);
         public Message FaceOffsetClip(string clipName) => WithArg(clipName);
 
@@ -124,13 +129,13 @@ namespace Baku.VMagicMirrorConfig
         /// <returns></returns>
         public Message CameraDeviceNames() => NoArg();
 
-        public Message EnableTouchTyping(bool enable) => WithArg($"{enable}");
+        public Message EnableTouchTyping(bool enable) => WithArg(enable);
 
-        public Message EnableLipSync(bool enable) => WithArg($"{enable}");
+        public Message EnableLipSync(bool enable) => WithArg(enable);
 
         public Message SetMicrophoneDeviceName(string deviceName) => WithArg(deviceName);
-        public Message SetMicrophoneSensitivity(int sensitivity) => WithArg($"{sensitivity}");
-        public Message SetMicrophoneVolumeVisibility(bool isVisible) => WithArg($"{isVisible}");
+        public Message SetMicrophoneSensitivity(int sensitivity) => WithArg(sensitivity);
+        public Message SetMicrophoneVolumeVisibility(bool isVisible) => WithArg(isVisible);
 
         /// <summary>
         /// Query.
@@ -139,17 +144,17 @@ namespace Baku.VMagicMirrorConfig
         public Message MicrophoneDeviceNames() => NoArg();
 
         public Message LookAtStyle(string v) => WithArg(v);
-        public Message SetEyeBoneRotationScale(int percent) => WithArg($"{percent}");
+        public Message SetEyeBoneRotationScale(int percent) => WithArg(percent);
 
         #endregion
 
         #region カメラの配置
 
-        public Message CameraFov(int cameraFov) => WithArg($"{cameraFov}");
+        public Message CameraFov(int cameraFov) => WithArg(cameraFov);
         public Message SetCustomCameraPosition(string posData) => WithArg(posData);
         public Message QuickLoadViewPoint(string posData) => WithArg(posData);
 
-        public Message EnableFreeCameraMode(bool enable) => WithArg($"{enable}");
+        public Message EnableFreeCameraMode(bool enable) => WithArg(enable);
 
         public Message ResetCameraPosition() => NoArg();
 
@@ -163,15 +168,15 @@ namespace Baku.VMagicMirrorConfig
 
         #region キーボード・マウスパッド
 
-        public Message HidVisibility(bool visible) => WithArg($"{visible}");
+        public Message HidVisibility(bool visible) => WithArg(visible);
 
-        public Message SetPenVisibility(bool visible) => WithArg($"{visible}");
+        public Message SetPenVisibility(bool visible) => WithArg(visible);
 
-        public Message MidiControllerVisibility(bool visible) => WithArg($"{visible}");
+        public Message MidiControllerVisibility(bool visible) => WithArg(visible);
 
-        public Message SetKeyboardTypingEffectType(int typeIndex) => WithArg($"{typeIndex}");
+        public Message SetKeyboardTypingEffectType(int typeIndex) => WithArg(typeIndex);
 
-        public Message EnableDeviceFreeLayout(bool enable) => WithArg($"{enable}");
+        public Message EnableDeviceFreeLayout(bool enable) => WithArg(enable);
 
         public Message SetDeviceLayout(string data) => WithArg(data);
 
@@ -187,23 +192,23 @@ namespace Baku.VMagicMirrorConfig
 
         #region MIDI
 
-        public Message EnableMidiRead(bool enable) => WithArg($"{enable}");
+        public Message EnableMidiRead(bool enable) => WithArg(enable);
 
         #endregion
 
         #region ゲームパッド
 
-        public Message EnableGamepad(bool enable) => WithArg($"{enable}");
-        public Message PreferDirectInputGamepad(bool preferDirectInput) => WithArg($"{preferDirectInput}");
-        public Message GamepadHeight(int height) => WithArg($"{height}");
-        public Message GamepadHorizontalScale(int scale) => WithArg($"{scale}");
+        public Message EnableGamepad(bool enable) => WithArg(enable);
+        public Message PreferDirectInputGamepad(bool preferDirectInput) => WithArg(preferDirectInput);
+        public Message GamepadHeight(int height) => WithArg(height);
+        public Message GamepadHorizontalScale(int scale) => WithArg(scale);
 
-        public Message GamepadVisibility(bool visibility) => WithArg($"{visibility}");
+        public Message GamepadVisibility(bool visibility) => WithArg(visibility);
 
         public Message GamepadLeanMode(string v) => WithArg(v);
 
-        public Message GamepadLeanReverseHorizontal(bool reverse) => WithArg($"{reverse}");
-        public Message GamepadLeanReverseVertical(bool reverse) => WithArg($"{reverse}");
+        public Message GamepadLeanReverseHorizontal(bool reverse) => WithArg(reverse);
+        public Message GamepadLeanReverseVertical(bool reverse) => WithArg(reverse);
 
         #endregion
 
@@ -215,7 +220,7 @@ namespace Baku.VMagicMirrorConfig
         /// <returns></returns>
         public Message GetQualitySettingsInfo() => NoArg();
         public Message SetImageQuality(string name) => WithArg(name);
-        public Message SetHalfFpsMode(bool enable) => WithArg($"{enable}");
+        public Message SetHalfFpsMode(bool enable) => WithArg(enable);
 
         /// <summary>
         /// Query
@@ -224,25 +229,25 @@ namespace Baku.VMagicMirrorConfig
         public Message ApplyDefaultImageQuality() => NoArg();
 
         public Message LightColor(int r, int g, int b) => WithArg($"{r},{g},{b}");
-        public Message LightIntensity(int intensityPercent) => WithArg($"{intensityPercent}");
-        public Message LightYaw(int angleDeg) => WithArg($"{angleDeg}");
-        public Message LightPitch(int angleDeg) => WithArg($"{angleDeg}");
-        public Message UseDesktopLightAdjust(bool use) => WithArg($"{use}");
+        public Message LightIntensity(int intensityPercent) => WithArg(intensityPercent);
+        public Message LightYaw(int angleDeg) => WithArg(angleDeg);
+        public Message LightPitch(int angleDeg) => WithArg(angleDeg);
+        public Message UseDesktopLightAdjust(bool use) => WithArg(use);
 
-        public Message ShadowEnable(bool enable) => WithArg($"{enable}");
-        public Message ShadowIntensity(int intensityPercent) => WithArg($"{intensityPercent}");
-        public Message ShadowYaw(int angleDeg) => WithArg($"{angleDeg}");
-        public Message ShadowPitch(int angleDeg) => WithArg($"{angleDeg}");
-        public Message ShadowDepthOffset(int depthCentimeter) => WithArg($"{depthCentimeter}");
+        public Message ShadowEnable(bool enable) => WithArg(enable);
+        public Message ShadowIntensity(int intensityPercent) => WithArg(intensityPercent);
+        public Message ShadowYaw(int angleDeg) => WithArg(angleDeg);
+        public Message ShadowPitch(int angleDeg) => WithArg(angleDeg);
+        public Message ShadowDepthOffset(int depthCentimeter) => WithArg(depthCentimeter);
 
         public Message BloomColor(int r, int g, int b) => WithArg($"{r},{g},{b}");
-        public Message BloomIntensity(int intensityPercent) => WithArg($"{intensityPercent}");
-        public Message BloomThreshold(int thresholdPercent) => WithArg($"{thresholdPercent}");
+        public Message BloomIntensity(int intensityPercent) => WithArg(intensityPercent);
+        public Message BloomThreshold(int thresholdPercent) => WithArg(thresholdPercent);
 
-        public Message WindEnable(bool enableWind) => WithArg($"{enableWind}");
-        public Message WindStrength(int strength) => WithArg($"{strength}");
-        public Message WindInterval(int percentage) => WithArg($"{percentage}");
-        public Message WindYaw(int windYaw) => WithArg($"{windYaw}");
+        public Message WindEnable(bool enableWind) => WithArg(enableWind);
+        public Message WindStrength(int strength) => WithArg(strength);
+        public Message WindInterval(int percentage) => WithArg(percentage);
+        public Message WindYaw(int windYaw) => WithArg(windYaw);
 
         #endregion
 
@@ -252,12 +257,12 @@ namespace Baku.VMagicMirrorConfig
 
         //NOTE: 以下の3つはユーザーが動作チェックに使う
         public Message PlayWordToMotionItem(string word) => WithArg(word);
-        public Message EnableWordToMotionPreview(bool enable) => WithArg($"{enable}");
+        public Message EnableWordToMotionPreview(bool enable) => WithArg(enable);
         public Message SendWordToMotionPreviewInfo(string json) => WithArg(json);
-        public Message SetDeviceTypeToStartWordToMotion(int deviceType) => WithArg($"{deviceType}");
+        public Message SetDeviceTypeToStartWordToMotion(int deviceType) => WithArg(deviceType);
 
         public Message LoadMidiNoteToMotionMap(string content) => WithArg(content);
-        public Message RequireMidiNoteOnMessage(bool require) => WithArg($"{require}");
+        public Message RequireMidiNoteOnMessage(bool require) => WithArg(require);
 
         public Message RequestCustomMotionDoctor() => NoArg();
 
@@ -272,11 +277,11 @@ namespace Baku.VMagicMirrorConfig
         #region External Tracker
 
         //共通: 基本操作のオン/オフ + キャリブレーション
-        public Message ExTrackerEnable(bool enable) => WithArg($"{enable}");
-        public Message ExTrackerEnableLipSync(bool enable) => WithArg($"{enable}");
-        public Message ExTrackerEnableEmphasizeExpression(bool enable) => WithArg($"{enable}");
-        public Message ExTrackerEnablePerfectSync(bool enable) => WithArg($"{enable}");
-        public Message ExTrackerUseVRoidDefaultForPerfectSync(bool enable) => WithArg($"{enable}");
+        public Message ExTrackerEnable(bool enable) => WithArg(enable);
+        public Message ExTrackerEnableLipSync(bool enable) => WithArg(enable);
+        public Message ExTrackerEnableEmphasizeExpression(bool enable) => WithArg(enable);
+        public Message ExTrackerEnablePerfectSync(bool enable) => WithArg(enable);
+        public Message ExTrackerUseVRoidDefaultForPerfectSync(bool enable) => WithArg(enable);
         public Message ExTrackerCalibrate() => NoArg();
         //NOTE: このdataについて詳細
         // - Unityが送ってくるのをまるごと保持してたデータを返すだけで、WPF側では中身に関知しない
@@ -285,7 +290,7 @@ namespace Baku.VMagicMirrorConfig
         public Message ExTrackerSetCalibrateData(string data) => WithArg(data);
 
         //連携先の切り替え + アプリ固有設定の送信
-        public Message ExTrackerSetSource(int sourceType) => WithArg($"{sourceType}");
+        public Message ExTrackerSetSource(int sourceType) => WithArg(sourceType);
         public Message ExTrackerSetApplicationValue(ExternalTrackerSettingData data) => WithArg(data.ToJsonString());
 
         //共通: 表情スイッチ機能

--- a/WPF/VMagicMirrorConfig/Model/SettingSync/MotionSettingSync.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingSync/MotionSettingSync.cs
@@ -20,6 +20,7 @@ namespace Baku.VMagicMirrorConfig
             //NOTE: 長大になってるのはプロパティの初期化仕様によるもの。半手動でテキスト変換して作ってます
 
             EnableNoHandTrackMode = new RProperty<bool>(setting.EnableNoHandTrackMode, v => SendMessage(factory.EnableNoHandTrackMode(v)));
+            EnableTwistBodyMotion = new RProperty<bool>(setting.EnableTwistBodyMotion, v => SendMessage(factory.EnableTwistBodyMotion(v)));
 
             EnableFaceTracking = new RProperty<bool>(setting.EnableFaceTracking, v => SendMessage(factory.EnableFaceTracking(v)));
             AutoBlinkDuringFaceTracking = new RProperty<bool>(setting.AutoBlinkDuringFaceTracking, v => SendMessage(factory.AutoBlinkDuringFaceTracking(v)));
@@ -124,6 +125,8 @@ namespace Baku.VMagicMirrorConfig
         #region Full Body 
 
         public RProperty<bool> EnableNoHandTrackMode { get; }
+
+        public RProperty<bool> EnableTwistBodyMotion { get; }
 
         #endregion
 

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -182,6 +182,7 @@ png image and 3D model by glb or gltf is available.</sys:String>
     <sys:String x:Key="Motion_FullBody">Upper Body</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode">Always-Hands-Down Mode (*Increase body move)</sys:String>    
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">Hands-Down Mode</sys:String>    
+    <sys:String x:Key="Motion_FullBody_TwistBodyMotion">Enable Twist Motion</sys:String>    
     
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">Arm</sys:String>    

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -183,7 +183,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_FullBody">上半身</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode">つねに手下げモード (※体の動きが増えます)</sys:String>    
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">つねに手下げモード</sys:String>    
-    <sys:String x:Key="Motion_FullBody_TwistBodyMotion">くねりモーション</sys:String>    
+    <sys:String x:Key="Motion_FullBody_TwistBodyMotion">ひねりモーション</sys:String>    
     
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">腕・ひじ</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -183,6 +183,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_FullBody">上半身</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode">つねに手下げモード (※体の動きが増えます)</sys:String>    
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">つねに手下げモード</sys:String>    
+    <sys:String x:Key="Motion_FullBody_TwistBodyMotion">くねりモーション</sys:String>    
     
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">腕・ひじ</sys:String>

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
@@ -389,6 +389,7 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
@@ -398,15 +399,16 @@
                             <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                                       Margin="10,0"
                                       IsChecked="{Binding MotionSetting.EnableNoHandTrackMode.Value}"
-                                      >
-                                <CheckBox.Content>
-                                    <TextBlock Text="{DynamicResource Motion_FullBody_NoHandTrackMode_Streaming}"/>
-                                </CheckBox.Content>
-                            </CheckBox>
+                                      Content="{DynamicResource Motion_FullBody_NoHandTrackMode_Streaming}"/>
+
+                            <CheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                      Margin="10,0"
+                                      IsChecked="{Binding MotionSetting.EnableTwistBodyMotion.Value}"
+                                      Content="{DynamicResource Motion_FullBody_TwistBodyMotion}"/>
                             
-                            <TextBlock Grid.Row="1" Grid.Column="0"
+                            <TextBlock Grid.Row="2" Grid.Column="0"
                                        Text="{DynamicResource Motion_Arm_MouseAndKeyMode}"/>
-                            <ComboBox Grid.Row="1" Grid.Column="1"
+                            <ComboBox Grid.Row="2" Grid.Column="1"
                                       Margin="10,3" 
                                       Height="30"
                                       IsEnabled="{Binding MotionSetting.EnableNoHandTrackMode.Value, 
@@ -428,8 +430,8 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                             
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource Motion_Arm_GamepadMode}"/>
-                            <ComboBox Grid.Row="2" Grid.Column="1"
+                            <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource Motion_Arm_GamepadMode}"/>
+                            <ComboBox Grid.Row="3" Grid.Column="1"
                                       Margin="10,3" 
                                       IsEnabled="{Binding MotionSetting.EnableNoHandTrackMode.Value, 
                                                           Converter={StaticResource BooleanReverseConverter}}"

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -45,6 +45,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -54,16 +55,16 @@
                         <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
                                   Margin="5,0"
                                   IsChecked="{Binding EnableNoHandTrackMode.Value}"
-                                  >
-                            <CheckBox.Content>
-                                <TextBlock Text="{DynamicResource Motion_FullBody_NoHandTrackMode}"/>
-                            </CheckBox.Content>
-                        </CheckBox>
+                                  Content="{DynamicResource Motion_FullBody_NoHandTrackMode}"/>
 
-
-                        <TextBlock Grid.Row="1" Grid.Column="0"
+                        <CheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                  Margin="5,0"
+                                  IsChecked="{Binding EnableTwistBodyMotion.Value}"
+                                  Content="{DynamicResource Motion_FullBody_TwistBodyMotion}"/>
+                        
+                        <TextBlock Grid.Row="2" Grid.Column="0"
                                        Text="{DynamicResource Motion_Arm_MouseAndKeyMode}"/>
-                        <ComboBox Grid.Row="1" Grid.Column="1"
+                        <ComboBox Grid.Row="2" Grid.Column="1"
                                   Margin="10,3" 
                                   Height="30"
                                   IsEnabled="{Binding EnableNoHandTrackMode.Value,
@@ -85,8 +86,8 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Text="{DynamicResource Motion_Arm_GamepadMode}"/>
-                        <ComboBox Grid.Row="2" Grid.Column="1"
+                        <TextBlock Grid.Row="3" Grid.Column="0" Text="{DynamicResource Motion_Arm_GamepadMode}"/>
+                        <ComboBox Grid.Row="3" Grid.Column="1"
                                   Margin="10,3" 
                                   IsEnabled="{Binding EnableNoHandTrackMode.Value,
                                                       Converter={StaticResource BooleanReverseConverter}}"

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
@@ -212,6 +212,7 @@ namespace Baku.VMagicMirrorConfig
         #region Full Body 
 
         public RProperty<bool> EnableNoHandTrackMode => _model.EnableNoHandTrackMode;
+        public RProperty<bool> EnableTwistBodyMotion => _model.EnableTwistBodyMotion;
 
         #endregion
 


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [ ] Bug fix
- [x] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

#731 

`ひねりモーション` (`Twist Motion`)というオプションを有効にすると、肩が首と同方向ではなく、逆方向に回転するようになります。この機能はデフォルトではオフであり、コントロールパネルの`配信`タブから有効にできます。

https://twitter.com/baku_dreameater/status/1503994882578599937

## Note

コントロールパネルUIの高さがちょっと怪しいことになってますが、
次バージョン(多分v2.0.3)までにコードを含めたUIのリファクタ機会を持つつもりのため、
このPRでは一旦無視しています。
