### PR TITLE
デバイスポーリングのスレッドで例外を起きにくくする

### DIFF
--- a/WPF/VMagicMirrorConfig/Model/Devices/DeviceListSource.cs
+++ b/WPF/VMagicMirrorConfig/Model/Devices/DeviceListSource.cs
@@ -105,16 +105,15 @@ namespace Baku.VMagicMirrorConfig
                 }
                 catch(Exception ex)
                 {
-                    LogOutput.Instance.Write("Exception on PollingDeviceNames");
+                    LogOutput.Instance.Write("Exception on PollingDeviceNames, quitting...");
                     LogOutput.Instance.Write(ex);
-                    throw;                    
+                    break;
                 }
             }
         }
 
         private async Task ReloadDevicesAsync()
         {
-            LogOutput.Instance.Write("Reload Devices...");
             var dispatcher = GetDispatcher();
 
             //NOTE: OC<T>へのアクセスがスレッドセーフでなくなるのを避けている
@@ -131,11 +130,9 @@ namespace Baku.VMagicMirrorConfig
             dispatcher.Invoke(() =>
             {
                 var microphoneName = _setting.LipSyncMicrophoneDeviceName.Value;
-                LogOutput.Instance.Write($"Reload Devices (invoke), mic name={microphoneName}");
                 var micIsInDeviceNamesNew = _microphoneNames.Contains(_setting.LipSyncMicrophoneDeviceName.Value);
                 if (!string.IsNullOrEmpty(microphoneName))
                 {
-                    LogOutput.Instance.Write($"Mic name is in device? {micIsInDeviceNames} -> {micIsInDeviceNamesNew}");
                     if (!micIsInDeviceNames && micIsInDeviceNamesNew)
                     {
                         _sender.SendMessage(MessageFactory.Instance.SetMicrophoneDeviceName(microphoneName));
@@ -166,10 +163,7 @@ namespace Baku.VMagicMirrorConfig
                     ));
                     _setting.LipSyncMicrophoneDeviceName.ForceRaisePropertyChanged();
                 }
-                LogOutput.Instance.Write("Reload Devices (invoke) ended.");
             });
-
-            LogOutput.Instance.Write("Reload Devices ended.");
         }
 
         private Dispatcher GetDispatcher()

--- a/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/MainWindowViewModel.cs
@@ -86,6 +86,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             if (!_appQuitSetting.SkipAutoSaveAndRestart)
             {
                 _saveFileManager.SaveAsAutoSave();
+                LogOutput.Instance.Write("AutoSave Completed.");
             }
             _settingModel.Automation.Dispose();
             _messageIo.Dispose();


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

fixed #751 

- ログ→なぜ入れっぱなしでマージしてしまったのか
- スレッド例外キャッチ→別にポーリングできないなら頑張らないでいいじゃん、という程度の扱いに落とす

## How to confirm

- このブランチのWPFバイナリを使って起動+終了を繰り返したときに終了時にエラーダイアログが出ないこと
    - 20回くらい試して大丈夫なら多分OK
