### PR TITLE
特定ケースでアクセサリーのTransformControlのギズモが残ってしまうのを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ sysinfo.txt
 *.apk
 *.unitypackage
 
+/VMagicMirror/Logs/
+
 # Streaming Assets (now only include DlibFaceLandmarkDetector, so it must be ignored)
 /VMagicMirror/Assets/StreamingAssets/
 /VMagicMirror/Assets/StreamingAssets.meta

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Accessory/AccessoryItem.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Accessory/AccessoryItem.prefab
@@ -172,7 +172,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mode: 0
   global: 0
   useDistance: 1
   distance: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/ArcadeStick.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/ArcadeStick.prefab
@@ -679,7 +679,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mode: 0
   global: 0
   useDistance: 1
   distance: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/GamePad.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/GamePad.prefab
@@ -135,7 +135,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mode: 0
   global: 0
   useDistance: 1
   distance: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/Keyboard.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/Keyboard.prefab
@@ -139,7 +139,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mode: 0
   global: 0
   useDistance: 1
   distance: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/MidiController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/MidiController.prefab
@@ -149,7 +149,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mode: 0
   global: 0
   useDistance: 1
   distance: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/PenTablet.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/PenTablet.prefab
@@ -127,7 +127,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mode: 0
   global: 0
   useDistance: 1
   distance: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/TouchPad.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/TouchPad.prefab
@@ -111,7 +111,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mode: 0
   global: 0
   useDistance: 1
   distance: 12

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceTransformController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceTransformController.cs
@@ -178,7 +178,6 @@ namespace Baku.VMagicMirror
         
         private void EnableDeviceFreeLayout(bool enable)
         {
-            Debug.Log("Enable Device Free Layout: " + enable);
             if (IsDeviceFreeLayoutEnabled == enable)
             {
                 return;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Baku.VMagicMirror
+﻿namespace Baku.VMagicMirror
 {
     public static class VmmCommands
     {

--- a/VMagicMirror/Assets/Packages/TransformControl/Scripts/TransformControl.cs
+++ b/VMagicMirror/Assets/Packages/TransformControl/Scripts/TransformControl.cs
@@ -74,7 +74,21 @@ namespace mattatz.TransformControl
             [TransformDirection.Z] = Vector3.forward,
         };
 
-        public TransformMode mode = TransformMode.Translate;
+        private TransformMode _mode = TransformMode.None;
+        public TransformMode mode
+        {
+            get => _mode;
+            set
+            {
+                //Noneに立ち下がった場合、AutoUpdateがfalseであっても無視してRendererをただちに隠す
+                if (_mode != TransformMode.None && value == TransformMode.None)
+                {
+                    gizmoRenderer.SetMode(TransformMode.None);
+                }
+                _mode = value;
+            }
+        }
+        
         public bool global;
         public bool useDistance;
         public float distance = 12f;

--- a/VMagicMirror/Assets/Packages/TransformControl/Scripts/TransformControl.cs
+++ b/VMagicMirror/Assets/Packages/TransformControl/Scripts/TransformControl.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Profiling;
 
 namespace mattatz.TransformControl
 {


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

fixed #741 

- 最前面表示のときTransformControlで`AutoUpdate == false`になっていたため、mode==NoneになったときにRendererの状態反映が滞るのが原因でした。
- このケースはTransformControl側でギズモを消して問題ないので、消せるようにしました。

## How to confirm

- #741 に記載した手順を取ったときギズモが消えること

