### PR TITLE
Feature/fix blendshape chattering

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/NeutralClipSettings.cs
@@ -40,8 +40,7 @@ namespace Baku.VMagicMirror
         {
             if (HasValidNeutralClipKey)
             {
-                //NOTE: 他の処理と被って値が1を超えるのを避けておく、一応
-                proxy.AccumulateValue(NeutralClipKey, Mathf.Min(weight, 1f - proxy.GetValue(NeutralClipKey)));
+                proxy.AccumulateValue(NeutralClipKey, weight);
             }
         }
 
@@ -49,8 +48,7 @@ namespace Baku.VMagicMirror
         {
             if (HasValidOffsetClipKey)
             {
-                //NOTE: 他の処理と被って値が1を超えるのを避けておく、一応
-                proxy.AccumulateValue(OffsetClipKey, 1f - proxy.GetValue(OffsetClipKey));
+                proxy.AccumulateValue(OffsetClipKey, 1f);
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/V2/WordToMotionRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/V2/WordToMotionRunner.cs
@@ -135,7 +135,11 @@ namespace Baku.VMagicMirror.WordToMotion
             if (request.UseBlendShape)
             {
                 _blendShapeResetCts = new CancellationTokenSource();
-                ResetBlendShapeAsync(duration, _blendShapeResetCts.Token).Forget(); 
+                //NOTE: HoldBlendShape == falseの場合、必ず有効なdurationが入ってるはず
+                if (!request.HoldBlendShape)
+                {
+                    ResetBlendShapeAsync(duration, _blendShapeResetCts.Token).Forget();
+                }
             }
 
             //アクセサリの処理


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #826 

- v2.0.10で「完了後も表情をキープ」が動かない→実際にフラグが無視されててリセット処理が予約されてたせい
- v2.0.8以降でのNeutralクリップのチャタリング→値が1超えしないようにガードしてる処理が余計なお世話だった

## How to confirm

ユーザーから報告を受けていたモデルであって、修正前だとNeutral表情のガタつきがあったようなモデルを使って

- 「完了後も表情をキープ」が指定された表情はWtMの実行後もキープされ、指定されない表情であれば元に戻ること
- 表情をリセットしたとき、Neutralクリップがチャタリングしないこと

