### PR TITLE
Fix 2D accessory exception when attached to world and Foreground Mode enabled

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -510,8 +510,10 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            var bone = _attachBones[ItemLayout.AttachTarget];
-            if (bone == null)
+            //マイナーケースで「2DアクセサリをWorld固定で最前面表示しようとしている」というのがあり、それをガードしている
+            //これによって描画が崩れる可能性があるが、GUI側で警告を出すことでユーザーに直してもらう想定
+            if (!_attachBones.TryGetValue(ItemLayout.AttachTarget, out var bone) || 
+                bone == null)
             {
                 return;
             }

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -145,6 +145,8 @@ png image and 3D model by glb or gltf is available.</sys:String>
     <sys:String x:Key="Accessory_Item_DisplayName">Display Name</sys:String>
     <sys:String x:Key="Accessory_Item_AttachTarget">Attach to</sys:String>
     <sys:String x:Key="Accessory_Item_BillboardMode">2D Foreground Mode (image file only)</sys:String>
+    <sys:String x:Key="Accessory_Item_BillboardMode_Warning" xml:space="preserve">*World attached Foreground 2D accessory is invalid.
+Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Accessory_Item_Position">Position</sys:String>
     <sys:String x:Key="Accessory_Item_Rotation">Rotation</sys:String>
     <sys:String x:Key="Accessory_Item_Scale">Scale</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -145,6 +145,8 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Accessory_Item_DisplayName">表示名</sys:String>
     <sys:String x:Key="Accessory_Item_AttachTarget">配置先</sys:String>
     <sys:String x:Key="Accessory_Item_BillboardMode">2Dのまま最前面に表示 (画像のみ)</sys:String>
+    <sys:String x:Key="Accessory_Item_BillboardMode_Warning" xml:space="preserve">※World + 最前面表示の組み合わせは無効です。
+最前面表示をオフにするか、World以外にアクセサリを配置して下さい。</sys:String>
     <sys:String x:Key="Accessory_Item_Position">Position</sys:String>
     <sys:String x:Key="Accessory_Item_Rotation">Rotation</sys:String>
     <sys:String x:Key="Accessory_Item_Scale">Scale</sys:String>

--- a/WPF/VMagicMirrorConfig/View/AccessoryParts/AccessoryPartItemView.xaml
+++ b/WPF/VMagicMirrorConfig/View/AccessoryParts/AccessoryPartItemView.xaml
@@ -104,6 +104,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
@@ -141,59 +142,34 @@
                           IsEnabled="{Binding CanSelectBillboardMode}"
                           />
 
-                <TextBlock Grid.Row="3" Grid.Column="0" 
+                <TextBlock Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="7"
+                           Margin="20,0"
+                           FontWeight="Bold"
+                           Visibility="{Binding ShowInvalidBillboardWarning.Value, 
+                                                Converter={StaticResource BooleanToVisibilityConverter}}"
+                           Text="{DynamicResource Accessory_Item_BillboardMode_Warning}"
+                           />
+                
+                <TextBlock Grid.Row="4" Grid.Column="0" 
                         HorizontalAlignment="Left"
                         Text="{DynamicResource Accessory_Item_Position}" 
                         Margin="0,0,20,0"
                         />
-                <TextBlock Grid.Row="3" Grid.Column="1" 
+                <TextBlock Grid.Row="4" Grid.Column="1" 
                         Style="{StaticResource AxisText}"
                         Text="X" 
                         />
-                <TextBox Grid.Row="3" Grid.Column="2" 
+                <TextBox Grid.Row="4" Grid.Column="2" 
                         Text="{Binding PosX.Value, StringFormat=0.######, FallbackValue=1.234567}">
                     <i:Interaction.Behaviors>
                         <view:SelectOnFocusBehavior/>
                     </i:Interaction.Behaviors>
                 </TextBox>
-                <TextBlock Grid.Row="3" Grid.Column="3" 
+                <TextBlock Grid.Row="4" Grid.Column="3" 
                         Style="{StaticResource AxisText}"
                         Text="Y" />
-                <TextBox Grid.Row="3" Grid.Column="4" 
+                <TextBox Grid.Row="4" Grid.Column="4" 
                          Text="{Binding PosY.Value, StringFormat=0.######}">
-                    <i:Interaction.Behaviors>
-                        <view:SelectOnFocusBehavior/>
-                    </i:Interaction.Behaviors>
-                </TextBox>
-                <TextBlock Grid.Row="3" Grid.Column="5" 
-                        Style="{StaticResource AxisText}"
-                        Text="Z" />
-                <TextBox Grid.Row="3" Grid.Column="6"
-                         Text="{Binding PosZ.Value, StringFormat=0.######}">
-                    <i:Interaction.Behaviors>
-                        <view:SelectOnFocusBehavior/>
-                    </i:Interaction.Behaviors>
-                </TextBox>
-
-                <TextBlock Grid.Row="4" Grid.Column="0"
-                        Margin="0,0,20,0"
-                        HorizontalAlignment="Left"
-                        Text="{DynamicResource Accessory_Item_Rotation}" 
-                        />
-                <TextBlock Grid.Row="4" Grid.Column="1"
-                        Style="{StaticResource AxisText}"
-                        Text="X" />
-                <TextBox Grid.Row="4" Grid.Column="2"
-                         Text="{Binding RotX.Value, StringFormat=0.###}">
-                    <i:Interaction.Behaviors>
-                        <view:SelectOnFocusBehavior/>
-                    </i:Interaction.Behaviors>
-                </TextBox>
-                <TextBlock Grid.Row="4" Grid.Column="3"
-                        Style="{StaticResource AxisText}"
-                        Text="Y" />
-                <TextBox Grid.Row="4" Grid.Column="4"
-                         Text="{Binding RotY.Value, StringFormat=0.###}">
                     <i:Interaction.Behaviors>
                         <view:SelectOnFocusBehavior/>
                     </i:Interaction.Behaviors>
@@ -202,18 +178,51 @@
                         Style="{StaticResource AxisText}"
                         Text="Z" />
                 <TextBox Grid.Row="4" Grid.Column="6"
+                         Text="{Binding PosZ.Value, StringFormat=0.######}">
+                    <i:Interaction.Behaviors>
+                        <view:SelectOnFocusBehavior/>
+                    </i:Interaction.Behaviors>
+                </TextBox>
+
+                <TextBlock Grid.Row="5" Grid.Column="0"
+                        Margin="0,0,20,0"
+                        HorizontalAlignment="Left"
+                        Text="{DynamicResource Accessory_Item_Rotation}" 
+                        />
+                <TextBlock Grid.Row="5" Grid.Column="1"
+                        Style="{StaticResource AxisText}"
+                        Text="X" />
+                <TextBox Grid.Row="5" Grid.Column="2"
+                         Text="{Binding RotX.Value, StringFormat=0.###}">
+                    <i:Interaction.Behaviors>
+                        <view:SelectOnFocusBehavior/>
+                    </i:Interaction.Behaviors>
+                </TextBox>
+                <TextBlock Grid.Row="5" Grid.Column="3"
+                        Style="{StaticResource AxisText}"
+                        Text="Y" />
+                <TextBox Grid.Row="5" Grid.Column="4"
+                         Text="{Binding RotY.Value, StringFormat=0.###}">
+                    <i:Interaction.Behaviors>
+                        <view:SelectOnFocusBehavior/>
+                    </i:Interaction.Behaviors>
+                </TextBox>
+                <TextBlock Grid.Row="5" Grid.Column="5" 
+                        Style="{StaticResource AxisText}"
+                        Text="Z" />
+                <TextBox Grid.Row="5" Grid.Column="6"
                          Text="{Binding RotZ.Value, StringFormat=0.###}">
                     <i:Interaction.Behaviors>
                         <view:SelectOnFocusBehavior/>
                     </i:Interaction.Behaviors>
                 </TextBox>
                 
-                <TextBlock Grid.Row="5" Grid.Column="0"
+                <TextBlock Grid.Row="6" Grid.Column="0"
                         Margin="0,0,20,0"
                         HorizontalAlignment="Left"
                         Text="{DynamicResource Accessory_Item_Scale}" 
                         />
-                <TextBox Grid.Row="5" Grid.Column="2" 
+                <TextBox Grid.Row="6" Grid.Column="2" 
                         Text="{Binding Scale.Value, StringFormat=0.######, FallbackValue=1.0}"
                          >
                     <i:Interaction.Behaviors>
@@ -221,14 +230,14 @@
                     </i:Interaction.Behaviors>
                 </TextBox>
 
-                <TextBlock Grid.Row="6" Grid.Column="0"
+                <TextBlock Grid.Row="7" Grid.Column="0"
                         Margin="0,0,20,0"
                         HorizontalAlignment="Left"
                         Text="{DynamicResource Accessory_Item_Fps}" 
                         Visibility="{Binding CanEditFramePerSecond, Converter={StaticResource BooleanToVisibilityConverter}}"
                         />
                 <Slider x:Name="sliderItemFps"
-                        Grid.Row="6" Grid.Column="2" Grid.ColumnSpan="3"
+                        Grid.Row="7" Grid.Column="2" Grid.ColumnSpan="3"
                         Minimum="5"
                         Maximum="30"
                         TickFrequency="1"
@@ -236,7 +245,7 @@
                         Value="{Binding FramePerSecond.Value, Mode=TwoWay, FallbackValue=15}"
                         Visibility="{Binding CanEditFramePerSecond, Converter={StaticResource BooleanToVisibilityConverter}}"
                         />
-                <TextBox Grid.Row="6" Grid.Column="6"
+                <TextBox Grid.Row="7" Grid.Column="6"
                          Text="{Binding Value, ElementName=sliderItemFps}"
                          Visibility="{Binding CanEditFramePerSecond, Converter={StaticResource BooleanToVisibilityConverter}}"
                          />

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/AccessorySettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/AccessorySettingViewModel.cs
@@ -117,11 +117,13 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             {
                 _item.UseBillboardMode = v;
                 UpdateItemFromUi();
+                UpdateShowInvalidBillboardWarning();
             });
             AttachTarget = new RProperty<int>((int)_item.AttachTarget, v =>
             {
                 _item.AttachTarget = (AccessoryAttachTarget)v;
                 UpdateItemFromUi();
+                UpdateShowInvalidBillboardWarning();
             });
 
             PosX = new RProperty<float>(_item.Position.X, v =>
@@ -167,6 +169,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 _item.FramePerSecond = v;
                 UpdateItemFromUi();
             });
+
+            UpdateShowInvalidBillboardWarning();
         }
 
         private readonly AccessorySettingModel _model;
@@ -200,6 +204,15 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<int> FramePerSecond { get; }
 
         public ActionCommand ResetCommand { get; }
+
+        public RProperty<bool> ShowInvalidBillboardWarning { get; } = new RProperty<bool>(false);
+
+        private void UpdateShowInvalidBillboardWarning()
+        {
+            ShowInvalidBillboardWarning.Value =
+                (AccessoryAttachTarget)AttachTarget.Value == AccessoryAttachTarget.World &&
+                UseBillboardMode.Value;
+        }
 
         //NOTE: Unityのコンポーネントリセットと同じノリで良いはずのため、確認ダイアログは無し。
         //手触りがまずかったらダイアログを挟むか、またはUI側をContextMenu化で「確認してるよ」感を出す


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #816 .

- When user attaches 2D accessory to world and enabled Foreground Mode, then accessory pose is somehow left as-is.
- In this case, GUI shows warning that those combination is invalid, and promotes to change setting.

