### PR TITLE
Word to Motion(WtM)のデータ送受信では値が0のブレンドシェイプ情報を省く

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/V2/WordToMotionRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/V2/WordToMotionRunner.cs
@@ -88,7 +88,7 @@ namespace Baku.VMagicMirror.WordToMotion
                 _blendShape.SetBlendShapes(
                     request.BlendShapeValuesDic.Select(
                         pair => (ExpressionKeyUtils.CreateKeyByName(pair.Key), pair.Value)
-                    ),
+                    ).ToArray(),
                     request.PreferLipSync
                 );
             }
@@ -166,7 +166,7 @@ namespace Baku.VMagicMirror.WordToMotion
                 _blendShape.SetForPreview(
                     request.BlendShapeValuesDic.Select(
                         pair => (ExpressionKeyUtils.CreateKeyByName(pair.Key), pair.Value)
-                    ),
+                    ).ToArray(),
                     request.PreferLipSync
                 );
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
@@ -120,7 +120,7 @@ namespace Baku.VMagicMirror
         /// </summary>
         /// <param name="values"></param>
         /// <param name="keepLipSync"></param>
-        public void SetForPreview(IEnumerable<(ExpressionKey, float)> values, bool keepLipSync)
+        public void SetForPreview((ExpressionKey k, float v)[] values, bool keepLipSync)
         {
             //SetBlendShapesとは違ってClearしない: 前回と同じ値でよい場合、_hasDiff == falseになるようにしたい
             foreach (var (key, value) in values)
@@ -131,6 +131,19 @@ namespace Baku.VMagicMirror
                 {
                     _blendShape[key] = value;
                     _hasDiff = true;
+                }
+            }
+
+            //送られてない値は0扱いする
+            foreach (var key in _allBlendShapeKeys)
+            {
+                if (!values.Any(v => v.k.Equals(key)))
+                {
+                    if (_blendShape.ContainsKey(key) && _blendShape[key] > 0f)
+                    {
+                        _hasDiff = true;
+                    }
+                    _blendShape[key] = 0f;
                 }
             }
 
@@ -146,16 +159,22 @@ namespace Baku.VMagicMirror
         /// </summary>
         /// <param name="values"></param>
         /// <param name="keepLipSync"></param>
-        public void SetBlendShapes(IEnumerable<(ExpressionKey, float)> values, bool keepLipSync)
+        public void SetBlendShapes((ExpressionKey k, float v)[] values, bool keepLipSync)
         {
             Clear();
+
+            foreach (var key in _allBlendShapeKeys)
+            {
+                _blendShape[key] = 0f;
+            }            
+            
             foreach (var (key, value) in values)
             {
                 _blendShape[key] = value;
                 //valuesがカラになるパターンはほぼ無いはずで、実質的にはいつも_hasDiff == trueになる
                 _hasDiff = true;
             }
-
+            
             if (KeepLipSync != keepLipSync)
             {
                 KeepLipSync = keepLipSync;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/WordToMotionBlendShape.cs
@@ -44,7 +44,7 @@ namespace Baku.VMagicMirror
             ExpressionKey.CreateFromPreset(ExpressionPreset.oh),
         };
         
-        private ExpressionKey[] _allBlendShapeKeys = new ExpressionKey[0];
+        private ExpressionKey[] _allBlendShapeKeys = Array.Empty<ExpressionKey>();
 
         private readonly Dictionary<ExpressionKey, float> _blendShape = new Dictionary<ExpressionKey, float>();
         
@@ -125,7 +125,6 @@ namespace Baku.VMagicMirror
             //SetBlendShapesとは違ってClearしない: 前回と同じ値でよい場合、_hasDiff == falseになるようにしたい
             foreach (var (key, value) in values)
             {
-                //NOTE: Removeは不要。ロード中のアバターのClipはぜんぶ飛んでくるはずのため
                 if (_allBlendShapeKeys.Any(k => k.Name == key.Name) && 
                     (!_blendShape.ContainsKey(key) || Mathf.Abs(_blendShape[key] - value) > 0.005f)
                    )
@@ -134,7 +133,7 @@ namespace Baku.VMagicMirror
                     _hasDiff = true;
                 }
             }
-            
+
             if (KeepLipSync != keepLipSync)
             {
                 KeepLipSync = keepLipSync;
@@ -188,7 +187,6 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            //NOTE: LateUpdateの実装(初期実装)と違い、必要なとこだけ狙ってAccumulateする
             for (int i = 0; i < _allBlendShapeKeys.Length; i++)
             {
                 var key = _allBlendShapeKeys[i];

--- a/WPF/VMagicMirrorConfig/Model/MessageData/MotionRequest.cs
+++ b/WPF/VMagicMirrorConfig/Model/MessageData/MotionRequest.cs
@@ -60,7 +60,9 @@ namespace Baku.VMagicMirrorConfig
 
         public MotionRequest ToVrm10Request()
         {
-            //基本は値コピーだが、ブレンドシェイプ名をVRM 1.0のものに読み替えているのがポイント
+            //基本は値コピーだが、以下の点で異なる
+            // - ブレンドシェイプ名をVRM 1.0のものに読み替える
+            // - 値が0であるようなカスタムブレンドシェイプは落とす (送信データを削るため)
             return new MotionRequest()
             {
                 MotionType = MotionType,
@@ -76,7 +78,7 @@ namespace Baku.VMagicMirrorConfig
                     p => DefaultBlendShapeNameStore.GetVrm10KeyName(p.Key),
                     p => p.Value
                     ),
-                ExtraBlendShapeValues = ExtraBlendShapeValues.ToList(),
+                ExtraBlendShapeValues = ExtraBlendShapeValues.Where(v => v.Value > 0).ToList(),
             };
         }
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #868

以下のケースでデータの送受信量がかなり増えすぎていて、MemoryMappedFileのサイズオーバーが起きやすくなってたのをマシにする、という改修です。

- パーフェクトシンク対応モデルを使う(使った事がある)
- WtMの項目をたくさん定義してる

## How to confirm

- [x] ログを一時的に仕込んでCommandArrayで送信される(=初期化時に送っている)メッセージを確認したとき、その文字数が十分小さい
- [x] プリセットの表情、およびカスタム表情1~2個からなる表情を含むWtMが正常に実行できる
- [x] プレビューの編集がおかしくなっていない

## Note

Please write something to be noted, if exists.

* *e.g. the point to be reviewed carefully, risk of the PR, etc.*

