### PR TITLE
メモリリーク(に見えて紛らわしい挙動)のfix

### DIFF
--- a/WPF/VMagicMirrorConfig/View/Windows/SettingWindow.xaml.cs
+++ b/WPF/VMagicMirrorConfig/View/Windows/SettingWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using MahApps.Metro.Controls;
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace Baku.VMagicMirrorConfig.View
@@ -30,12 +31,16 @@ namespace Baku.VMagicMirrorConfig.View
             }
         }
 
-        private static void OnSettingWindowClosed(object? sender, EventArgs e)
+        private static async void OnSettingWindowClosed(object? sender, EventArgs e)
         {
             if (CurrentWindow != null)
             {
                 CurrentWindow.Closed -= OnSettingWindowClosed;
                 CurrentWindow = null;
+
+                //NOTE: 設定ウィンドウを閉じたあとはGC可能なリソースがそこそこある(WindowとかViewModelとか)ので、明示的にやってしまう
+                await Task.Delay(1000);
+                GC.Collect();
             }
         }
     }

--- a/WPF/VMagicMirrorConfig/ViewModel/Infrastructure/SettingViewModelBase.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/Infrastructure/SettingViewModelBase.cs
@@ -1,23 +1,9 @@
-﻿using System.Threading.Tasks;
-
-namespace Baku.VMagicMirrorConfig.ViewModel
+﻿namespace Baku.VMagicMirrorConfig.ViewModel
 {
-    /// <summary> 
-    /// ViewModelから直接メッセージI/Oがしたい場合に使える基底クラス
+    /// <summary>
+    /// 設定関連のタブっぽいUIのViewModelに当てている基底クラスだが、特に意味はない。
     /// </summary>
     public abstract class SettingViewModelBase : ViewModelBase
     {
-        //private protected SettingViewModelBase(IMessageSender sender)
-        //{
-        //    Sender = sender;
-        //}
-
-        //private protected readonly IMessageSender Sender;
-
-        //private protected virtual void SendMessage(Message message)
-        //    => Sender.SendMessage(message);
-
-        //private protected async Task<string> SendQueryAsync(Message message)
-        //    => await Sender.QueryMessageAsync(message);
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/DeviceConnectionViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/DeviceConnectionViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Baku.VMagicMirrorConfig.ViewModel
 {
-    public class DeviceConnectionViewModel : ViewModelBase
+    public class DeviceConnectionViewModel : SettingViewModelBase
     {
         public DeviceConnectionViewModel() : this(
             ModelResolver.Instance.Resolve<GamepadSettingModel>(),


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [ ] Bug fix
- [ ] Add new feature
- [x] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

- 挙動確認の結果、真のメモリリークではなく「メモリに余裕がある環境だとGCをかなり積極的にサボってる」という挙動であったことが判明しています。
- 詳細設定ウィンドウの開閉でメモリ使用量が増えやすく、リークと区別しづらいため、明示的にGCを走らせるようにしました。

## How to confirm

以下を確認

- デバッグ過程で、設定タブのViewModel全てと`SettingWindow`についてデストラクタから`LogOutput`を呼ぶようにしてデストラクタ呼び出しを確認できるようにし、その状態で詳細設定ウィンドウを開閉することで、GCが呼ばれているの確認できること
- 詳細設定ウィンドウを繰り返し開閉したとき、メモリ使用量が開閉の回数に比例して増えず、どこかで頭打ちになること
