### PR TITLE
Set ambient color according to light color value

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -20,12 +20,12 @@ RenderSettings:
   m_FogDensity: 0.01
   m_LinearFogStart: 0
   m_LinearFogEnd: 300
-  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
-  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
-  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientSkyColor: {r: 1, g: 1, b: 1, a: 1}
+  m_AmbientEquatorColor: {r: 0.3962264, g: 0.3962264, b: 0.3962264, a: 1}
+  m_AmbientGroundColor: {r: 0.028301895, g: 0.028301895, b: 0.028301895, a: 1}
   m_AmbientIntensity: 1
-  m_AmbientMode: 0
-  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_AmbientMode: 1
+  m_SubtractiveShadowColor: {r: 0, g: 0, b: 0, a: 1}
   m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -124,11 +124,19 @@ namespace Baku.VMagicMirror
         private void SetMainLightColor()
         {
             var factor = desktopLightEstimator.RgbFactor;
-            mainLight.color = new Color(
+            var color = new Color(
                 _color.r * factor.x,
                 _color.g * factor.y,
                 _color.b * factor.z
-            );   
+            );
+
+            mainLight.color = color;
+
+            //ライトの色がそのまま環境光にのる、ただしEquator以下では弱めに。
+            RenderSettings.ambientSkyColor = color;
+            Color.RGBToHSV(color, out var h, out var s, out var v);
+            RenderSettings.ambientEquatorColor = Color.HSVToRGB(h, s, v * 0.4f);
+            RenderSettings.ambientGroundColor = Color.HSVToRGB(h, s, v * 0.06f);
         }
 
         private void SetLightIntensity(float intensity)


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #830 

Skyboxに決め打ちで青とか茶色系の色が入ってたのを廃止し、Lightの色に準じた値が入るようにしました。

- ※「環境光の設定がメインライトの色と別でほしい！」みたいな再FBが来たらUI追加を含めて再検討します。
- デフォルトでは白色光を推奨しているつもりなので、白色光での見映えをプレーンにするのを狙った改修になっています。

## How to confirm

- [x] ライトをピンクや黒にしたときの効きが強くなっていること
