### PR TITLE
マイク/カメラの接続状態をポーリングする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using NAudio.Wave;
 using Zenject;
 
@@ -93,13 +94,22 @@ namespace Baku.VMagicMirror
         
         public override string[] GetAvailableDeviceNames()
         {
-            var count = WaveInEvent.DeviceCount;
-            var result = new string[count];
-            for (int i = 0; i < count; i++)
+            //NOTE: タイミングによっては切断したデバイスのCapを取りに行ってエラーになることがある。
+            //こうなるとQueryが戻らなくなって都合が悪いため、エラーが起きたら拾える範囲の値だけ使って返却する
+            var result = new List<string>();
+            try
             {
-                result[i] = WaveInEvent.GetCapabilities(i).ProductName;
+                var count = WaveInEvent.DeviceCount;
+                for (int i = 0; i < count; i++)
+                {
+                    result.Add(WaveInEvent.GetCapabilities(i).ProductName);
+                }
             }
-            return result;
+            catch (Exception ex)
+            {
+                LogOutput.Instance.Write(ex);
+            }
+            return result.ToArray();
         }
 
         public override void StopRecording()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/LipSync/NAudioLipSyncContext.cs
@@ -106,6 +106,7 @@ namespace Baku.VMagicMirror
         {
             if (_waveIn != null)
             {
+                _waveIn.RecordingStopped -= OnRecordingStopped;
                 _waveIn.DataAvailable -= OnDataAvailable;
             }
             _waveIn?.StopRecording();
@@ -147,8 +148,18 @@ namespace Baku.VMagicMirror
                 NumberOfBuffers = 25,
                 WaveFormat = new WaveFormat(SampleRate, 2),
             };
+            _waveIn.RecordingStopped += OnRecordingStopped;
             _waveIn.DataAvailable += OnDataAvailable;
             _waveIn.StartRecording();
+        }
+
+        private void OnRecordingStopped(object sender, StoppedEventArgs e)
+        {
+            if (e.Exception != null)
+            {
+                LogOutput.Instance.Write($"Microphone Recording Stopped by exception, {e.Exception.Message}");
+            }
+            StopRecording();
         }
 
         private void OnDataAvailable(object sender, WaveInEventArgs e)

--- a/WPF/VMagicMirrorConfig/Common/RProperty.cs
+++ b/WPF/VMagicMirrorConfig/Common/RProperty.cs
@@ -61,12 +61,17 @@ namespace Baku.VMagicMirrorConfig
         public void SilentSet(T value) { _value = value; }
 
         /// <summary>
+        /// 便宜的にプロパティが変更された扱いにしたい場合に呼ぶ。
+        /// ViewModelとの同期ずれが起きてそうなModelで明示的に呼ぶなど、特殊な状況でのみ用いる
+        /// </summary>
+        public void ForceRaisePropertyChanged() => RaisePropertyChanged();
+
+        /// <summary>
         /// 弱いイベントパターンでプロパティ変更イベントを購読します。
         /// ViewModelからModelのイベントを購読する場合に使用します。
         /// </summary>
         /// <param name="handler"></param>
         public void AddWeakEventHandler(EventHandler<PropertyChangedEventArgs> handler)
             => WeakEventManager<RProperty<T>, PropertyChangedEventArgs>.AddHandler(this, nameof(PropertyChanged), handler);
-
     }
 }

--- a/WPF/VMagicMirrorConfig/Common/SnackbarWrapper.cs
+++ b/WPF/VMagicMirrorConfig/Common/SnackbarWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using MaterialDesignThemes.Wpf;
 
-namespace Baku.VMagicMirrorConfig.View
+namespace Baku.VMagicMirrorConfig
 {
     /// <summary>
     /// スナックバーのラッパークラスです。

--- a/WPF/VMagicMirrorConfig/Depdency/ModelInstaller.cs
+++ b/WPF/VMagicMirrorConfig/Depdency/ModelInstaller.cs
@@ -21,7 +21,6 @@
             resolver.Add(messageIo.Receiver);
             resolver.Add(messageIo.Sender);
 
-            resolver.Add(new DeviceListSource());
             resolver.Add(new LoadedAvatarInfo());
             resolver.Add(new ScreenshotTaker());
 
@@ -43,6 +42,7 @@
             resolver.Add(new AvatarLoader());
 
             resolver.Add(new RuntimeHelper());
+            resolver.Add(new DeviceListSource());
             resolver.Add(new CustomMotionList());
             resolver.Add(new ImageQualitySetting());
             resolver.Add(new WordToMotionRuntimeConfig());

--- a/WPF/VMagicMirrorConfig/Model/Devices/DeviceListSource.cs
+++ b/WPF/VMagicMirrorConfig/Model/Devices/DeviceListSource.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -8,18 +9,30 @@ namespace Baku.VMagicMirrorConfig
     /// <summary> 接続しているマイクやカメラなどのデバイス情報を保持する  </summary>
     class DeviceListSource
     {
-        public DeviceListSource() : this(ModelResolver.Instance.Resolve<IMessageSender>())
+        //あまり頻繁にポーリングしないでも良いと思うが、これ以上遅いとしんどそう
+        private const int DeviceNamesPollingIntervalMillisec = 5000;
+        private const string MicrophoneDisconnectedFormatKey = "Snackbar_MicrophoneDisconnected_Format";
+        private const string MicrophoneReconnectedFormatKey = "Snackbar_MicrophoneReconnected_Format";
+        private const string CameraReconnectedFormatKey = "Snackbar_CameraReconnected_Format";
+
+        public DeviceListSource() : this(
+            ModelResolver.Instance.Resolve<IMessageSender>(),
+            ModelResolver.Instance.Resolve<MotionSettingModel>()
+            )
         {
         }
 
-        public DeviceListSource(IMessageSender sender)
+        public DeviceListSource(IMessageSender sender, MotionSettingModel setting)
         {
             _sender = sender;
+            _setting = setting;
             MicrophoneNames = new ReadOnlyObservableCollection<string>(_microphoneNames);
             CameraNames = new ReadOnlyObservableCollection<string>(_cameraNames);
         }
 
         private readonly IMessageSender _sender;
+        private readonly MotionSettingModel _setting;
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
 
         private readonly ObservableCollection<string> _microphoneNames = new();
         public ReadOnlyObservableCollection<string> MicrophoneNames { get; }
@@ -30,36 +43,136 @@ namespace Baku.VMagicMirrorConfig
         //NOTE: 何回呼び出してもOKなことに注意アプリケーション起動後に呼び直してもOK
         public async Task InitializeDeviceNamesAsync()
         {
-            await InitializeMicrophoneNamesAsync();
-            await InitializeCameraNamesAsync();
+            await InitializeMicrophoneNamesAsync(true);
+            await InitializeCameraNamesAsync(true);
+            new Thread(() => PollingDeviceNames(_cts.Token)).Start();
         }
 
-        private async Task InitializeMicrophoneNamesAsync()
+        public void Dispose() => _cts.Cancel();
+
+        public async Task ReloadDevicesAsync()
+        {
+            var micIsInDeviceNames = _microphoneNames.Contains(_setting.LipSyncMicrophoneDeviceName.Value);
+            var webcamIsInDeviceNames = _cameraNames.Contains(_setting.CameraDeviceName.Value);
+
+            await InitializeMicrophoneNamesAsync(false);
+            await InitializeCameraNamesAsync(false);
+
+            //NOTE:
+            // - 選択中のデバイスが未接続→接続に切り替わったと考えられる場合、明示的なメッセージによって(必要なら)リップシンクなどが始まる
+            // - マイクに関しては接続→未接続の切り替えも検出するが、特に突っ込んでできることは無いので、トーストだけ表示しておく
+
+            var microphoneName = _setting.LipSyncMicrophoneDeviceName.Value;
+            var micIsInDeviceNamesNew = _microphoneNames.Contains(_setting.LipSyncMicrophoneDeviceName.Value);
+            if (!string.IsNullOrEmpty(microphoneName))
+            {
+                if (!micIsInDeviceNames && micIsInDeviceNamesNew)
+                {
+                    _sender.SendMessage(MessageFactory.Instance.SetMicrophoneDeviceName(microphoneName));
+                    SnackbarWrapper.Enqueue(string.Format(
+                        LocalizedString.GetString(MicrophoneReconnectedFormatKey),
+                        microphoneName
+                    ));
+                }
+                else if (micIsInDeviceNames && !micIsInDeviceNamesNew)
+                {
+                    SnackbarWrapper.Enqueue(string.Format(
+                        LocalizedString.GetString(MicrophoneDisconnectedFormatKey),
+                        microphoneName
+                    ));
+                }
+            }
+
+            var cameraName = _setting.CameraDeviceName.Value;
+            if (!string.IsNullOrEmpty(cameraName) && 
+                !webcamIsInDeviceNames &&
+                _cameraNames.Contains(_setting.CameraDeviceName.Value))
+            {
+                _sender.SendMessage(MessageFactory.Instance.SetCameraDeviceName(cameraName));
+                SnackbarWrapper.Enqueue(string.Format(
+                    LocalizedString.GetString(CameraReconnectedFormatKey),
+                    cameraName
+                ));
+            }
+        }
+
+        private async Task InitializeMicrophoneNamesAsync(bool refresh)
         {
             string rawNames = await _sender.QueryMessageAsync(MessageFactory.Instance.CameraDeviceNames());
             var names = DeviceNames.FromJson(rawNames, "Camera").Names;
             Application.Current.MainWindow.Dispatcher.Invoke(() =>
             {
-                _cameraNames.Clear();
-                foreach (var name in names)
+                if (refresh)
                 {
-                    _cameraNames.Add(name);
+                    _cameraNames.Clear();
+                    foreach (var name in names)
+                    {
+                        _cameraNames.Add(name);
+                    }
+                }
+                else
+                {
+                    AlignWithFewestRemove(names, _cameraNames);
                 }
             });
         }
 
-        private async Task InitializeCameraNamesAsync()
+        private async Task InitializeCameraNamesAsync(bool refresh)
         {
             var rawNames = await _sender.QueryMessageAsync(MessageFactory.Instance.MicrophoneDeviceNames());
             var names = DeviceNames.FromJson(rawNames, "Microphone").Names;
             Application.Current.MainWindow.Dispatcher.Invoke(() =>
             {
-                _microphoneNames.Clear();
-                foreach (var name in names)
+                if (refresh)
                 {
-                    _microphoneNames.Add(name);
+                    _microphoneNames.Clear();
+                    foreach (var name in names)
+                    {
+                        _microphoneNames.Add(name);
+                    }
+                }
+                else
+                {
+                    AlignWithFewestRemove(names, _microphoneNames);
                 }
             });
+        }
+
+        private async void PollingDeviceNames(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(DeviceNamesPollingIntervalMillisec, cancellationToken);
+                await ReloadDevicesAsync();
+            }
+        }
+
+        //OC<T>の要素の削除処理を最小限にしつつ(※ComboBoxにバインドしたときの挙動を安全にするため)、
+        //destの中身がsrcと同じになるように更新する
+        private static void AlignWithFewestRemove(string[] src, ObservableCollection<string> dest)
+        {
+            for (int i = 0; i < src.Length; i++)
+            {
+                var name = src[i];
+                if (i < dest.Count && dest[i] == name)
+                {
+                    //正しい
+                }
+                else if (dest.Contains(name))
+                {
+                    var index = dest.IndexOf(name);
+                    dest.Move(index, i);
+                }
+                else
+                {
+                    dest.Insert(i, name);
+                }
+            }
+
+            while (dest.Count > src.Length)
+            {
+                dest.RemoveAt(src.Length);
+            }
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -558,6 +558,11 @@ Use this only after checking the licenses of VRM you will use.
 
     <sys:String x:Key="DialogTitle_AlreadyLatestVersion">Latest Version</sys:String>
     <sys:String x:Key="DialogMessage_AlreadyLatestVersion">Current app version ({0}) is the latest.</sys:String>        
+
+    <!-- Snackbar Messages -->
+    <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">Selected Mic Disconnected: {0}</sys:String>
+    <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">Selected Mic Detected: {0}</sys:String>
+    <sys:String x:Key="Snackbar_CameraReconnected_Format">Selected Camera Detected: {0}</sys:String>    
     
     <!-- Other: Not on Dialog, but used from code -->
     <sys:String x:Key="CommonUi_DoNothing">(Do Nothing)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -566,6 +566,11 @@ webカメラでの顔トラッキングを有効にする場合は
     <sys:String x:Key="DialogTitle_AlreadyLatestVersion">最新バージョンです</sys:String>
     <sys:String x:Key="DialogMessage_AlreadyLatestVersion">現在のバージョン({0})は最新です。</sys:String>    
     
+    <!-- Snackbar Messages -->
+    <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">選択されたマイクが切断しました: {0}</sys:String>
+    <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">選択されたマイクの接続を検出しました: {0}</sys:String>
+    <sys:String x:Key="Snackbar_CameraReconnected_Format">選択されたカメラの接続を検出しました: {0}</sys:String>
+    
     <!-- Other: Not on Dialog, but used from code -->
     <sys:String x:Key="CommonUi_DoNothing">(何もしない)</sys:String>
     <sys:String x:Key="CommonUi_None">(なし)</sys:String>

--- a/WPF/VMagicMirrorConfig/View/Windows/MainWindow.xaml
+++ b/WPF/VMagicMirrorConfig/View/Windows/MainWindow.xaml
@@ -154,6 +154,6 @@
             </TabItem>
 
         </dragablz:TabablzControl>
-        <md:Snackbar MessageQueue="{x:Static view:SnackbarWrapper.SnackbarMessageQueue}" Grid.Column="1" HorizontalAlignment="Left" Margin="21,0,0,0"/>
+        <md:Snackbar MessageQueue="{x:Static vmm:SnackbarWrapper.SnackbarMessageQueue}" Grid.Column="1" HorizontalAlignment="Left" Margin="21,0,0,0"/>
     </Grid>
 </metro:MetroWindow>

--- a/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Windows;
 
 namespace Baku.VMagicMirrorConfig.ViewModel
@@ -22,11 +23,20 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             _model = model;
             _deviceListSource = deviceListSource;
 
+            CameraDeviceName = new RProperty<string>(_model.CameraDeviceName.Value, v =>
+            {
+                if (!string.IsNullOrEmpty(v))
+                {
+                    _model.CameraDeviceName.Value = v;
+                }
+            });
+
             OpenFullEditionDownloadUrlCommand = new ActionCommand(() => UrlNavigate.Open("https://baku-dreameater.booth.pm/items/3064040"));
             OpenHandTrackingPageUrlCommand = new ActionCommand(() => UrlNavigate.Open(LocalizedString.GetString("URL_docs_hand_tracking")));
 
             if (!IsInDesignMode)
             {
+                _model.CameraDeviceName.AddWeakEventHandler(OnCameraDeviceNameChanged);
                 //NOTE: ここでは表示にのみ影響するメッセージを受け取るため、ViewModelではあるが直接Receiverのイベントを見に行く
                 WeakEventManager<IMessageReceiver, CommandReceivedEventArgs>.AddHandler(
                     receiver,
@@ -51,6 +61,11 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             }
         }
 
+        private void OnCameraDeviceNameChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            CameraDeviceName.Value = _model.CameraDeviceName.Value;
+        }
+
         public RProperty<bool> EnableImageBasedHandTracking => _model.EnableImageBasedHandTracking;
         private readonly RProperty<bool> _alwaysOn = new RProperty<bool>(true);
         public RProperty<bool> ShowEffectDuringHandTracking => FeatureLocker.FeatureLocked
@@ -63,7 +78,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand OpenFullEditionDownloadUrlCommand { get; }
         public ActionCommand OpenHandTrackingPageUrlCommand { get; }
 
-        public RProperty<string> CameraDeviceName => _model.CameraDeviceName;
+        public RProperty<string> CameraDeviceName { get; }
         public ReadOnlyObservableCollection<string> CameraNames => _deviceListSource.CameraNames;
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -91,6 +91,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             _messageIo.Dispose();
             _runtimeHelper.Dispose();
             LargePointerController.Instance.Close();
+            ModelResolver.Instance.Resolve<DeviceListSource>().Dispose();
+
 
             //UX的には再起動を意味する
             if (_appQuitSetting.SkipAutoSaveAndRestart)

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
@@ -26,6 +26,21 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             _deviceListSource = deviceListSource;
             _microphoneStatus = microphoneStatus;
 
+            LipSyncMicrophoneDeviceName = new RProperty<string>(_model.LipSyncMicrophoneDeviceName.Value, v =>
+            {
+                if (!string.IsNullOrEmpty(v))
+                {
+                    _model.LipSyncMicrophoneDeviceName.Value = v;
+                }
+            });
+            CameraDeviceName = new RProperty<string>(_model.CameraDeviceName.Value, v =>
+            {
+                if (!string.IsNullOrEmpty(v))
+                {
+                    _model.CameraDeviceName.Value = v;
+                }
+            });
+
             ResetFaceBasicSettingCommand = new ActionCommand(
                 () => SettingResetUtils.ResetSingleCategoryAsync(ResetFaceBasicSetting)
                 );
@@ -47,6 +62,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             _model.EyeBoneRotationScale.AddWeakEventHandler(OnEyeBoneRotationScaleChanged);
             _model.FaceNeutralClip.AddWeakEventHandler(OnFaceClipChanged);
             _model.FaceOffsetClip.AddWeakEventHandler(OnFaceClipChanged);
+            _model.LipSyncMicrophoneDeviceName.AddWeakEventHandler(OnMicrophoneDeviceNameChanged);
+            _model.CameraDeviceName.AddWeakEventHandler(OnCameraDeviceNameChanged);
             UpdateEyeRotRangeText();
         }
 
@@ -65,6 +82,15 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             _blendShapeNameStore.Refresh(_model.FaceNeutralClip.Value, _model.FaceOffsetClip.Value);
         }
 
+        private void OnMicrophoneDeviceNameChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            LipSyncMicrophoneDeviceName.Value = _model.LipSyncMicrophoneDeviceName.Value;
+        }
+        private void OnCameraDeviceNameChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            CameraDeviceName.Value = _model.CameraDeviceName.Value;
+        }
+
         #region Face
 
         public RProperty<bool> EnableFaceTracking => _model.EnableFaceTracking;
@@ -78,7 +104,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<bool> DisableFaceTrackingHorizontalFlip => _model.DisableFaceTrackingHorizontalFlip;
         public RProperty<bool> EnableWebCamHighPowerMode => _model.EnableWebCamHighPowerMode;
 
-        public RProperty<string> CameraDeviceName => _model.CameraDeviceName;
+        public RProperty<string> CameraDeviceName { get; }
         public ReadOnlyObservableCollection<string> CameraNames => _deviceListSource.CameraNames;
 
         public ActionCommand CalibrateFaceCommand { get; }
@@ -119,7 +145,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         #region Mouth
 
         public RProperty<bool> EnableLipSync => _model.EnableLipSync;
-        public RProperty<string> LipSyncMicrophoneDeviceName => _model.LipSyncMicrophoneDeviceName;
+        public RProperty<string> LipSyncMicrophoneDeviceName { get; }
         public RProperty<int> MicrophoneSensitivity => _model.MicrophoneSensitivity;
 
         public RProperty<bool> ShowMicrophoneVolume => _microphoneStatus.ShowMicrophoneVolume;


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [ ] Bug fix
- [ ] Add new feature
- [x] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

fixed #736 

issueに書いてあるような挙動にしました。

## How to confirm

- 選択しているマイクが動的に切断、接続するときのトースト表示、およびリップシンクが停止/再開すること
- 選択したカメラがアプリ起動時に切断しており、あとから接続したときのトースト表示、および顔トラッキングが開始すること
- 特にマイクについて、切断したあとでアプリを終了した場合に設定ファイル側にはマイク名が残ること。つまり、一旦アプリを終了してマイクを接続したのちアプリを再起動したならば、起動時点でリップシンクが動作すること
- 特にマイクで、
    - 使っているのとは別のマイクが切断されてもトーストが表示されないこと
    - 外部トラッキングが有効でマイクは特に使われてない場合であっても、選択中マイクの切断/接続時にはトーストは表示されること