### PR TITLE
Send world fixed accessory pos even though when has no attached bone

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -13,7 +13,7 @@ namespace Baku.VMagicMirror
         //カメラのnear clipが0.05なので、それより大きく、かつ十分小さめの値にする
         private const float BillboardZ = 0.1f;
 
-        private static readonly Vector3 DefaultPosition = new Vector3(0f, 0.05f, 0.17f);
+        private static readonly Vector3 DefaultPosition = new(0f, 0.05f, 0.17f);
         private static readonly Vector3 DefaultRotationEuler = Vector3.zero;
         private static readonly Vector3 DefaultScale = Vector3.one;
         
@@ -29,8 +29,7 @@ namespace Baku.VMagicMirror
         private Camera _cam = null;
 
         private Animator _animator = null;
-        private readonly Dictionary<AccessoryAttachTarget, Transform> _attachBones =
-            new Dictionary<AccessoryAttachTarget, Transform>();
+        private readonly Dictionary<AccessoryAttachTarget, Transform> _attachBones = new();
 
         private bool _visibleByWordToMotion;
         public bool VisibleByWordToMotion
@@ -403,13 +402,21 @@ namespace Baku.VMagicMirror
         //Unity上でTransformControlによって改変したPosition/Rotation/Scaleがある場合に呼び出すことで、layoutを更新します。
         private void UpdateLayout(TransformControl.TransformMode mode)
         {
+            Transform bone = null;
             if (ItemLayout == null || 
                 _animator == null || 
-                !_attachBones.TryGetValue(ItemLayout.AttachTarget, out var bone))
+                (ItemLayout.AttachTarget != AccessoryAttachTarget.World &&
+                 !_attachBones.TryGetValue(ItemLayout.AttachTarget, out bone)
+                ))
             {
                 return;
             }
 
+            var hasBone = bone != null;
+            var boneForward = hasBone ? bone.forward : Vector3.forward;
+            var bonePosition = hasBone ? bone.position : Vector3.zero;
+            var boneRightY = hasBone ? bone.right.y : 0f;
+            
             HasLayoutChange = true;
             switch (mode)
             {
@@ -425,15 +432,14 @@ namespace Baku.VMagicMirror
                     var cPos = ct.position;
                     var ray = new Ray(cPos, transform.position - cPos);
 
-                    var boneForward = bone.forward;
-                    var plane = new Plane(boneForward, bone.position + boneForward * ItemLayout.Position.z);
+                    var plane = new Plane(boneForward, bonePosition + boneForward * ItemLayout.Position.z);
 
                     //手にアタッチするケースではボーンのXY平面が動きすぎて難しいので、
                     //諦めてワールドのXY平面方向でやる
                     if (ItemLayout.AttachTarget == AccessoryAttachTarget.LeftHand ||
                         ItemLayout.AttachTarget == AccessoryAttachTarget.RightHand)
                     {
-                        plane = new Plane(Vector3.forward, bone.position);
+                        plane = new Plane(Vector3.forward, bonePosition);
                     }
 
                     if (!plane.Raycast(ray, out var enter))
@@ -442,7 +448,7 @@ namespace Baku.VMagicMirror
                     }
 
                     var dst = ray.origin + ray.direction * enter;
-                    ItemLayout.Position = bone.InverseTransformPoint(dst);
+                    ItemLayout.Position = hasBone ? bone.InverseTransformPoint(dst) : dst;
                     break;
                 
                 case TransformControl.TransformMode.Rotate:
@@ -467,7 +473,7 @@ namespace Baku.VMagicMirror
                     }
                     angle = MathUtil.ClampAngle(angle);
 
-                    var roll = Mathf.Asin(bone.right.y) * Mathf.Rad2Deg;
+                    var roll = boneRightY * Mathf.Rad2Deg;
                     if (ItemLayout.AttachTarget == AccessoryAttachTarget.LeftHand ||
                         ItemLayout.AttachTarget == AccessoryAttachTarget.RightHand)
                     {


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

fixed #793 
ワールド固定アクセサリについて、ギズモから操作した場合だけレイアウト情報の更新が保存されない問題を修正しました。
この問題は、ワールド固定時に親ボーンが存在しないことが理由で発生していました。

## How to confirm

エディタで、ワールド固定アクセサリを移動・回転したあとに終了して再起動したとき、アクセサリの配置が保持されていること。

