### PR TITLE
BlendShapeの補間オプションをデフォルト有効で適用する

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 5187863769921554747}
   - component: {fileID: 6241239198292537160}
   - component: {fileID: 6186883453983643772}
+  - component: {fileID: 2342025005093802096}
   m_Layer: 0
   m_Name: FaceController
   m_TagString: Untagged
@@ -138,6 +139,7 @@ MonoBehaviour:
   perfectSync: {fileID: 5187863769921554747}
   faceSwitch: {fileID: 8701057551241780110}
   neutralClipSettings: {fileID: 6186883453983643772}
+  blendShapeInterpolator: {fileID: 2342025005093802096}
 --- !u!114 &6186883453983643772
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -148,6 +150,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6bd1898a983ab3f4bbfbdf6b73895499, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2342025005093802096
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3748028266611161173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 74ad09254c619b64cb9899e8d2b2b82e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &3748028267383499195

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
@@ -3,9 +3,30 @@ using UnityEngine;
 using Zenject;
 using VRM;
 using Baku.VMagicMirror.ExternalTracker;
+using UniRx;
 
 namespace Baku.VMagicMirror
 {
+    public readonly struct FaceSwitchKeyApplyContent
+    {
+        private FaceSwitchKeyApplyContent(bool hasValue, bool keepLipSync, BlendShapeKey key)
+        {
+            HasValue = hasValue;
+            KeepLipSync = keepLipSync;
+            Key = key;
+        }
+
+        public static FaceSwitchKeyApplyContent Empty() 
+            => new FaceSwitchKeyApplyContent(false, false, default);
+
+        public static FaceSwitchKeyApplyContent Create(BlendShapeKey key, bool keepLipSync)
+            => new FaceSwitchKeyApplyContent(true, keepLipSync, key);
+        
+        public bool HasValue { get; }
+        public bool KeepLipSync { get; }
+        public BlendShapeKey Key { get; }
+    }
+        
     public class ExternalTrackerFaceSwitchApplier : MonoBehaviour
     {
         private bool _hasModel = false;
@@ -13,10 +34,13 @@ namespace Baku.VMagicMirror
         private ExternalTrackerDataSource _externalTracker;
         private EyeBonePostProcess _eyeBoneResetter;
 
-        //NOTE: 毎回Keyを生成するとGCAlloc警察に怒られるので、回数が減るように書いてます
         private string _latestClipName = "";
-        private BlendShapeKey _latestKey = default;
-        
+
+        private readonly ReactiveProperty<FaceSwitchKeyApplyContent> _currentValue 
+            = new ReactiveProperty<FaceSwitchKeyApplyContent>(FaceSwitchKeyApplyContent.Empty());
+        public IReadOnlyReactiveProperty<FaceSwitchKeyApplyContent> CurrentValue => _currentValue;
+
+
         [Inject]
         public void Initialize(
             IVRMLoadable vrmLoadable, 
@@ -37,30 +61,48 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmDisposing += () =>
             {
                 _hasModel = false;
+                _currentValue.Value = FaceSwitchKeyApplyContent.Empty();
+                _latestClipName = "";
             };
         }
+        
+        //public bool HasClipToApply => !string.IsNullOrEmpty(_externalTracker.FaceSwitchClipName);
+        public bool KeepLipSync => _currentValue.Value.KeepLipSync;
+        public bool HasClipToApply => _currentValue.Value.HasValue;
 
-        public bool HasClipToApply => !string.IsNullOrEmpty(_externalTracker.FaceSwitchClipName);
-        public bool KeepLipSync => _externalTracker.KeepLipSyncForFaceSwitch;
-
-        public void Accumulate(VRMBlendShapeProxy proxy)
+        public void UpdateCurrentValue()
         {
-            if (!_hasModel ||
-                string.IsNullOrEmpty(_externalTracker.FaceSwitchClipName) || 
-                _config.WordToMotionExpressionActive
-            )
+            //NOTE: FaceSwitchClipNameはnullにはならないという前提で実装している
+            if (!_hasModel || _latestClipName == _externalTracker.FaceSwitchClipName)
             {
                 return;
             }
-            
-            if (_latestClipName != _externalTracker.FaceSwitchClipName)
+
+            if (string.IsNullOrEmpty(_externalTracker.FaceSwitchClipName))
             {
-                _latestKey = CreateKey(_externalTracker.FaceSwitchClipName);
+                _currentValue.Value = FaceSwitchKeyApplyContent.Empty();
+                _latestClipName = "";
+            }
+            else
+            {
+                var key = CreateKey(_externalTracker.FaceSwitchClipName);
+                _currentValue.Value = FaceSwitchKeyApplyContent.Create(key, KeepLipSync);
                 _latestClipName = _externalTracker.FaceSwitchClipName;
+            }
+        }
+
+        public void Accumulate(VRMBlendShapeProxy proxy)
+        {
+            //NOTE:
+            //3つ目の条件について、表情間の補間処理中はこのクラスではないクラスがAccumulateを代行するので、
+            //このクラスはWtMが有効なら表情は適用しないでOK
+            if (!_hasModel || !_currentValue.HasValue || _config.WordToMotionExpressionActive)
+            {
+                return;
             }
 
             //ターゲットのキーだけいじり、他のクリップ状態については呼び出し元に責任を持ってもらう
-            proxy.AccumulateValue(_latestKey, 1.0f);
+            proxy.AccumulateValue(_currentValue.Value.Key, 1f);
             //表情を適用した = 目ボーンは正面向きになってほしい
             _eyeBoneResetter.ReserveReset = true;
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
@@ -106,7 +106,6 @@ namespace Baku.VMagicMirror
             //表情を適用した = 目ボーンは正面向きになってほしい
             _eyeBoneResetter.ReserveReset = true;
         }
-        
 
         private static BlendShapeKey CreateKey(string name) => 
             _presets.ContainsKey(name)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceSwitchApplier.cs
@@ -86,7 +86,7 @@ namespace Baku.VMagicMirror
             else
             {
                 var key = CreateKey(_externalTracker.FaceSwitchClipName);
-                _currentValue.Value = FaceSwitchKeyApplyContent.Create(key, KeepLipSync);
+                _currentValue.Value = FaceSwitchKeyApplyContent.Create(key, _externalTracker.KeepLipSyncForFaceSwitch);
                 _latestClipName = _externalTracker.FaceSwitchClipName;
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using Zenject;
@@ -87,10 +88,13 @@ namespace Baku.VMagicMirror.ExternalTracker
         /// 口を適用するかどうか。原則<see cref="PreferWriteMouthBlendShape"/>
         /// </param>
         /// <param name="writeExcludedKeys">
+        /// <param name="mouthWeight"></param>
+        /// <param name="nonMouthWeight"></param>
         /// trueを指定すると非適用のクリップに0を書き込みます。
         /// これにより、常にパーフェクトシンク分のクリップ情報が過不足なく更新されるのを保証します。
         /// </param>
-        public void Accumulate(VRMBlendShapeProxy proxy, bool nonMouthPart, bool mouthPart, bool writeExcludedKeys)
+        public void Accumulate(VRMBlendShapeProxy proxy, bool nonMouthPart, bool mouthPart, 
+            bool writeExcludedKeys, float mouthWeight = 1f, float nonMouthWeight = 1f)
         {
             if (!IsReadyToAccumulate)
             {                
@@ -103,38 +107,39 @@ namespace Baku.VMagicMirror.ExternalTracker
             //それよりは関数ごと分けた方がパフォーマンスがいいのでは？という意図で書いてます。何となくです
             if (_externalTracker.DisableHorizontalFlip)
             {
-                AccumulateWithFlip(proxy, source, nonMouthPart, mouthPart, writeExcludedKeys);
+                AccumulateWithFlip(proxy, source, nonMouthPart, mouthPart, writeExcludedKeys, mouthWeight, nonMouthWeight);
             }
             else
             {
-                AccumulateWithoutFlip(proxy, source, nonMouthPart, mouthPart, writeExcludedKeys);
+                AccumulateWithoutFlip(proxy, source, nonMouthPart, mouthPart, writeExcludedKeys, mouthWeight, nonMouthWeight);
             }
         }
 
         private void AccumulateWithoutFlip(
             VRMBlendShapeProxy proxy,  IFaceTrackSource source,
-            bool nonMouthPart, bool mouthPart, bool writeExcludedKeys
+            bool nonMouthPart, bool mouthPart, bool writeExcludedKeys,
+            float mouthWeight, float nonMouthWeight
             )
         {
             if (nonMouthPart)
             {
                 //目
                 var eye = source.Eye;
-                proxy.AccumulateValue(Keys.EyeBlinkLeft, eye.LeftBlink);
-                proxy.AccumulateValue(Keys.EyeLookUpLeft, eye.LeftLookUp);
-                proxy.AccumulateValue(Keys.EyeLookDownLeft, eye.LeftLookDown);
-                proxy.AccumulateValue(Keys.EyeLookInLeft, eye.LeftLookIn);
-                proxy.AccumulateValue(Keys.EyeLookOutLeft, eye.LeftLookOut);
-                proxy.AccumulateValue(Keys.EyeWideLeft, eye.LeftWide);
-                proxy.AccumulateValue(Keys.EyeSquintLeft, eye.LeftSquint);
+                proxy.AccumulateValue(Keys.EyeBlinkLeft, eye.LeftBlink * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookUpLeft, eye.LeftLookUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookDownLeft, eye.LeftLookDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookInLeft, eye.LeftLookIn * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookOutLeft, eye.LeftLookOut * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeWideLeft, eye.LeftWide * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeSquintLeft, eye.LeftSquint * nonMouthWeight);
 
-                proxy.AccumulateValue(Keys.EyeBlinkRight, eye.RightBlink);
-                proxy.AccumulateValue(Keys.EyeLookUpRight, eye.RightLookUp);
-                proxy.AccumulateValue(Keys.EyeLookDownRight, eye.RightLookDown);
-                proxy.AccumulateValue(Keys.EyeLookInRight, eye.RightLookIn);
-                proxy.AccumulateValue(Keys.EyeLookOutRight, eye.RightLookOut);
-                proxy.AccumulateValue(Keys.EyeWideRight, eye.RightWide);
-                proxy.AccumulateValue(Keys.EyeSquintRight, eye.RightSquint);
+                proxy.AccumulateValue(Keys.EyeBlinkRight, eye.RightBlink * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookUpRight, eye.RightLookUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookDownRight, eye.RightLookDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookInRight, eye.RightLookIn * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookOutRight, eye.RightLookOut * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeWideRight, eye.RightWide * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeSquintRight, eye.RightSquint * nonMouthWeight);
 
                 //NOTE: 瞬き時の目下げ処理に使うためにセット
                 _faceControlConfig.AlternativeBlinkL = eye.LeftBlink;
@@ -142,15 +147,15 @@ namespace Baku.VMagicMirror.ExternalTracker
                 
                 
                 //鼻
-                proxy.AccumulateValue(Keys.NoseSneerLeft, source.Nose.LeftSneer);
-                proxy.AccumulateValue(Keys.NoseSneerRight, source.Nose.RightSneer);
+                proxy.AccumulateValue(Keys.NoseSneerLeft, source.Nose.LeftSneer * nonMouthWeight);
+                proxy.AccumulateValue(Keys.NoseSneerRight, source.Nose.RightSneer * nonMouthWeight);
 
                 //まゆげ
-                proxy.AccumulateValue(Keys.BrowDownLeft, source.Brow.LeftDown);
-                proxy.AccumulateValue(Keys.BrowOuterUpLeft, source.Brow.LeftOuterUp);
-                proxy.AccumulateValue(Keys.BrowDownRight, source.Brow.RightDown);
-                proxy.AccumulateValue(Keys.BrowOuterUpRight, source.Brow.RightOuterUp);
-                proxy.AccumulateValue(Keys.BrowInnerUp, source.Brow.InnerUp);
+                proxy.AccumulateValue(Keys.BrowDownLeft, source.Brow.LeftDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowOuterUpLeft, source.Brow.LeftOuterUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowDownRight, source.Brow.RightDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowOuterUpRight, source.Brow.RightOuterUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowInnerUp, source.Brow.InnerUp * nonMouthWeight);
             }
             else if (writeExcludedKeys)
             {
@@ -191,45 +196,45 @@ namespace Baku.VMagicMirror.ExternalTracker
             {
                 //口(多い)
                 var mouth = source.Mouth;
-                proxy.AccumulateValue(Keys.MouthLeft, mouth.Left);
-                proxy.AccumulateValue(Keys.MouthSmileLeft, mouth.LeftSmile);
-                proxy.AccumulateValue(Keys.MouthFrownLeft, mouth.LeftFrown);
-                proxy.AccumulateValue(Keys.MouthPressLeft, mouth.LeftPress);
-                proxy.AccumulateValue(Keys.MouthUpperUpLeft, mouth.LeftUpperUp);
-                proxy.AccumulateValue(Keys.MouthLowerDownLeft, mouth.LeftLowerDown);
-                proxy.AccumulateValue(Keys.MouthStretchLeft, mouth.LeftStretch);
-                proxy.AccumulateValue(Keys.MouthDimpleLeft, mouth.LeftDimple);
+                proxy.AccumulateValue(Keys.MouthLeft, mouth.Left * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthSmileLeft, mouth.LeftSmile * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthFrownLeft, mouth.LeftFrown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthPressLeft, mouth.LeftPress * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthUpperUpLeft, mouth.LeftUpperUp * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthLowerDownLeft, mouth.LeftLowerDown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthStretchLeft, mouth.LeftStretch * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthDimpleLeft, mouth.LeftDimple * mouthWeight);
 
-                proxy.AccumulateValue(Keys.MouthRight, mouth.Right);
-                proxy.AccumulateValue(Keys.MouthSmileRight, mouth.RightSmile);
-                proxy.AccumulateValue(Keys.MouthFrownRight, mouth.RightFrown);
-                proxy.AccumulateValue(Keys.MouthPressRight, mouth.RightPress);
-                proxy.AccumulateValue(Keys.MouthUpperUpRight, mouth.RightUpperUp);
-                proxy.AccumulateValue(Keys.MouthLowerDownRight, mouth.RightLowerDown);
-                proxy.AccumulateValue(Keys.MouthStretchRight, mouth.RightStretch);
-                proxy.AccumulateValue(Keys.MouthDimpleRight, mouth.RightDimple);
+                proxy.AccumulateValue(Keys.MouthRight, mouth.Right * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthSmileRight, mouth.RightSmile * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthFrownRight, mouth.RightFrown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthPressRight, mouth.RightPress * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthUpperUpRight, mouth.RightUpperUp * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthLowerDownRight, mouth.RightLowerDown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthStretchRight, mouth.RightStretch * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthDimpleRight, mouth.RightDimple * mouthWeight);
 
-                proxy.AccumulateValue(Keys.MouthClose, mouth.Close);
-                proxy.AccumulateValue(Keys.MouthFunnel, mouth.Funnel);
-                proxy.AccumulateValue(Keys.MouthPucker, mouth.Pucker);
-                proxy.AccumulateValue(Keys.MouthShrugUpper, mouth.ShrugUpper);
-                proxy.AccumulateValue(Keys.MouthShrugLower, mouth.ShrugLower);
-                proxy.AccumulateValue(Keys.MouthRollUpper, mouth.RollUpper);
-                proxy.AccumulateValue(Keys.MouthRollLower, mouth.RollLower);
+                proxy.AccumulateValue(Keys.MouthClose, mouth.Close * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthFunnel, mouth.Funnel * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthPucker, mouth.Pucker * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthShrugUpper, mouth.ShrugUpper * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthShrugLower, mouth.ShrugLower * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthRollUpper, mouth.RollUpper * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthRollLower, mouth.RollLower * mouthWeight);
 
                 //あご
-                proxy.AccumulateValue(Keys.JawOpen, source.Jaw.Open);
-                proxy.AccumulateValue(Keys.JawForward, source.Jaw.Forward);
-                proxy.AccumulateValue(Keys.JawLeft, source.Jaw.Left);
-                proxy.AccumulateValue(Keys.JawRight, source.Jaw.Right);
+                proxy.AccumulateValue(Keys.JawOpen, source.Jaw.Open * mouthWeight);
+                proxy.AccumulateValue(Keys.JawForward, source.Jaw.Forward * mouthWeight);
+                proxy.AccumulateValue(Keys.JawLeft, source.Jaw.Left * mouthWeight);
+                proxy.AccumulateValue(Keys.JawRight, source.Jaw.Right * mouthWeight);
 
                 //舌
-                proxy.AccumulateValue(Keys.TongueOut, source.Tongue.TongueOut);
+                proxy.AccumulateValue(Keys.TongueOut, source.Tongue.TongueOut * mouthWeight);
 
                 //ほお
-                proxy.AccumulateValue(Keys.CheekPuff, source.Cheek.Puff);
-                proxy.AccumulateValue(Keys.CheekSquintLeft, source.Cheek.LeftSquint);
-                proxy.AccumulateValue(Keys.CheekSquintRight, source.Cheek.RightSquint);                
+                proxy.AccumulateValue(Keys.CheekPuff, source.Cheek.Puff * mouthWeight);
+                proxy.AccumulateValue(Keys.CheekSquintLeft, source.Cheek.LeftSquint * mouthWeight);
+                proxy.AccumulateValue(Keys.CheekSquintRight, source.Cheek.RightSquint * mouthWeight);                
             }
             else if (writeExcludedKeys)
             {
@@ -278,43 +283,44 @@ namespace Baku.VMagicMirror.ExternalTracker
         
         private void AccumulateWithFlip(
             VRMBlendShapeProxy proxy,  IFaceTrackSource source,
-            bool nonMouthPart, bool mouthPart, bool writeExcludedKeys
+            bool nonMouthPart, bool mouthPart, bool writeExcludedKeys,
+            float mouthWeight, float nonMouthWeight
         )
         {
             if (nonMouthPart)
             {
                 //目
                 var eye = source.Eye;
-                proxy.AccumulateValue(Keys.EyeBlinkRight, eye.LeftBlink);
-                proxy.AccumulateValue(Keys.EyeLookUpRight, eye.LeftLookUp);
-                proxy.AccumulateValue(Keys.EyeLookDownRight, eye.LeftLookDown);
-                proxy.AccumulateValue(Keys.EyeLookInRight, eye.LeftLookIn);
-                proxy.AccumulateValue(Keys.EyeLookOutRight, eye.LeftLookOut);
-                proxy.AccumulateValue(Keys.EyeWideRight, eye.LeftWide);
-                proxy.AccumulateValue(Keys.EyeSquintRight, eye.LeftSquint);
+                proxy.AccumulateValue(Keys.EyeBlinkRight, eye.LeftBlink * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookUpRight, eye.LeftLookUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookDownRight, eye.LeftLookDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookInRight, eye.LeftLookIn * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookOutRight, eye.LeftLookOut * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeWideRight, eye.LeftWide * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeSquintRight, eye.LeftSquint * nonMouthWeight);
 
-                proxy.AccumulateValue(Keys.EyeBlinkLeft, eye.RightBlink);
-                proxy.AccumulateValue(Keys.EyeLookUpLeft, eye.RightLookUp);
-                proxy.AccumulateValue(Keys.EyeLookDownLeft, eye.RightLookDown);
-                proxy.AccumulateValue(Keys.EyeLookInLeft, eye.RightLookIn);
-                proxy.AccumulateValue(Keys.EyeLookOutLeft, eye.RightLookOut);
-                proxy.AccumulateValue(Keys.EyeWideLeft, eye.RightWide);
-                proxy.AccumulateValue(Keys.EyeSquintLeft, eye.RightSquint);
+                proxy.AccumulateValue(Keys.EyeBlinkLeft, eye.RightBlink * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookUpLeft, eye.RightLookUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookDownLeft, eye.RightLookDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookInLeft, eye.RightLookIn * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeLookOutLeft, eye.RightLookOut * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeWideLeft, eye.RightWide * nonMouthWeight);
+                proxy.AccumulateValue(Keys.EyeSquintLeft, eye.RightSquint * nonMouthWeight);
 
                 //NOTE: 瞬き時の目下げ処理に使うためにセット
                 _faceControlConfig.AlternativeBlinkR = eye.LeftBlink;
                 _faceControlConfig.AlternativeBlinkL = eye.RightBlink;
 
                 //鼻
-                proxy.AccumulateValue(Keys.NoseSneerRight, source.Nose.LeftSneer);
-                proxy.AccumulateValue(Keys.NoseSneerLeft, source.Nose.RightSneer);
+                proxy.AccumulateValue(Keys.NoseSneerRight, source.Nose.LeftSneer * nonMouthWeight);
+                proxy.AccumulateValue(Keys.NoseSneerLeft, source.Nose.RightSneer * nonMouthWeight);
 
                 //まゆげ
-                proxy.AccumulateValue(Keys.BrowDownRight, source.Brow.LeftDown);
-                proxy.AccumulateValue(Keys.BrowOuterUpRight, source.Brow.LeftOuterUp);
-                proxy.AccumulateValue(Keys.BrowDownLeft, source.Brow.RightDown);
-                proxy.AccumulateValue(Keys.BrowOuterUpLeft, source.Brow.RightOuterUp);
-                proxy.AccumulateValue(Keys.BrowInnerUp, source.Brow.InnerUp);
+                proxy.AccumulateValue(Keys.BrowDownRight, source.Brow.LeftDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowOuterUpRight, source.Brow.LeftOuterUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowDownLeft, source.Brow.RightDown * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowOuterUpLeft, source.Brow.RightOuterUp * nonMouthWeight);
+                proxy.AccumulateValue(Keys.BrowInnerUp, source.Brow.InnerUp * nonMouthWeight);
             }
             else if (writeExcludedKeys)
             {
@@ -355,45 +361,45 @@ namespace Baku.VMagicMirror.ExternalTracker
             {
                 //口(多い)
                 var mouth = source.Mouth;
-                proxy.AccumulateValue(Keys.MouthRight, mouth.Left);
-                proxy.AccumulateValue(Keys.MouthSmileRight, mouth.LeftSmile);
-                proxy.AccumulateValue(Keys.MouthFrownRight, mouth.LeftFrown);
-                proxy.AccumulateValue(Keys.MouthPressRight, mouth.LeftPress);
-                proxy.AccumulateValue(Keys.MouthUpperUpRight, mouth.LeftUpperUp);
-                proxy.AccumulateValue(Keys.MouthLowerDownRight, mouth.LeftLowerDown);
-                proxy.AccumulateValue(Keys.MouthStretchRight, mouth.LeftStretch);
-                proxy.AccumulateValue(Keys.MouthDimpleRight, mouth.LeftDimple);
+                proxy.AccumulateValue(Keys.MouthRight, mouth.Left * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthSmileRight, mouth.LeftSmile * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthFrownRight, mouth.LeftFrown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthPressRight, mouth.LeftPress * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthUpperUpRight, mouth.LeftUpperUp * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthLowerDownRight, mouth.LeftLowerDown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthStretchRight, mouth.LeftStretch * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthDimpleRight, mouth.LeftDimple * mouthWeight);
 
-                proxy.AccumulateValue(Keys.MouthLeft, mouth.Right);
-                proxy.AccumulateValue(Keys.MouthSmileLeft, mouth.RightSmile);
-                proxy.AccumulateValue(Keys.MouthFrownLeft, mouth.RightFrown);
-                proxy.AccumulateValue(Keys.MouthPressLeft, mouth.RightPress);
-                proxy.AccumulateValue(Keys.MouthUpperUpLeft, mouth.RightUpperUp);
-                proxy.AccumulateValue(Keys.MouthLowerDownLeft, mouth.RightLowerDown);
-                proxy.AccumulateValue(Keys.MouthStretchLeft, mouth.RightStretch);
-                proxy.AccumulateValue(Keys.MouthDimpleLeft, mouth.RightDimple);
+                proxy.AccumulateValue(Keys.MouthLeft, mouth.Right * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthSmileLeft, mouth.RightSmile * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthFrownLeft, mouth.RightFrown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthPressLeft, mouth.RightPress * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthUpperUpLeft, mouth.RightUpperUp * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthLowerDownLeft, mouth.RightLowerDown * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthStretchLeft, mouth.RightStretch * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthDimpleLeft, mouth.RightDimple * mouthWeight);
 
-                proxy.AccumulateValue(Keys.MouthClose, mouth.Close);
-                proxy.AccumulateValue(Keys.MouthFunnel, mouth.Funnel);
-                proxy.AccumulateValue(Keys.MouthPucker, mouth.Pucker);
-                proxy.AccumulateValue(Keys.MouthShrugUpper, mouth.ShrugUpper);
-                proxy.AccumulateValue(Keys.MouthShrugLower, mouth.ShrugLower);
-                proxy.AccumulateValue(Keys.MouthRollUpper, mouth.RollUpper);
-                proxy.AccumulateValue(Keys.MouthRollLower, mouth.RollLower);
+                proxy.AccumulateValue(Keys.MouthClose, mouth.Close * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthFunnel, mouth.Funnel * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthPucker, mouth.Pucker * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthShrugUpper, mouth.ShrugUpper * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthShrugLower, mouth.ShrugLower * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthRollUpper, mouth.RollUpper * mouthWeight);
+                proxy.AccumulateValue(Keys.MouthRollLower, mouth.RollLower * mouthWeight);
 
                 //あご
-                proxy.AccumulateValue(Keys.JawOpen, source.Jaw.Open);
-                proxy.AccumulateValue(Keys.JawForward, source.Jaw.Forward);
-                proxy.AccumulateValue(Keys.JawRight, source.Jaw.Left);
-                proxy.AccumulateValue(Keys.JawLeft, source.Jaw.Right);
+                proxy.AccumulateValue(Keys.JawOpen, source.Jaw.Open * mouthWeight);
+                proxy.AccumulateValue(Keys.JawForward, source.Jaw.Forward * mouthWeight);
+                proxy.AccumulateValue(Keys.JawRight, source.Jaw.Left * mouthWeight);
+                proxy.AccumulateValue(Keys.JawLeft, source.Jaw.Right * mouthWeight);
 
                 //舌
-                proxy.AccumulateValue(Keys.TongueOut, source.Tongue.TongueOut);
+                proxy.AccumulateValue(Keys.TongueOut, source.Tongue.TongueOut * mouthWeight);
 
                 //ほお
-                proxy.AccumulateValue(Keys.CheekPuff, source.Cheek.Puff);
-                proxy.AccumulateValue(Keys.CheekSquintRight, source.Cheek.LeftSquint);
-                proxy.AccumulateValue(Keys.CheekSquintLeft, source.Cheek.RightSquint);                
+                proxy.AccumulateValue(Keys.CheekPuff, source.Cheek.Puff * mouthWeight);
+                proxy.AccumulateValue(Keys.CheekSquintRight, source.Cheek.LeftSquint * mouthWeight);
+                proxy.AccumulateValue(Keys.CheekSquintLeft, source.Cheek.RightSquint * mouthWeight);                
             }
             else if (writeExcludedKeys)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -135,7 +135,6 @@ namespace Baku.VMagicMirror
             //遷移元か遷移先がIsBinary: 補間を完全にスキップ
             if (_toState.IsBinary || _fromState.IsBinary)
             {
-                Debug.Log("Skip count since binary BS exist");
                 _faceAppliedCount = FaceApplyCountMax;
             }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -96,7 +96,7 @@ namespace Baku.VMagicMirror
                     _hasWordToMotionOutput.Value = v.HasValue;
                     if (v.HasValue)
                     {
-                        SetWordToMotion(v.Keys, v.KeepLipSync);
+                        SetWordToMotion(v.Keys, v.KeepLipSync, v.IsPreview);
                     }
                 })
                 .AddTo(this);
@@ -198,7 +198,7 @@ namespace Baku.VMagicMirror
             _faceAppliedCount = 0;
         }
 
-        private void SetWordToMotion(List<(BlendShapeKey, float)> blendShapes, bool keepLipSync)
+        private void SetWordToMotion(List<(BlendShapeKey, float)> blendShapes, bool keepLipSync, bool isPreview)
         {
             _toState.CopyTo(_fromState);
             
@@ -207,7 +207,8 @@ namespace Baku.VMagicMirror
             _toState.Keys.Clear();
             _toState.Keys.AddRange(blendShapes);
             _toState.KeepLipSync = keepLipSync;
-            _toState.IsBinary = _hasModel && blendShapes
+            //NOTE: プレビュー表示の場合、補間は考えないでOK
+            _toState.IsBinary = _hasModel && (isPreview || blendShapes
                 .Any(pair =>
                 {
                     var (key, value) = pair;
@@ -217,7 +218,7 @@ namespace Baku.VMagicMirror
                     }
                     var clip = _blendShapeAvatar.GetClip(key);
                     return (clip != null) && clip.IsBinary;
-                });
+                }));
 
             _faceAppliedCount = 0;
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -1,0 +1,246 @@
+using System.Collections.Generic;
+using System.Linq;
+using UniRx;
+using UnityEngine;
+using VRM;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// <see cref="BlendShapeResultSetter"/>で適用する表情のうち、
+    /// FaceSwitchとWord to Motionを適用するときのフェードを考慮できるようにするクラス
+    /// </summary>
+    public class BlendShapeInterpolator : MonoBehaviour
+    {
+        private const int FaceApplyCountMax = 6;
+        
+        //補間する場合のフレーム単位で考慮するウェイト。メンドいのでdeltaTimeには依存させない。
+        //理想的には0.1secで表情が切り替わる
+        private static readonly float[] WeightCurve = new float[]
+        {
+            0f,
+            0.1f,
+            0.2f,
+            0.5f,
+            0.8f,
+            0.9f,
+            1f,
+        };
+        
+        [Inject]
+        public void Initialize(IMessageReceiver receiver, IVRMLoadable vrmLoadable)
+        {
+            receiver.AssignCommandHandler(
+                VmmCommands.DisableBlendShapeInterpolate,
+                command => _interpolateBlendShapeWeight = !command.ToBoolean());
+
+            vrmLoadable.VrmLoaded += info =>
+            {
+                _blendShapeAvatar = info.blendShape.BlendShapeAvatar;
+                _hasModel = true;
+            };
+
+            vrmLoadable.VrmDisposing += () =>
+            {
+                _blendShapeAvatar = null;
+                _hasModel = false;
+            };
+        }
+
+        private bool _hasModel;
+        private BlendShapeAvatar _blendShapeAvatar;
+
+        private bool _interpolateBlendShapeWeight = true;
+        
+        public bool NeedToInterpolate { get; private set; }
+
+        //いわゆる普段の表情のウェイト: だいたい1で、たまに0になる
+        public float NonMouthWeight { get; private set; } = 1f;
+        public float MouthWeight { get; private set; } = 1f;
+
+        //NOTE: 何も適用してない状態はIsEmpty == trueになることで表現される
+        private readonly State _fromState = new State();
+        private readonly State _toState = new State();
+        
+        //WtMかFace Switchが適用されると0からプラスの値に推移していく。
+        //30fpsの場合、1フレームごとに2加算され、最大値は6。
+        private int _faceAppliedCount = 0;
+
+        private readonly ReactiveProperty<bool> _hasWordToMotionOutput = new ReactiveProperty<bool>(false);
+        private readonly ReactiveProperty<bool> _hasFaceSwitchOutput = new ReactiveProperty<bool>(false);
+
+        public void Setup(ExternalTrackerFaceSwitchApplier faceSwitch, WordToMotionBlendShape wtmBlendShape)
+        {
+            faceSwitch.CurrentValue
+                .Subscribe(v =>
+                {
+                    _hasFaceSwitchOutput.Value = v.HasValue;
+                    if (v.HasValue)
+                    {
+                        SetFaceSwitch(v.Key, v.KeepLipSync);
+                    }
+                })
+                .AddTo(this);
+            
+            wtmBlendShape.CurrentValue
+                .Subscribe(v =>
+                {
+                    _hasWordToMotionOutput.Value = v.HasValue;
+                    if (v.HasValue)
+                    {
+                        SetWordToMotion(v.Keys, v.KeepLipSync);
+                    }
+                })
+                .AddTo(this);
+
+            Observable.CombineLatest(
+                    _hasWordToMotionOutput,
+                    _hasFaceSwitchOutput,
+                    (a, b) => a || b
+                )
+                .Subscribe(hasOutput =>
+                {
+                    if (!hasOutput)
+                    {
+                        Clear();
+                    }
+                })
+                .AddTo(this);
+        }
+        
+        /// <summary>
+        /// 毎フレーム呼び出すことで各weightを更新する。
+        /// </summary>
+        public void UpdateWeight()
+        {
+            if (!_hasModel || !_interpolateBlendShapeWeight)
+            {
+                NeedToInterpolate = false;
+                _faceAppliedCount = 0;
+                NonMouthWeight = 1f;
+                MouthWeight = 1f;
+                return;
+            }
+
+            //普段どおりの表情になって一定時間経った
+            if (_toState.IsEmpty && _faceAppliedCount >= FaceApplyCountMax)
+            {
+                NeedToInterpolate = false;
+                NonMouthWeight = 1f;
+                MouthWeight = 1f;
+                return;
+            }
+
+            //表情が適用され、補間が終了したので従来処理でもよくなったケース: 実態に沿うようにする
+            if (!_toState.IsEmpty && _faceAppliedCount >= FaceApplyCountMax)
+            {
+                NeedToInterpolate = false;
+                NonMouthWeight = 0f;
+                MouthWeight = _toState.KeepLipSync ? 1f : 0f;
+                return;
+            }
+            
+            //上記どちらでもない: 補間が要るはず
+            NeedToInterpolate = true;
+            
+            var weight = WeightCurve[_faceAppliedCount];
+            MouthWeight = Mathf.Lerp(_fromState.MouthWeight, _toState.MouthWeight, weight);
+            NonMouthWeight = Mathf.Lerp(_fromState.NonMouthWeight, _toState.NonMouthWeight, weight);
+            _fromState.Weight = 1 - weight;
+            _toState.Weight = weight;
+
+            var fps = Application.targetFrameRate;
+            _faceAppliedCount++;
+            if (fps < 60)
+            {
+                _faceAppliedCount++;
+            }
+        }
+
+        //NOTE: fromかtoにFaceSwitch / WtMいずれかの表情が入っている時だけ呼ぶ想定の関数。
+        //ただし、それ以外のケースで呼んでも破綻はしないはず
+        public void Accumulate(VRMBlendShapeProxy proxy)
+        {
+            foreach (var item in _fromState.Keys)
+            {
+                proxy.AccumulateValue(item.Item1, item.Item2 * _fromState.Weight);
+            }
+
+            foreach (var item in _toState.Keys)
+            {
+                proxy.AccumulateValue(item.Item1, item.Item2 * _toState.Weight);
+            }
+        }
+
+        private void SetFaceSwitch(BlendShapeKey key, bool keepLipSync)
+        {
+            _toState.CopyTo(_fromState);
+            
+            _toState.IsEmpty = false;
+            _toState.Weight = 0f;
+            _toState.Keys.Clear();
+            _toState.Keys.Add((key, 1f));
+            _toState.KeepLipSync = keepLipSync;
+            _toState.IsBinary = _hasModel && _blendShapeAvatar.GetClip(key)?.IsBinary == true;
+            
+            _faceAppliedCount = 0;
+        }
+
+        private void SetWordToMotion(List<(BlendShapeKey, float)> blendshapes, bool keepLipSync)
+        {
+            _toState.CopyTo(_fromState);
+            
+            _toState.IsEmpty = false;
+            _toState.Weight = 0f;
+            _toState.Keys.Clear();
+            _toState.Keys.AddRange(blendshapes);
+            _toState.KeepLipSync = keepLipSync;
+            _toState.IsBinary =
+                _hasModel && blendshapes.Any(b => _blendShapeAvatar.GetClip(b.Item1)?.IsBinary == true);
+
+            _faceAppliedCount = 0;
+        }
+
+        /// <summary> 表情が未適用の状態に遷移させる。 </summary>
+        private void Clear()
+        {
+            _toState.CopyTo(_fromState);
+            _toState.OverwriteToEmpty();
+            _toState.Weight = 0f;
+            _faceAppliedCount = 0;
+        }
+        
+        //NOTE: 「FaceSwitchもWtMも必要ない」という状態はIsEmpty == trueにすることで表現する
+        class State
+        {
+            public bool IsEmpty { get; set; }
+            public List<(BlendShapeKey, float)> Keys { get; } = new List<(BlendShapeKey, float)>(8);
+            public bool KeepLipSync { get; set; }
+            public bool IsBinary { get; set; }
+            public float Weight { get; set; }
+
+            //このステートのときにMouth/それ以外が最終的にWeightいくらで動いてほしいか
+            public float MouthWeight => IsEmpty || KeepLipSync ? 1f : 0f;
+            public float NonMouthWeight => IsEmpty ? 1f : 0f;
+
+            public void CopyTo(State other)
+            {
+                other.IsEmpty = IsEmpty;
+                other.Keys.Clear();
+                other.Keys.AddRange(Keys);
+                other.KeepLipSync = KeepLipSync;
+                other.IsBinary = IsBinary;
+                other.Weight = Weight;
+            }
+
+            public void OverwriteToEmpty()
+            {
+                IsEmpty = true;
+                Keys.Clear();
+                KeepLipSync = false;
+                IsBinary = false;
+            }
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74ad09254c619b64cb9899e8d2b2b82e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBonePostProcess.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBonePostProcess.cs
@@ -12,7 +12,10 @@ namespace Baku.VMagicMirror
     public class EyeBonePostProcess : MonoBehaviour
     {
         public float Scale { get; set; } = 1.0f;
+        /// <summary> 目を中央に固定したい場合、毎フレームtrueに設定する </summary>
         public bool ReserveReset { get; set; }
+        /// <summary> 目の移動ウェイトを小さくしたい場合、毎フレーム指定する </summary>
+        public float ReserveWeight { get; set; }
 
         private bool _hasEye = false;
         private Transform _leftEye = null;
@@ -54,14 +57,13 @@ namespace Baku.VMagicMirror
             if (_hasEye && (Scale < 0.995 || Scale > 1.005))
             {
                 _leftEye.localRotation.ToAngleAxis(out var leftAngle, out var leftAxis);
-                //範囲を[-180, 180]に保証する: 保証しないと角度の掛け算が成り立たないので
-                leftAngle = Mathf.Repeat(leftAngle + 180f, 360f) - 180f;
+                leftAngle = MathUtil.ClampAngle(leftAngle);
                 //絞った範囲でスケーリングしてから入れ直す
                 _leftEye.localRotation = Quaternion.AngleAxis(leftAngle * Scale, leftAxis);
                 
                 //leftEyeと同じ
                 _rightEye.localRotation.ToAngleAxis(out var rightAngle, out var rightAxis);
-                rightAngle = Mathf.Repeat(rightAngle + 180f, 360f) - 180f;
+                rightAngle = MathUtil.ClampAngle(rightAngle);
                 _rightEye.localRotation = Quaternion.AngleAxis(rightAngle * Scale, rightAxis);
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBonePostProcess.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBonePostProcess.cs
@@ -40,7 +40,8 @@ namespace Baku.VMagicMirror
         
         private void LateUpdate()
         {
-            //Face SwitchとかWord to Motionが指定されていれば、それを適用して終わり
+            //Face SwitchとかWord to Motionが指定されている: scale == 0に相当するので計算を省いて終了
+            //単にscale = 0として後半の計算に帰着しても良いが、まあ無駄が多いので…
             if (ReserveReset)
             {
                 if (_hasEye)
@@ -49,22 +50,27 @@ namespace Baku.VMagicMirror
                     _rightEye.localRotation = Quaternion.identity;
                 }
                 ReserveReset = false;
+                ReserveWeight = 1f;
                 return;
             }
 
             //それ以外の場合、回転量のスケーリングをしておく。
             //ただし、デフォルト設定時は何もしない。これはパフォーマンスと後方互換のカタさを両立するため
-            if (_hasEye && (Scale < 0.995 || Scale > 1.005))
+
+            var scale = Scale * ReserveWeight;
+            ReserveWeight = 1f;
+
+            if (_hasEye && (scale < 0.995 || scale > 1.005))
             {
                 _leftEye.localRotation.ToAngleAxis(out var leftAngle, out var leftAxis);
                 leftAngle = MathUtil.ClampAngle(leftAngle);
                 //絞った範囲でスケーリングしてから入れ直す
-                _leftEye.localRotation = Quaternion.AngleAxis(leftAngle * Scale, leftAxis);
+                _leftEye.localRotation = Quaternion.AngleAxis(leftAngle * scale, leftAxis);
                 
                 //leftEyeと同じ
                 _rightEye.localRotation.ToAngleAxis(out var rightAngle, out var rightAxis);
                 rightAngle = MathUtil.ClampAngle(rightAngle);
-                _rightEye.localRotation = Quaternion.AngleAxis(rightAngle * Scale, rightAxis);
+                _rightEye.localRotation = Quaternion.AngleAxis(rightAngle * scale, rightAxis);
             }
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceControlManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceControlManager.cs
@@ -44,7 +44,7 @@ namespace Baku.VMagicMirror
         /// <summary> WebCamベースのトラッキング中でも自動まばたきを優先するかどうかを取得、設定します。 </summary>
         public bool PreferAutoBlinkOnWebCamTracking { get; set; } = true;
         
-        public void Accumulate(VRMBlendShapeProxy proxy)
+        public void Accumulate(VRMBlendShapeProxy proxy, float weight = 1f)
         {
             if (!_hasModel)
             {
@@ -62,8 +62,8 @@ namespace Baku.VMagicMirror
                 (_config.ControlMode == FaceControlModes.WebCam && !PreferAutoBlinkOnWebCamTracking) ? imageBasedBlinkController.BlinkSource :
                 autoBlink.BlinkSource;
             
-            proxy.AccumulateValue(BlinkLKey, blinkSource.Left);
-            proxy.AccumulateValue(BlinkRKey, blinkSource.Right);        
+            proxy.AccumulateValue(BlinkLKey, blinkSource.Left * weight);
+            proxy.AccumulateValue(BlinkRKey, blinkSource.Right * weight);
         }
 
         private void Update()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/LipSyncIntegrator.cs
@@ -38,18 +38,18 @@ namespace Baku.VMagicMirror
             }
         }
         
-        public void Accumulate(VRMBlendShapeProxy proxy)
+        public void Accumulate(VRMBlendShapeProxy proxy, float weight = 1f)
         {
             //NOTE: マイクが無効な場合はanimMorphEasedTargetの出力がゼロになる、というのを想定した書き方でもあります
             var src = PreferExternalTrackerLipSync
                 ? externalTrackerLipSync.LipSyncSource
                 : animMorphEasedTarget.LipSyncSource;
 
-            proxy.AccumulateValue(_a, src.A);
-            proxy.AccumulateValue(_i, src.I);
-            proxy.AccumulateValue(_u, src.U);
-            proxy.AccumulateValue(_e, src.E);
-            proxy.AccumulateValue(_o, src.O);
+            proxy.AccumulateValue(_a, src.A * weight);
+            proxy.AccumulateValue(_i, src.I * weight);
+            proxy.AccumulateValue(_u, src.U * weight);
+            proxy.AccumulateValue(_e, src.E * weight);
+            proxy.AccumulateValue(_o, src.O * weight);
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs
@@ -36,19 +36,19 @@ namespace Baku.VMagicMirror
                 });
         }
         
-        public void ApplyNeutralClip(VRMBlendShapeProxy proxy) 
+        public void ApplyNeutralClip(VRMBlendShapeProxy proxy, float weight = 1f) 
         {
             if (HasValidNeutralClipKey)
             {
-                proxy.AccumulateValue(NeutralClipKey, 1f);
+                proxy.AccumulateValue(NeutralClipKey, weight);
             }
         }
 
-        public void ApplyOffsetClip(VRMBlendShapeProxy proxy)
+        public void ApplyOffsetClip(VRMBlendShapeProxy proxy, float weight = 1f)
         {
             if (HasValidOffsetClipKey)
             {
-                proxy.AccumulateValue(OffsetClipKey, 1f);
+                proxy.AccumulateValue(OffsetClipKey, weight);
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UniRx;
 using UnityEngine;
@@ -53,9 +54,9 @@ namespace Baku.VMagicMirror
         private bool _hasDiff;
 
         private readonly List<(BlendShapeKey, float)> _currentValueSource = new List<(BlendShapeKey, float)>(8);
-        private readonly ReactiveProperty<WordToMotionBlendShapeApplyContent> _currentValue
-            = new ReactiveProperty<WordToMotionBlendShapeApplyContent>(WordToMotionBlendShapeApplyContent.Empty);
-        public IReadOnlyReactiveProperty<WordToMotionBlendShapeApplyContent> CurrentValue => _currentValue;
+        private readonly Subject<WordToMotionBlendShapeApplyContent> _currentValue
+            = new Subject<WordToMotionBlendShapeApplyContent>();
+        public IObservable<WordToMotionBlendShapeApplyContent> CurrentValue => _currentValue;
         
         [Inject]
         public void Initialize(EyeBonePostProcess eyeBoneResetter)
@@ -87,6 +88,7 @@ namespace Baku.VMagicMirror
                 return;
             }
 
+            _hasDiff = false;
             _currentValueSource.Clear();
             foreach (var pair in _blendShape)
             {
@@ -95,11 +97,11 @@ namespace Baku.VMagicMirror
 
             if (_currentValueSource.Count > 0)
             {
-                _currentValue.Value = WordToMotionBlendShapeApplyContent.Create(_currentValueSource, KeepLipSync);
+                _currentValue.OnNext(WordToMotionBlendShapeApplyContent.Create(_currentValueSource, KeepLipSync));
             }
             else
             {
-                _currentValue.Value = WordToMotionBlendShapeApplyContent.Empty;
+                _currentValue.OnNext(WordToMotionBlendShapeApplyContent.Empty);
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
@@ -10,22 +10,28 @@ namespace Baku.VMagicMirror
 {
     public readonly struct WordToMotionBlendShapeApplyContent
     {
-        private WordToMotionBlendShapeApplyContent(bool hasValue, List<(BlendShapeKey, float)> keys, bool keepLipSync)
+        private WordToMotionBlendShapeApplyContent(
+            bool hasValue, List<(BlendShapeKey, float)> keys, bool keepLipSync, bool isPreview)
         {
             HasValue = hasValue;
             Keys = keys;
             KeepLipSync = keepLipSync;
+            IsPreview = isPreview;
         }
         
         public static WordToMotionBlendShapeApplyContent Empty { get; } 
-            = new WordToMotionBlendShapeApplyContent(false, new List<(BlendShapeKey, float)>(), false);
+            = new WordToMotionBlendShapeApplyContent(
+                false, new List<(BlendShapeKey, float)>(), false, false
+                );
 
-        public static WordToMotionBlendShapeApplyContent Create(List<(BlendShapeKey, float)> keys, bool keepLipSync)
-            => new WordToMotionBlendShapeApplyContent(true, keys, keepLipSync);
+        public static WordToMotionBlendShapeApplyContent Create(
+            List<(BlendShapeKey, float)> keys, bool keepLipSync, bool isPreview)
+            => new WordToMotionBlendShapeApplyContent(true, keys, keepLipSync, isPreview);
 
         public bool HasValue { get; }
         public List<(BlendShapeKey, float)> Keys { get; }
         public bool KeepLipSync { get; }
+        public bool IsPreview { get; }
         
     }
     /// <summary>
@@ -79,7 +85,23 @@ namespace Baku.VMagicMirror
         }
 
         /// <summary> trueの場合、このスクリプトではリップシンクのブレンドシェイプに書き込みを行いません。 </summary>
-        public bool KeepLipSync { get; set; }
+        public bool KeepLipSync { get; private set; }
+
+        private bool _isPreview = false;
+        /// <summary> 現在保持している値がPreview用のクリップの場合はtrue </summary>
+        public bool IsPreview
+        {
+            get => _isPreview;
+            set
+            {
+                if (_isPreview == value)
+                {
+                    return;
+                }
+                _isPreview = value;
+                _hasDiff = true;
+            }
+        }
 
         public void UpdateCurrentValue()
         {
@@ -97,7 +119,7 @@ namespace Baku.VMagicMirror
 
             if (_currentValueSource.Count > 0)
             {
-                _currentValue.OnNext(WordToMotionBlendShapeApplyContent.Create(_currentValueSource, KeepLipSync));
+                _currentValue.OnNext(WordToMotionBlendShapeApplyContent.Create(_currentValueSource, KeepLipSync, IsPreview));
             }
             else
             {
@@ -106,35 +128,64 @@ namespace Baku.VMagicMirror
         }
 
         /// <summary>
-        /// Word To Motionによるブレンドシェイプを指定します。
+        /// Preview用のクリップ情報があるとき、毎フレーム呼び出します。
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <remarks>1つ以上のブレンドシェイプを指定すると通常の表情制御をオーバーライドする。</remarks>
-        public void Add(BlendShapeKey key, float value)
+        /// <param name="values"></param>
+        /// <param name="keepLipSync"></param>
+        public void SetForPreview(IEnumerable<(BlendShapeKey, float)> values, bool keepLipSync)
         {
-            if (_allBlendShapeKeys.Any(k => k.Name == key.Name) && !_blendShape.ContainsKey(key))
+            //SetBlendShapesとは違ってClearしない: 前回と同じ値でよい場合、_hasDiff == falseになるようにしたい
+            foreach (var (key, value) in values)
+            {
+                //NOTE: Removeは不要。ロード中のアバターのClipはぜんぶ飛んでくるはずのため
+                if (_allBlendShapeKeys.Any(k => k.Name == key.Name) && 
+                    (!_blendShape.ContainsKey(key) || Mathf.Abs(_blendShape[key] - value) > 0.005f)
+                   )
+                {
+                    _blendShape[key] = value;
+                    _hasDiff = true;
+                }
+            }
+            
+            if (KeepLipSync != keepLipSync)
+            {
+                KeepLipSync = keepLipSync;
+                _hasDiff = true;
+            }
+        }
+
+        /// <summary>
+        /// Preview用ではない表情を適用する時、開始時に1回だけ呼び出すことで、表情を更新します。
+        /// </summary>
+        /// <param name="values"></param>
+        /// <param name="keepLipSync"></param>
+        public void SetBlendShapes(IEnumerable<(BlendShapeKey, float)> values, bool keepLipSync)
+        {
+            Clear();
+            foreach (var (key, value) in values)
             {
                 _blendShape[key] = value;
+                //valuesがカラになるパターンはほぼ無いはずで、実質的にはいつも_hasDiff == trueになる
                 _hasDiff = true;
             }
-        }
 
-        /// <summary>Word To Motionによる表情制御を無効化(終了)します。</summary>
-        public void Clear()
-        {
-            if (_blendShape.Count > 0)
+            if (KeepLipSync != keepLipSync)
             {
+                KeepLipSync = keepLipSync;
                 _hasDiff = true;
             }
-            _blendShape.Clear();
         }
-
+        
+        /// <summary>
+        /// Word To Motionによる表情制御(Preview表示や通常の適用)の終了時に呼び出します。
+        /// </summary>
         public void ResetBlendShape()
-        {
-            if (_blendShape.Count > 0)
+        { 
+            Clear();
+            if (KeepLipSync)
             {
-                Clear();
+                KeepLipSync = false;
+                _hasDiff = true;
             }
         }
 
@@ -166,6 +217,15 @@ namespace Baku.VMagicMirror
                 }
             }
             _eyeBoneResetter.ReserveReset = true;
+        }
+
+        private void Clear()
+        {
+            if (_blendShape.Count > 0)
+            {
+                _hasDiff = true;
+            }
+            _blendShape.Clear();
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -74,6 +74,7 @@
         public const string FaceDefaultFun = nameof(FaceDefaultFun);
         public const string FaceNeutralClip = nameof(FaceNeutralClip);
         public const string FaceOffsetClip = nameof(FaceOffsetClip);
+        public const string DisableBlendShapeInterpolate = nameof(DisableBlendShapeInterpolate);
 
         // Motion, Mouth
         public const string EnableLipSync = nameof(EnableLipSync);

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -53,6 +53,8 @@
         public string FaceNeutralClip { get; set; } = "";
         public string FaceOffsetClip { get; set; } = "";
 
+        public bool DisableBlendShapeInterpolate { get; set; } = false;
+
         #endregion
 
         #region Eye
@@ -143,6 +145,7 @@
             FaceDefaultFun = 0;
             FaceNeutralClip = "";
             FaceOffsetClip = "";
+            DisableBlendShapeInterpolate = false;
         }
 
         public void ResetArmSetting()

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -122,6 +122,7 @@ namespace Baku.VMagicMirrorConfig
         public Message FaceNeutralClip(string clipName) => WithArg(clipName);
         public Message FaceOffsetClip(string clipName) => WithArg(clipName);
 
+        public Message DisableBlendShapeInterpolate(bool enable) => WithArg(enable);
 
         /// <summary>
         /// Query.

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -61,6 +61,9 @@ namespace Baku.VMagicMirrorConfig
             FaceNeutralClip = new RProperty<string>(setting.FaceNeutralClip, v => SendMessage(factory.FaceNeutralClip(v)));
             FaceOffsetClip = new RProperty<string>(setting.FaceOffsetClip, v => SendMessage(factory.FaceOffsetClip(v)));
 
+            DisableBlendShapeInterpolate = new RProperty<bool>(
+                setting.DisableBlendShapeInterpolate, v => SendMessage(factory.DisableBlendShapeInterpolate(v)));
+
             //TODO: 排他のタイミング次第でRadioButtonが使えなくなってしまうので要検証
             UseLookAtPointNone = new RProperty<bool>(setting.UseLookAtPointNone, v =>
             {
@@ -164,9 +167,10 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<string> CalibrateFaceData { get; }
 
         public RProperty<int> FaceDefaultFun { get; }
-
         public RProperty<string> FaceNeutralClip { get; }
         public RProperty<string> FaceOffsetClip { get; }
+
+        public RProperty<bool> DisableBlendShapeInterpolate { get; }
 
         public void RequestCalibrateFace() => SendMessage(MessageFactory.Instance.CalibrateFace());
 
@@ -264,6 +268,7 @@ namespace Baku.VMagicMirrorConfig
             FaceDefaultFun.Value = setting.FaceDefaultFun;
             FaceNeutralClip.Value = setting.FaceNeutralClip;
             FaceOffsetClip.Value = setting.FaceOffsetClip;
+            DisableBlendShapeInterpolate.Value = setting.DisableBlendShapeInterpolate;
         }
 
         public void ResetArmSetting()

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -280,8 +280,9 @@ If the face tracking works correctly, please ignore this warning.
     <sys:String x:Key="Motion_Face_OffsetClip">Offset BlendShape</sys:String>
     <sys:String x:Key="Motion_Face_OffsetClip_Help" xml:space="preserve">* Offset BlendShape is always applied.
   Use it when the model has BlendShape which is to adjust body shape.</sys:String>
+    <sys:String x:Key="Motion_Face_DisableBlendShapeInterpolate">Disable BlendShape interpolation</sys:String>
     
-    
+
     <!-- Layout Setting -->
     <sys:String x:Key="Layout_Header">Layout</sys:String>   
    

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -283,6 +283,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_Face_OffsetClip">体型調整ブレンドシェイプ</sys:String>
     <sys:String x:Key="Motion_Face_OffsetClip_Help" xml:space="preserve">※体型調整ブレンドシェイプはつねに適用されます。
 　体格や輪郭の調整をブレンドシェイプで行っている場合に使用します。</sys:String>
+    <sys:String x:Key="Motion_Face_DisableBlendShapeInterpolate">表情切り替えを補間しない</sys:String>
     
     <!-- Layout Setting -->
     <sys:String x:Key="Layout_Header">レイアウト</sys:String>   

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
@@ -393,6 +393,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -400,28 +401,38 @@
                             <ColumnDefinition Width="1*"/>
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Row="0" Grid.Column="0"
+                        <CheckBox Grid.Row="0" Grid.Column="0" 
+                                  Grid.ColumnSpan="2"
+                                  Margin="0,5"
+                                  IsChecked="{Binding DisableBlendShapeInterpolate.Value}"
+                                  >
+                            <CheckBox.Content>
+                                <TextBlock Text="{DynamicResource Motion_Face_DisableBlendShapeInterpolate}"/>
+                            </CheckBox.Content>
+                        </CheckBox>
+
+                        <TextBlock Grid.Row="1" Grid.Column="0"
                                     Text="{DynamicResource Motion_Face_DefaultFun}"/>
-                        <Slider Grid.Row="0" Grid.Column="1"
+                        <Slider Grid.Row="1" Grid.Column="1"
                                 x:Name="sliderFaceDefaultFun"
                                 Minimum="0"
                                 Maximum="100"
                                 Value="{Binding FaceDefaultFun.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="0" Grid.Column="2"
+                        <TextBox Grid.Row="1" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderFaceDefaultFun}"
                                  />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0"
+                        <TextBlock Grid.Row="2" Grid.Column="0"
                                    Text="{DynamicResource Motion_Face_NeutralClip}"
                                    />
 
-                        <TextBlock Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3"
+                        <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3"
                                    Margin="15,5,15,10"
                                    Text="{DynamicResource Motion_Face_NeutralClip_Help}"
                                    TextWrapping="Wrap"
                                    />
-                        <ComboBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
+                        <ComboBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2"
                                   HorizontalAlignment="Stretch"
                                   Margin="5"
                                   ItemsSource="{Binding BlendShapeNames}"
@@ -442,16 +453,16 @@
                         </ComboBox>
 
 
-                        <TextBlock Grid.Row="3" Grid.Column="0"
+                        <TextBlock Grid.Row="4" Grid.Column="0"
                                    Text="{DynamicResource Motion_Face_OffsetClip}"
                                    />
 
-                        <TextBlock Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="3"
+                        <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3"
                                    Margin="15,5"
                                    Text="{DynamicResource Motion_Face_OffsetClip_Help}"
                                    TextWrapping="Wrap"
                                      />
-                        <ComboBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2"
+                        <ComboBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
                                   HorizontalAlignment="Stretch"
                                   Margin="5"
                                   ItemsSource="{Binding BlendShapeNames}"

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
@@ -117,6 +117,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<string> FaceNeutralClip => _model.FaceNeutralClip;
         public RProperty<string> FaceOffsetClip => _model.FaceOffsetClip;
 
+        public RProperty<bool> DisableBlendShapeInterpolate => _model.DisableBlendShapeInterpolate;
+
         #endregion
 
         #region Eye


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [ ] Bug fix
- [ ] Add new feature
- [x] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

概要

- #756 
- UIを直接編集せずに範囲で発生するような表情の変化に対して補間ができるようになります。

やってること

- Face SwitchまたはWord to Motionで指定された表情について、BlendShape値が補間されるように適用します。
- `IsBinary`を含むClipが適用されるとき、補間はされず、ただちに表情が切り替わります。
- 目ボーンのウェイトも補間対象になります。
- 設定ウィンドウの「顔・表情」タブ>「ブレンドシェイプ」から、この補間をオフにできます。

やらないこと

- WtMの編集中のプレビュー表示のあいだは補間は適用されません。
- 外部トラッキングのオン/オフを行った場合なども補間は適用されません。
- アクセサリーの表示に対しては特段配慮しません。例えば、画像アクセサリーをフェードイン/アウトするような処理は組み込まれません。

## How to confirm

「外部トラッキング + パーフェクトシンク無効 + マイク非使用(=外部トラッキングでリップシンク)」の組み合わせに対して以下が動作すること。

- UIから補間をオフにすると補間されなくなる
- ベース状態、WtM、Face Switchの間での遷移において
    - 遷移元か遷移先がIsBinaryの表情だと直ちに遷移し、そうでない場合は補間される
    - リップシンク続行が指定されたWtM / Face Switchの場合、リップシンクが続行する
    - ベース状態以外に遷移するときの目ボーンについて、補間があれば徐々に中央に戻り、補間がなければ直ちに中央に戻る
- WtMの編集中の表情プレビューでは補間なしでWtMが有効であり、特に、Face Switchの条件を満たしてもFace Switchが適用されない

また、ベースの表情が以下2ケースになった場合も同様に動作し、特にWtM/Face Switchとベースの表情が意図せず混ざってしまわないこと。

- webカメラトラッキング + マイクリップシンク
- パーフェクトシンク





