### PR TITLE
Fix avatar load failure with model without chest bone

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionSubroutines/ClapMotionKeyPoseCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionSubroutines/ClapMotionKeyPoseCalculator.cs
@@ -47,7 +47,13 @@ namespace Baku.VMagicMirror.IK
                 Vector3.Distance(rightUpperArm.position, rightLowerArm.position) +
                 Vector3.Distance(rightLowerArm.position, rightHand.position);
 
-            var chest = animator.GetBoneTransform(HumanBodyBones.Chest).position;
+            //chestは必須ボーンではないことに注意
+            var chestBone = animator.GetBoneTransform(HumanBodyBones.Chest);
+            if (chestBone == null)
+            {
+                chestBone = animator.GetBoneTransform(HumanBodyBones.Spine);
+            }
+            var chest = chestBone.position;
             var head = animator.GetBoneTransform(HumanBodyBones.Head).position;
 
             //ClapHeightは手首を持ってく位置を指定することに注意。気持ち低めを狙う。


### PR DESCRIPTION
## PR category

PR type: 

- [ ] Documentation fix / update
- [x] Bug fix
- [ ] Add new feature
- [ ] Improve existing feature
- [ ] Refactor (e.g. typo fix)

## What the PR does

fixed #797 

Chestは必須ボーンではないにもかかわらず、ClapするときのIK計算で必ず参照するような書き方になってしまっていたので、必須ではない扱いに修正しました。

## How to confirm

Unity公式アセットのRobot Kyle (Chestがない)をVRM化したものが読み込めること。ついでに、拍手も可能であること
