### PR TITLE
カメラ操作でShift/Altキー入力が使えていなかった問題の修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/KeyboardToWordToMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/KeyboardToWordToMotion.cs
@@ -39,7 +39,7 @@ namespace Baku.VMagicMirror
 
         public KeyboardToWordToMotion(IKeyMouseEventSource keyMouseEventSource)
         {
-            _inputObserver = keyMouseEventSource.PressedRawKeys.Subscribe(keyName =>
+            _inputObserver = keyMouseEventSource.RawKeyDown.Subscribe(keyName =>
             {
                 //NOTE: D0-D8とNumPad系のキーはサニタイズ対象じゃないので、そのまま受け取っても大丈夫
                 if (_keyToItemIndex.ContainsKey(keyName))

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionTriggers.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionTriggers.cs
@@ -64,7 +64,7 @@ namespace Baku.VMagicMirror
                 }
             };
 
-            keyMouseEventSource.PressedRawKeys.Subscribe(keyName =>
+            keyMouseEventSource.RawKeyDown.Subscribe(keyName =>
             {
                 if (UseKeyboardWordTypingForWordToMotion)
                 {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/GlobalHookInputChecker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/GlobalHookInputChecker.cs
@@ -18,7 +18,8 @@ namespace Baku.VMagicMirror
     /// </remarks>
     public class GlobalHookInputChecker : MonoBehaviour, IReleaseBeforeQuit, IKeyMouseEventSource
     {
-        public IObservable<string> PressedRawKeys { get; } = new Subject<string>();
+        public IObservable<string> RawKeyDown { get; } = new Subject<string>();
+        public IObservable<string> RawKeyUp { get; } = new Subject<string>();
         //NOTE: このクラスはKeyDown/KeyUpを発火させない(すでにダミー実装が差し込まれてしまってるため)
         public IObservable<string> KeyDown { get; } = new Subject<string>();
         public IObservable<string> KeyUp { get; } = new Subject<string>();        

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/HybridInputChecker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/HybridInputChecker.cs
@@ -17,7 +17,8 @@ namespace Baku.VMagicMirror
         private readonly RawInputChecker _rawInput;
         private readonly GlobalHookInputChecker _globalHookInput;
 
-        public IObservable<string> PressedRawKeys => _rawInput.PressedRawKeys;
+        public IObservable<string> RawKeyDown => _rawInput.RawKeyDown;
+        public IObservable<string> RawKeyUp => _rawInput.RawKeyUp;
         public IObservable<string> KeyDown => _rawInput.KeyDown;
         public IObservable<string> KeyUp => _rawInput.KeyUp;
         public IObservable<string> MouseButton => _globalHookInput.MouseButton;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/IKeyboardEventSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/IKeyboardEventSource.cs
@@ -4,7 +4,8 @@ namespace Baku.VMagicMirror
 {
     public interface IKeyMouseEventSource
     {
-        IObservable<string> PressedRawKeys { get; }
+        IObservable<string> RawKeyDown { get; }
+        IObservable<string> RawKeyUp { get; }
         IObservable<string> KeyDown { get; }
         IObservable<string> KeyUp { get; }
         IObservable<string> MouseButton { get; }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/RawInputChecker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/KeyAndMouseInput/RawInputChecker.cs
@@ -21,8 +21,11 @@ namespace Baku.VMagicMirror
         
         private WindowProcedureHook _windowProcedureHook = null;
 
-        public IObservable<string> PressedRawKeys => _rawKeys;
-        private readonly Subject<string> _rawKeys = new Subject<string>();
+        public IObservable<string> RawKeyDown => _rawKeyDown;
+        private readonly Subject<string> _rawKeyDown = new Subject<string>();
+        
+        public IObservable<string> RawKeyUp => _rawKeyUp;
+        private readonly Subject<string> _rawKeyUp = new Subject<string>();
         
         public IObservable<string> KeyDown => _keyDown;
         private readonly Subject<string> _keyDown = new Subject<string>();
@@ -150,7 +153,7 @@ namespace Baku.VMagicMirror
                 else
                 {
                     var rawKey = ((Keys)keyCode).ToString();
-                    _rawKeys.OnNext(rawKey);
+                    _rawKeyDown.OnNext(rawKey);
                     
                     if (_randomizeKey)
                     {
@@ -166,8 +169,10 @@ namespace Baku.VMagicMirror
                 }
             }
             
-            while (_upKeys.TryDequeue(out int keyCode))
+            while (_upKeys.TryDequeue(out var keyCode))
             {
+                var rawKey = ((Keys)keyCode).ToString();
+                _rawKeyUp.OnNext(rawKey);
                 if (_randomizeKey)
                 {
                     //ランダム化されている場合、ともかく押したキーを順に離す、という挙動にして破綻しづらくする
@@ -179,7 +184,6 @@ namespace Baku.VMagicMirror
                 }
                 else
                 {
-                    var rawKey = ((Keys)keyCode).ToString();
                     _keyUp.OnNext(rawKey);
                 }
             }
@@ -339,7 +343,7 @@ namespace Baku.VMagicMirror
                 if (Input.GetKeyDown(_editorCheckTargetKeyCodes[i]))
                 {
                     string keyName = _editorCheckTargetKeyCodes[i].ToString();
-                    _rawKeys.OnNext(keyName);
+                    _rawKeyDown.OnNext(keyName);
 
                     if (_randomizeKey)
                     {
@@ -352,8 +356,9 @@ namespace Baku.VMagicMirror
                 if (Input.GetKeyUp(_editorCheckTargetKeyCodes[i]))
                 {
                     string keyName = _editorCheckTargetKeyCodes[i].ToString();
+                    _rawKeyUp.OnNext(keyName);
                     _keyUp.OnNext(keyName);
-                }      
+                }
             }
         }
         


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

- fixed #764
- `RawInput`でキー入力監視しているせいでUnity本体の`Input.GetKey`が軒並み動作していないのが根本原因のようでした

## How to confirm

ビルドした状態でのフリーカメラモードで

- LShift/RShiftで平行移動ができること
- LAlt/RAltで回転ができること
