### PR TITLE
Continue eye move during blendshape applied / 表情適用中にも目ボーンを動かせるオプションを追加する

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
@@ -40,7 +40,7 @@ namespace Baku.VMagicMirror
         private bool _hasLeftEye;
         private bool _hasRightEye;
 
-        private bool _skipReset = false;
+        private bool _moveEyesDuringFaceClipApplied = false;
         private float _motionScale = 1f;
         private float _motionScaleWithMap = 1f;
         private bool _useAvatarEyeCurveMap = true;
@@ -65,7 +65,7 @@ namespace Baku.VMagicMirror
             
             receiver.AssignCommandHandler(
                 VmmCommands.EnableEyeMotionDuringClipApplied, 
-                command => _skipReset = command.ToBoolean()
+                command => _moveEyesDuringFaceClipApplied = command.ToBoolean()
                 );
             
             receiver.AssignCommandHandler(
@@ -156,7 +156,7 @@ namespace Baku.VMagicMirror
             leftPitch += _eyeLookAt.Pitch;
             rightPitch += _eyeLookAt.Pitch;
 
-            if (ReserveReset && !_skipReset)
+            if (ReserveReset && !_moveEyesDuringFaceClipApplied)
             {
                 //NOTE: 0でもmap処理が入った結果、非ゼロの角度が入る可能性があるのでreturnはしない
                 leftPitch = 0f;
@@ -169,7 +169,7 @@ namespace Baku.VMagicMirror
                 var motionScale = _useAvatarEyeCurveMap
                     ? _motionScaleWithMap
                     : _motionScale * factorWhenMapDisable;
-                var weightFactor = motionScale * ReserveWeight;
+                var weightFactor = motionScale * (_moveEyesDuringFaceClipApplied ? 1 : ReserveWeight);
                 leftPitch = ScaleAndClampAngle(leftPitch, weightFactor);
                 leftYaw = ScaleAndClampAngle(leftYaw, weightFactor);
                 rightPitch = ScaleAndClampAngle(rightPitch, weightFactor);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
@@ -40,6 +40,7 @@ namespace Baku.VMagicMirror
         private bool _hasLeftEye;
         private bool _hasRightEye;
 
+        private bool _skipReset = false;
         private float _motionScale = 1f;
         private float _motionScaleWithMap = 1f;
         private bool _useAvatarEyeCurveMap = true;
@@ -61,6 +62,11 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += OnVrmLoaded;
             vrmLoadable.VrmDisposing += OnVrmDisposed;
+            
+            receiver.AssignCommandHandler(
+                VmmCommands.EnableEyeMotionDuringClipApplied, 
+                command => _skipReset = command.ToBoolean()
+                );
             
             receiver.AssignCommandHandler(
                 VmmCommands.SetEyeBoneRotationScale,
@@ -150,14 +156,13 @@ namespace Baku.VMagicMirror
             leftPitch += _eyeLookAt.Pitch;
             rightPitch += _eyeLookAt.Pitch;
 
-            if (ReserveReset)
+            if (ReserveReset && !_skipReset)
             {
                 //NOTE: 0でもmap処理が入った結果、非ゼロの角度が入る可能性があるのでreturnはしない
                 leftPitch = 0f;
                 leftYaw = 0f;
                 rightPitch = 0f;
                 rightYaw = 0f;
-                ReserveReset = false;
             }
             else
             {
@@ -170,6 +175,7 @@ namespace Baku.VMagicMirror
                 rightPitch = ScaleAndClampAngle(rightPitch, weightFactor);
                 rightYaw = ScaleAndClampAngle(rightYaw, weightFactor);
             }
+            ReserveReset = false;
             ReserveWeight = 1f;
             
             if (_useAvatarEyeCurveMap)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -71,9 +71,11 @@
         public const string DisableFaceTrackingHorizontalFlip = nameof(DisableFaceTrackingHorizontalFlip);
         public const string CalibrateFace = nameof(CalibrateFace);
         public const string SetCalibrateFaceData = nameof(SetCalibrateFaceData);
+
         public const string FaceDefaultFun = nameof(FaceDefaultFun);
         public const string FaceNeutralClip = nameof(FaceNeutralClip);
         public const string FaceOffsetClip = nameof(FaceOffsetClip);
+        public const string EnableEyeMotionDuringClipApplied = nameof(EnableEyeMotionDuringClipApplied);
         public const string DisableBlendShapeInterpolate = nameof(DisableBlendShapeInterpolate);
 
         // Motion, Mouth

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -63,6 +63,7 @@
         public bool UseLookAtPointMousePointer { get; set; } = true;
         public bool UseLookAtPointMainCamera { get; set; } = false;
 
+        public bool MoveEyesDuringFaceClipApplied { get; set; } = false;
         public bool UseAvatarEyeBoneMap { get; set; } = true;
         public int EyeBoneRotationScale { get; set; } = 100;
         public int EyeBoneRotationScaleWithMap { get; set; } = 100;
@@ -140,6 +141,7 @@
             UseLookAtPointMousePointer = true;
             UseLookAtPointMainCamera = false;
 
+            MoveEyesDuringFaceClipApplied = false;
             UseAvatarEyeBoneMap = true;
             EyeBoneRotationScale = 100;
             EyeBoneRotationScaleWithMap = 100;

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -145,6 +145,7 @@ namespace Baku.VMagicMirrorConfig
         public Message MicrophoneDeviceNames() => NoArg();
 
         public Message LookAtStyle(string v) => WithArg(v);
+        public Message EnableEyeMotionDuringClipApplied(bool enable) => WithArg(enable);
         public Message SetUseAvatarEyeBoneMap(bool use) => WithArg(use);
         public Message SetEyeBoneRotationScale(int percent) => WithArg(percent);
         public Message SetEyeBoneRotationScaleWithMap(int percent) => WithArg(percent);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -61,6 +61,8 @@ namespace Baku.VMagicMirrorConfig
             FaceNeutralClip = new RProperty<string>(setting.FaceNeutralClip, v => SendMessage(factory.FaceNeutralClip(v)));
             FaceOffsetClip = new RProperty<string>(setting.FaceOffsetClip, v => SendMessage(factory.FaceOffsetClip(v)));
 
+            MoveEyesDuringFaceClipApplied = new RProperty<bool>(
+                setting.MoveEyesDuringFaceClipApplied, v => SendMessage(factory.EnableEyeMotionDuringClipApplied(v)));
             DisableBlendShapeInterpolate = new RProperty<bool>(
                 setting.DisableBlendShapeInterpolate, v => SendMessage(factory.DisableBlendShapeInterpolate(v)));
 
@@ -172,6 +174,7 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<string> FaceNeutralClip { get; }
         public RProperty<string> FaceOffsetClip { get; }
 
+        public RProperty<bool> MoveEyesDuringFaceClipApplied { get; }
         public RProperty<bool> DisableBlendShapeInterpolate { get; }
 
         public void RequestCalibrateFace() => SendMessage(MessageFactory.Instance.CalibrateFace());
@@ -263,6 +266,8 @@ namespace Baku.VMagicMirrorConfig
             UseLookAtPointNone.Value = setting.UseLookAtPointNone;
             UseLookAtPointMousePointer.Value = setting.UseLookAtPointMousePointer;
             UseLookAtPointMainCamera.Value = setting.UseLookAtPointMainCamera;
+
+            MoveEyesDuringFaceClipApplied.Value = setting.MoveEyesDuringFaceClipApplied;
             UseAvatarEyeBoneMap.Value = setting.UseAvatarEyeBoneMap;
             EyeBoneRotationScale.Value = setting.EyeBoneRotationScale;
             EyeBoneRotationScaleWithMap.Value = setting.EyeBoneRotationScaleWithMap;

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -269,6 +269,7 @@ If the face tracking works correctly, please ignore this warning.
     <sys:String x:Key="Motion_Eye_LookAtPoint_None">None</sys:String>
     <sys:String x:Key="Motion_Eye_LookAtPoint_MousePointer">Mouse</sys:String>
     <sys:String x:Key="Motion_Eye_LookAtPoint_MainCamera">User</sys:String>
+    <sys:String x:Key="Motion_Eye_MoveDuringClip">Move eyes during facial expression applied</sys:String>
     <sys:String x:Key="Motion_Eye_UseAvatarEyeBoneMap">Apply eye bone curve defined in avatar</sys:String>
     <sys:String x:Key="Motion_Eye_RotScale">Eye Motion Scale[%]</sys:String>
     <sys:String x:Key="Motion_Eye_ApproxRotRangePrefix">(Eye bones will move about: </sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -270,6 +270,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_Eye_LookAtPoint_None">固定</sys:String>
     <sys:String x:Key="Motion_Eye_LookAtPoint_MousePointer">マウス</sys:String>
     <sys:String x:Key="Motion_Eye_LookAtPoint_MainCamera">ユーザー</sys:String>
+    <sys:String x:Key="Motion_Eye_MoveDuringClip">表情きりかえ時にも目ボーンを動かし続ける</sys:String>
     <sys:String x:Key="Motion_Eye_UseAvatarEyeBoneMap">アバターに定義した目ボーンのカーブ設定を使用</sys:String>
     <sys:String x:Key="Motion_Eye_RotScale">目の動きの大きさ[%]</sys:String>
     <sys:String x:Key="Motion_Eye_ApproxRotRangePrefix">(参考)目ボーンのおおよその可動範囲: </sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
@@ -327,6 +327,14 @@
                                   Content="{DynamicResource Motion_Eye_LookAtPoint_None}"/>
                     </Grid>
 
+                    <CheckBox Margin="15,5,0,0"
+                              IsChecked="{Binding MoveEyesDuringFaceClipApplied.Value}"
+                              >
+                        <CheckBox.Content>
+                            <TextBlock Text="{DynamicResource Motion_Eye_MoveDuringClip}"/>
+                        </CheckBox.Content>
+                    </CheckBox>
+
                     <Grid Margin="5,0,0,10">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -340,6 +348,7 @@
                         </Grid.ColumnDefinitions>
 
                         <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
+                                  Margin="10,0"
                                   IsChecked="{Binding UseAvatarEyeBoneMap.Value}">
                             <CheckBox.Content>
                                 <TextBlock Text="{DynamicResource Motion_Eye_UseAvatarEyeBoneMap}"/>

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
@@ -126,6 +126,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<bool> UseLookAtPointNone => _model.UseLookAtPointNone;
         public RProperty<bool> UseLookAtPointMousePointer => _model.UseLookAtPointMousePointer;
         public RProperty<bool> UseLookAtPointMainCamera => _model.UseLookAtPointMainCamera;
+
+        public RProperty<bool> MoveEyesDuringFaceClipApplied => _model.MoveEyesDuringFaceClipApplied;
         public RProperty<bool> UseAvatarEyeBoneMap => _model.UseAvatarEyeBoneMap;
         public RProperty<int> EyeBoneRotationScale => _model.EyeBoneRotationScale;
         public RProperty<int> EyeBoneRotationScaleWithMap => _model.EyeBoneRotationScaleWithMap;


### PR DESCRIPTION
## PR category

- [x] Add new feature

## What the PR does

fixed #813 .

アバターの表情セットアップによっては表情を適用したまま目ボーンが動いても特に害がないのでそれを許可する、というPRです。

このオプションはデフォルトではオフになっています。

※このPR時点で #803 との相性が特に考慮されていませんが、楽観的には特に問題ないはずなのと、最悪「BlendShapeの眼球運動が設定されたアバターでは本機能は無効」という事にしてもよい想定です。

## How to confirm

- パーフェクトシンクとそうでないケースについて、表情と目ボーンの両立動作がヘンでないこと。
- 特にパーフェクトシンクではないケースについて、自動瞬き処理に由来した目の上下運動が、表情の適用中に間違って発生してしまわないこと。
