### PR TITLE
Fix burst folder path to delete

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Editor/BuildHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Editor/BuildHelper.cs
@@ -198,8 +198,7 @@ namespace Baku.VMagicMirror
 
         private static void RemoveBurstRelatedFolder(string savePath)
         {
-            var rootFolder = Path.GetDirectoryName(savePath);
-            var burstDir = Path.Combine(rootFolder, "VMagicMirror_BurstDebugInformation_DoNotShip");
+            var burstDir = Path.Combine(savePath, "VMagicMirror_BurstDebugInformation_DoNotShip");
             if (Directory.Exists(burstDir))
             {
                 Directory.Delete(burstDir, true);


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

prodビルド時に`DoNotShip`フォルダがビルド内訳に入ってしまうのを修正しました。
本来は #788 に入ってるべきコミットが漏れてたのを追加しています。

This PR fixes path to `DoNotShip` folder which is created in Unity 2021 build. 
The commit was to be included in #788 .