### PR TITLE
Add bone-only frame reduction option

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/MotionController.prefab
@@ -29,7 +29,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5813678810510073683}
   m_RootOrder: 4
@@ -103,7 +102,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5813678810510073683}
   m_RootOrder: 2
@@ -259,7 +257,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5813678810510073683}
   m_RootOrder: 1
@@ -329,7 +326,7 @@ MonoBehaviour:
   eyeSpeedFactor: 4
   motionBlendDuration: 0.5
   keepEyeCenterProbability: 0.5
-  eyeRotationFactor: 0.4
+  eyeRotationRateFactor: 0.05
   eyeOrientationVaryRange: 10
   inactiveFactors: {x: 10, y: 10}
   activeFactors: {x: 10, y: 10}
@@ -374,7 +371,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5813678810510073683}
   m_RootOrder: 3
@@ -431,7 +427,6 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5813678810510073683}
   m_RootOrder: 0
@@ -689,6 +684,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5813678810510073683}
   - component: {fileID: 733898353923353159}
+  - component: {fileID: 5470382612402142914}
   m_Layer: 0
   m_Name: MotionController
   m_TagString: Untagged
@@ -706,7 +702,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5813678810404708599}
   - {fileID: 5813678809054739211}
@@ -735,6 +730,19 @@ MonoBehaviour:
   headMotionClipPlayer: {fileID: 3163774597481480951}
   colliderBasedAvatarParamLoader: {fileID: 8229117264469737190}
   nonImageBasedMotion: {fileID: 3373783041301125446}
+--- !u!114 &5470382612402142914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5813678810510073684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 936b5a492f001084ebc1446b2abe1827, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  updateInterval: 0.12
 --- !u!1 &7492520328184788948
 GameObject:
   m_ObjectHideFlags: 0
@@ -762,7 +770,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5813678810510073683}
   m_RootOrder: 5
@@ -819,7 +826,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5813678810510073683}
   m_RootOrder: 6

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7caa99133e02f5f4d831c7d91bf03409
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
@@ -40,7 +40,7 @@ namespace Baku.VMagicMirror.FK
             vrmLoadable.VrmLoaded += OnModelLoaded;
             vrmLoadable.VrmDisposing += OnModelUnloaded;
             receiver.AssignCommandHandler(
-                VmmCommands.UseFrameReduction,
+                VmmCommands.UseFrameReductionEffect,
                 c => _frameReduceEnabled = c.ToBoolean()
             );
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
@@ -1,0 +1,136 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Zenject;
+
+namespace Baku.VMagicMirror.FK
+{
+    /// <summary>
+    /// Humanoidボーンのフレームをナイーブにリダクションするやつ。
+    /// </summary>
+    /// <remarks>
+    /// Experimentalというか、「動くけど見栄えが微妙」という実装ステータス。
+    /// やってないけど検討すべき事: 
+    /// - タイピングで指がいちばん降りたタイミングなど、リダクション後に優先的に選択して表示するフレームを拾う仕組みを足す
+    /// - (このクラスの仕事じゃないけど)捨てるフレームの情報を残像的な何かとして使う
+    /// </remarks>
+    public class BoneFrameReducer : MonoBehaviour
+    {
+        [Range(0.01f, 0.2f)] 
+        [SerializeField] private float updateInterval = 0.05f;
+
+        //NOTE: 揺れものはフルFPSでええねん、という事です
+        private readonly Dictionary<HumanBodyBones, Transform> _bones = new Dictionary<HumanBodyBones, Transform>();
+        private readonly Dictionary<HumanBodyBones, Quaternion> _reducedRotations =
+            new Dictionary<HumanBodyBones, Quaternion>();   
+        private readonly Dictionary<HumanBodyBones, Quaternion> _tempRotations =
+            new Dictionary<HumanBodyBones, Quaternion>();
+
+        private Vector3 _reducedHipsPosition;
+        private Vector3 _tempHipsPosition;
+
+        private bool _hasModel;
+        private float _updateCount = 0f;
+
+        private bool _frameReduceEnabled = false;
+
+        [Inject]
+        public void Initialize(IMessageReceiver receiver, IVRMLoadable vrmLoadable)
+        {
+            vrmLoadable.VrmLoaded += OnModelLoaded;
+            vrmLoadable.VrmDisposing += OnModelUnloaded;
+            receiver.AssignCommandHandler(
+                VmmCommands.UseFrameReduction,
+                c => _frameReduceEnabled = c.ToBoolean()
+            );
+        }
+
+        private void OnModelLoaded(VrmLoadedInfo info)
+        {
+            _bones.Clear();
+            _reducedRotations.Clear();
+            _tempRotations.Clear();
+
+            for (var i = (int) HumanBodyBones.Hips; i < (int) HumanBodyBones.LastBone; i++)
+            {
+                var boneType = (HumanBodyBones) i;
+                var bone = info.animator.GetBoneTransform(boneType);
+                if (bone != null)
+                {
+                    _bones[boneType] = bone;
+                    _reducedRotations[boneType] = Quaternion.identity;
+                    _tempRotations[boneType] = Quaternion.identity;
+                }
+            }
+            _hasModel = true;
+            _updateCount = updateInterval;
+        }
+
+        private void OnModelUnloaded()
+        {
+            _bones.Clear();
+            _hasModel = false;
+        }
+
+        private void Start()
+        {
+            StartCoroutine(RestoreFullFpsPose());
+        }
+
+        private void LateUpdate()
+        {
+            if (!_hasModel || !_frameReduceEnabled)
+            {
+                _updateCount = updateInterval;
+                return;
+            }
+
+            //2つのことをやる
+            // 1. 一定間隔で「reduceした状態で適用するボーン値」を取る
+            // 2. ボーン情報をreduce値に全部書き換えて描画させてから描画後に元に戻す -> 揺れものの計算をいい感じにするため
+            _updateCount += Time.deltaTime;
+            if (_updateCount >= updateInterval)
+            {
+                _updateCount -= updateInterval;
+                _reducedHipsPosition = _bones[HumanBodyBones.Hips].position;
+                foreach (var bonePair in _bones)
+                {
+                    var rot = bonePair.Value.localRotation;
+                    _reducedRotations[bonePair.Key] = rot;
+                    _tempRotations[bonePair.Key] = rot;
+                }
+            }
+
+            _tempHipsPosition = _bones[HumanBodyBones.Hips].position;
+            foreach (var bonePair in _bones)
+            {
+                _tempRotations[bonePair.Key] = bonePair.Value.localRotation;
+            }
+            
+            _bones[HumanBodyBones.Hips].position = _reducedHipsPosition;
+            foreach (var rotPair in _reducedRotations)
+            {
+                _bones[rotPair.Key].localRotation = rotPair.Value;
+            }
+        }
+
+        private IEnumerator RestoreFullFpsPose()
+        {
+            var eof = new WaitForEndOfFrame();
+            while (true)
+            {
+                yield return eof;
+                if (!_hasModel || !_frameReduceEnabled)
+                {
+                    continue;
+                }
+
+                _bones[HumanBodyBones.Hips].position = _tempHipsPosition;
+                foreach (var rotPair in _tempRotations)
+                {
+                    _bones[rotPair.Key].localRotation = rotPair.Value;
+                }
+            }
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 936b5a492f001084ebc1446b2abe1827
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 20080
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -134,7 +134,7 @@
 
         // Lighting 
         //NOTE: フレームリダクションはモーションよりはエフェクトかな～という事でこっち。
-        public const string UseFrameReduction = nameof(UseFrameReduction);
+        public const string UseFrameReductionEffect = nameof(UseFrameReductionEffect);
 
         public const string LightIntensity = nameof(LightIntensity);
         public const string LightColor = nameof(LightColor);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -133,6 +133,9 @@
         public const string SetHalfFpsMode = nameof(SetHalfFpsMode);
 
         // Lighting 
+        //NOTE: フレームリダクションはモーションよりはエフェクトかな～という事でこっち。
+        public const string UseFrameReduction = nameof(UseFrameReduction);
+
         public const string LightIntensity = nameof(LightIntensity);
         public const string LightColor = nameof(LightColor);
         public const string LightYaw = nameof(LightYaw);

--- a/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
@@ -13,7 +13,8 @@
         #region Image Quality
 
         public bool HalfFpsMode { get; set; } = false;
-
+        public bool UseFrameReductionEffect { get; set; } = false;
+        
         #endregion
 
         #region Light

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -224,6 +224,7 @@ namespace Baku.VMagicMirrorConfig
         public Message GetQualitySettingsInfo() => NoArg();
         public Message SetImageQuality(string name) => WithArg(name);
         public Message SetHalfFpsMode(bool enable) => WithArg(enable);
+        public Message UseFrameReductionEffect(bool enable) => WithArg(enable);
 
         /// <summary>
         /// Query

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -19,6 +19,8 @@ namespace Baku.VMagicMirrorConfig
 
             //エフェクト関係は設定項目がシンプルなため、例外はほぼ無い(色関係のメッセージ送信がちょっと特殊なくらい)
             HalfFpsMode = new RProperty<bool>(s.HalfFpsMode, v => SendMessage(factory.SetHalfFpsMode(v)));
+            UseFrameReductionEffect = new RProperty<bool>(
+                s.UseFrameReductionEffect, v => SendMessage(factory.UseFrameReductionEffect(v)));
 
             LightIntensity = new RProperty<int>(s.LightIntensity, i => SendMessage(factory.LightIntensity(i)));
             LightYaw = new RProperty<int>(s.LightYaw, i => SendMessage(factory.LightYaw(i)));
@@ -54,6 +56,7 @@ namespace Baku.VMagicMirrorConfig
         #region Image Quality
 
         public RProperty<bool> HalfFpsMode { get; }
+        public RProperty<bool> UseFrameReductionEffect { get; }
 
         #endregion
 
@@ -110,6 +113,7 @@ namespace Baku.VMagicMirrorConfig
         public void ResetImageQuality()
         {
             HalfFpsMode.Value = false;
+            UseFrameReductionEffect.Value = false;
         }
 
         public void ResetLightSetting()

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -364,6 +364,7 @@ Translate (2 way):
     <sys:String x:Key="ImageQuality">Image Quality</sys:String>
     <sys:String x:Key="ImageQuality_CurrentQuality">Quality</sys:String>
     <sys:String x:Key="ImageQuality_HalfFpsMode">Half FPS (Medium or higher quality)</sys:String>
+    <sys:String x:Key="ImageQuality_UseBoneFrameReduction">Low FPS for Bone Motion</sys:String>
     
     <sys:String x:Key="Light">Light</sys:String>
     <sys:String x:Key="Light_Intensity">Intensity [%]</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -366,7 +366,8 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="ImageQuality">画質</sys:String>
     <sys:String x:Key="ImageQuality_CurrentQuality">現在の設定</sys:String>
     <sys:String x:Key="ImageQuality_HalfFpsMode">FPSを半減 (Medium以上で有効)</sys:String>
-    
+    <sys:String x:Key="ImageQuality_UseBoneFrameReduction">ボーンのみ低FPS化</sys:String>
+
     <sys:String x:Key="Light">ライト</sys:String>
     <sys:String x:Key="Light_Intensity">明るさ[%]</sys:String>
     <sys:String x:Key="Light_Yaw">向き(横)[deg]</sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -66,10 +66,16 @@
                                   />
                     </Grid>
 
-                    <CheckBox Margin="10,5,10,15"
+                    <CheckBox Margin="10,5"
                               Content="{DynamicResource ImageQuality_HalfFpsMode}"
                               IsChecked="{Binding HalfFpsMode.Value}"
                               />
+
+                    <CheckBox Margin="10,5,10,15"
+                              Content="{DynamicResource ImageQuality_UseBoneFrameReduction}"
+                              IsChecked="{Binding UseFrameReductionEffect.Value}"
+                              />
+
                 </StackPanel>
             </Border>
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -57,6 +57,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<string> ImageQuality => _imageQuality.ImageQuality;
         public ReadOnlyObservableCollection<string> ImageQualityNames => _imageQuality.ImageQualityNames;
         public RProperty<bool> HalfFpsMode => _model.HalfFpsMode;
+        public RProperty<bool> UseFrameReductionEffect => _model.UseFrameReductionEffect;
 
         void UpdateLightColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(LightColor));
         void UpdateBloomColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(BloomColor));


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature

## What the PR does

#787 に最低限何かを入れるPRで、オプションを有効にするとアバターが8FPSで動くようになります。

見栄えがあまり追求されていないためissue fixedとは言えませんが、下記の理由からこの実装だけで一旦入れています。

- うまく使ったら使えそう
- 後載せでBlendShapeをリダクションする実装を入れても大丈夫
- リダクションするフレームを選ぶ処理も後載せで入る見込み

## How to confirm

ビルドしたGUI+Unity Editorにて、オプションのon/offに応じてボーンのリダクションが効いたり効かなかったりすること

