### PR TITLE
Decrease light intensity for backward compatibility

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
@@ -188,7 +188,7 @@ Light:
   m_Type: 1
   m_Shape: 0
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_Intensity: 1
+  m_Intensity: 0.85
   m_Range: 10
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208
@@ -564,8 +564,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2ad687426819894b991a0bed05efd34, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mainCam: {fileID: 1574337991341618299}
-  postProcessLayer: {fileID: 1574337991341618294}
 --- !u!1 &1574337991882445229
 GameObject:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -6,6 +6,10 @@ namespace Baku.VMagicMirror
 {
     public class LightingController : MonoBehaviour
     {
+        //NOTE: 本質的な意味はない値だが、VRM 0.xから1.0に引き上げたら同等のライティングでも強すぎに見えるようになったため、
+        //この係数をかけて光量を抑える。(MToonの何かが変わったものと思われるけど把握できてない)
+        private const float LightIntensityConstFactor = 0.85f;
+        
         [SerializeField] private Light mainLight = null;
         [SerializeField] private Vector3 mainLightLocalEulerAngle = default;
         
@@ -140,7 +144,7 @@ namespace Baku.VMagicMirror
         }
 
         private void SetLightIntensity(float intensity)
-            => mainLight.intensity = intensity;
+            => mainLight.intensity = intensity * LightIntensityConstFactor;
 
         private void SetLightYaw(int yawDeg)
         {


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #861

常時、ライトの明るさを85%に引き下げます。

※アクセサリの見えに対する検証が甘いですが、アバターに対してコンパチな見た目にするためには…ということで、こういうfixになっています。

## How to confirm

- VMM v2.0.11と本branchで明るさ100%の白色光が当たっているアバターの明るさが同じであること
- 100%(デフォルト)からそれ以外の明るさに変更したときに明るさが急に変わってしまわない = デフォルト値も0.85倍されていること
