### PR TITLE
アクセサリを大量にフォルダに含めているときのメモリ使用量を改善

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFile.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFile.cs
@@ -80,7 +80,9 @@ namespace Baku.VMagicMirror
         /// </remarks>
         public string FileId { get; }
         public bool IsFolder { get; }
- 
+
+        //NOTE: バイナリはアンロードしない。ちょっと効率が悪いが、画像をリサイズしたいときに欲しくなるため。
+        
         //.png, .glbの本体、あるいは.gltfファイルで.gltfファイルそのもの。連番画像の場合はカラ 
         public byte[] Bytes { get; private set; } = Array.Empty<byte>();
 
@@ -125,6 +127,7 @@ namespace Baku.VMagicMirror
             }
         }
 
+        //NOTE: 
         /// <summary>
         /// 取得したバイナリを使い終わったあとで呼ぶことで、バイナリをGC対象にします。
         /// </summary>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
@@ -26,17 +26,17 @@ namespace Baku.VMagicMirror
         // NOTE: ぜんぶ同じフォルダに入ってる事は保証されてない事に注意。
         // gltfや、(今は無いけど想定される例として)連番画像とかはフォルダを区切った中に入る。
 
-        public static AccessoryFileContext<Texture2D> LoadPngImage(byte[] bytes)
+        public static AccessoryFileContext<Texture2D> LoadPngImage(AccessoryFile file, byte[] bytes)
         {
             if (bytes == null || bytes.Length == 0)
             {
-                return new AccessoryFileContext<Texture2D>(null, new ImageAccessoryActions(null));
+                return new AccessoryFileContext<Texture2D>(null, new ImageAccessoryActions(file, null));
             }
 
             var tex = new Texture2D(8, 8, TextureFormat.RGBA32, false);
             tex.LoadImage(bytes);
             tex.Apply();
-            return new AccessoryFileContext<Texture2D>(tex, new ImageAccessoryActions(tex));
+            return new AccessoryFileContext<Texture2D>(tex, new ImageAccessoryActions(file, tex));
         }
 
         public static AccessoryFileContext<GameObject> LoadGltf(string path, byte[] bytes)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using UniGLTF;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -26,6 +28,11 @@ namespace Baku.VMagicMirror
 
         public static AccessoryFileContext<Texture2D> LoadPngImage(byte[] bytes)
         {
+            if (bytes == null || bytes.Length == 0)
+            {
+                return new AccessoryFileContext<Texture2D>(null, new ImageAccessoryActions(null));
+            }
+
             var tex = new Texture2D(8, 8, TextureFormat.RGBA32, false);
             tex.LoadImage(bytes);
             tex.Apply();
@@ -34,6 +41,11 @@ namespace Baku.VMagicMirror
 
         public static AccessoryFileContext<GameObject> LoadGltf(string path, byte[] bytes)
         {
+            if (!File.Exists(path) || bytes == null || bytes.Length == 0)
+            {
+                return new AccessoryFileContext<GameObject>(new GameObject("(empty)"), new EmptyFileActions());
+            }
+
             var parser = new AutoGltfFileParser(path);
             using var data = parser.Parse();
             return LoadGlbOrGltf(data);
@@ -41,6 +53,11 @@ namespace Baku.VMagicMirror
 
         public static AccessoryFileContext<GameObject> LoadGlb(string path, byte[] bytes)
         {
+            if (!File.Exists(path) || bytes == null || bytes.Length == 0)
+            {
+                return new AccessoryFileContext<GameObject>(new GameObject("(empty)"), new EmptyFileActions());
+            }
+
             var parser = new GlbLowLevelParser("", bytes);
             using var data = parser.Parse();
             return LoadGlbOrGltf(data);
@@ -48,6 +65,10 @@ namespace Baku.VMagicMirror
 
         public static AccessoryFileContext<AnimatableImage> LoadNumberedPngImage(byte[][] binaries)
         {
+            if (binaries == null)
+            {
+                binaries = Array.Empty<byte[]>();
+            }
             var res = new AnimatableImage(binaries);
             //他と違い、AnimatableImage自体がFileActionを実装済み
             return new AccessoryFileContext<AnimatableImage>(res, res);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -103,13 +103,13 @@ namespace Baku.VMagicMirror
                     case AccessoryType.Glb:
                         var glbContext = AccessoryFileReader.LoadGlb(_file.FilePath, _file.Bytes);
                         var glbObj = glbContext.Object;
-                        glbObj.transform.SetParent(modelParent);
+                        glbObj.transform.SetParent(modelParent, false);
                         _fileActions = glbContext.Actions;
                         break;
                     case AccessoryType.Gltf:
                         var gltfContext = AccessoryFileReader.LoadGltf(_file.FilePath, _file.Bytes);
                         var gltfObj = gltfContext.Object;
-                        gltfObj.transform.SetParent(modelParent);
+                        gltfObj.transform.SetParent(modelParent, false);
                         _fileActions = gltfContext.Actions;
                         break;
                     case AccessoryType.NumberedPng:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -92,39 +92,33 @@ namespace Baku.VMagicMirror
 
         public void LoadContent()
         {
-            try
+            _file.LoadBinary();
+            switch (_file.Type)
             {
-                _file.LoadBinary();
-                switch (_file.Type)
-                {
-                    case AccessoryType.Png:
-                        InitializeImage(_file);
-                        break;
-                    case AccessoryType.Glb:
-                        var glbContext = AccessoryFileReader.LoadGlb(_file.FilePath, _file.Bytes);
-                        var glbObj = glbContext.Object;
-                        glbObj.transform.SetParent(modelParent, false);
-                        _fileActions = glbContext.Actions;
-                        break;
-                    case AccessoryType.Gltf:
-                        var gltfContext = AccessoryFileReader.LoadGltf(_file.FilePath, _file.Bytes);
-                        var gltfObj = gltfContext.Object;
-                        gltfObj.transform.SetParent(modelParent, false);
-                        _fileActions = gltfContext.Actions;
-                        break;
-                    case AccessoryType.NumberedPng:
-                        InitializeAnimatableImage(_file);
-                        break;
-                    default:
-                        LogOutput.Instance.Write($"WARN: Tried to load unknown data, id={_file.FileId}");
-                        break;
-                }
+                case AccessoryType.Png:
+                    InitializeImage(_file);
+                    break;
+                case AccessoryType.Glb:
+                    var glbContext = AccessoryFileReader.LoadGlb(_file.FilePath, _file.Bytes);
+                    var glbObj = glbContext.Object;
+                    glbObj.transform.SetParent(modelParent, false);
+                    _fileActions = glbContext.Actions;
+                    break;
+                case AccessoryType.Gltf:
+                    var gltfContext = AccessoryFileReader.LoadGltf(_file.FilePath, _file.Bytes);
+                    var gltfObj = gltfContext.Object;
+                    gltfObj.transform.SetParent(modelParent, false);
+                    _fileActions = gltfContext.Actions;
+                    break;
+                case AccessoryType.NumberedPng:
+                    InitializeAnimatableImage(_file);
+                    break;
+                default:
+                    LogOutput.Instance.Write($"WARN: Tried to load unknown data, id={_file.FileId}");
+                    break;
             }
-            finally
-            {
-                //NOTE: もしglb/glTFでbyte[]を捨てて怒られる場合はちょっと考える
-                _file.ReleaseBinary();
-            }
+            
+            _fileActions?.UpdateLayout(ItemLayout);
         }
         
         /// <summary>
@@ -185,7 +179,7 @@ namespace Baku.VMagicMirror
 
         private void InitializeImage(AccessoryFile file)
         {
-            var context = AccessoryFileReader.LoadPngImage(file.Bytes);
+            var context = AccessoryFileReader.LoadPngImage(file, file.Bytes);
             var tex = context.Object;
             _fileActions = context.Actions;
             

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -122,7 +122,7 @@ namespace Baku.VMagicMirror
             }
             finally
             {
-                //NOTE: glb / glTFの場合、バイナリって破棄しても安全なんだっけ…？(安全そうには見えるが)
+                //NOTE: もしglb/glTFでbyte[]を捨てて怒られる場合はちょっと考える
                 _file.ReleaseBinary();
             }
         }
@@ -162,7 +162,7 @@ namespace Baku.VMagicMirror
                     _firstEnabledCalled = true;
                 }
 
-                _fileActions.Update(Time.deltaTime);
+                _fileActions?.Update(Time.deltaTime);
             }
         }
         
@@ -199,13 +199,18 @@ namespace Baku.VMagicMirror
             context.Object.Renderer = imageRenderer;
             _fileActions = context.Actions;
             
-            var tex = context.Object.FirstTexture;
+            var tex = context.Object.FirstValidTexture;
             imageRenderer.material.mainTexture = tex;
             SetImageRendererAspect(tex);
         }
 
         private void SetImageRendererAspect(Texture2D tex)
         {
+            if (tex == null)
+            {
+                return;
+            }
+
             if (tex.width < tex.height)
             {
                 var aspect = tex.width * 1.0f / tex.height;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -10,6 +10,11 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
+    //TODO: このクラスでアクセサリ由来のメモリ消費量が爆発しないように工夫を入れる。
+    // - アクセサリのenable on/offに応じてリソースの初期化 + 解放を行う
+    // - 解放は何か一定のstableな戦略をとる。minimumでは「1回もactiveになってないうちはロードしない」とかでもいい
+    //   - (連番pngについては何かうまい方法を考えていただけると…)
+
     /// <summary>
     /// アクセサリー機能の管理としては一番えらいクラス
     /// </summary>
@@ -138,6 +143,7 @@ namespace Baku.VMagicMirror
             {
                 var item = Instantiate(itemPrefab);
                 item.Initialize(_cam, file);
+                item.FirstEnabled += OnItemFirstEnabled;
                 if (_hasModel)
                 {
                     item.SetAnimator(_animator);
@@ -152,8 +158,14 @@ namespace Baku.VMagicMirror
             _items.Clear();
             foreach (var item in items)
             {
+                item.FirstEnabled -= OnItemFirstEnabled;
                 item.Dispose();
             }
+        }
+
+        private void OnItemFirstEnabled(AccessoryItem item)
+        {
+            item.LoadContent();
         }
         
         private void SetSingleAccessoryLayout(string json)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
@@ -17,6 +17,16 @@ namespace Baku.VMagicMirror
         World = 6,
     }
 
+    //値の定義順も含めてWPFと一致させる
+    public enum AccessoryImageResolutionLimit : int
+    {
+        None = 0,
+        Max1024 = 1,
+        Max512 = 2,
+        Max256 = 3,
+        Max128 = 4,
+    }
+
     [Serializable]
     public class AccessoryResetTargetItems
     {
@@ -45,5 +55,17 @@ namespace Baku.VMagicMirror
         public bool UseBillboardMode;
         //連番画像でのみ意味のある値
         public int FramePerSecond;
+        //画像または連番画像でのみ意味のある値 (※glTFのテクスチャに適用する手もあるが、面倒なので一旦パス)
+        public AccessoryImageResolutionLimit ResolutionLimit;
+
+        public int GetResolutionLimitSize() => ResolutionLimit switch
+        {
+            AccessoryImageResolutionLimit.Max1024 => 1024,
+            AccessoryImageResolutionLimit.Max512 => 512,
+            AccessoryImageResolutionLimit.Max256 => 256,
+            AccessoryImageResolutionLimit.Max128 => 128,
+            //無限大のことを指す
+            _ => 16384,
+        };
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
@@ -18,7 +18,7 @@ namespace Baku.VMagicMirror
     }
 
     //値の定義順も含めてWPFと一致させる
-    public enum AccessoryImageResolutionLimit : int
+    public enum AccessoryImageResolutionLimit
     {
         None = 0,
         Max1024 = 1,
@@ -32,7 +32,6 @@ namespace Baku.VMagicMirror
     {
         public string[] FileIds;
     }
-
     
     [Serializable]
     public class AccessoryLayouts

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryTextureResizer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryTextureResizer.cs
@@ -6,7 +6,7 @@ namespace Baku.VMagicMirror
 {
     public static class AccessoryTextureResizer
     {
-        //戻り値: 画像が生データのと同じ解像度ならtrue, 縮まっていればfalse
+        //戻り値: textureの解像度を変更したらtrue, そのまま戻したらfalse
         public static bool ResizeImage(
             Texture2D texture, int maxSize, byte[] rawBytes, int rawSize)
         {
@@ -28,29 +28,30 @@ namespace Baku.VMagicMirror
             {
                 if (rawSize <= maxSize)
                 {
-                    return true;
+                    return false;
                 }
                 else
                 {
                     TextureSizeUtil.GetSizeLimitedTexture(texture, maxSize);
-                    return false;
+                    return true;
                 }
             }
 
             if (size > maxSize)
             {
                 TextureSizeUtil.GetSizeLimitedTexture(texture, maxSize);
-                return false;
+                return true;
             }
             else if (size * 2 <= maxSize)
             {
                 var rawTexture = new Texture2D(16, 16, TextureFormat.ARGB32, false);
                 rawTexture.LoadImage(rawBytes);
                 rawTexture.Apply();
+                var currentWidth = texture.width;
                 TextureSizeUtil.GetSizeLimitedTexture(rawTexture, texture, maxSize);
-                var result = Math.Max(rawTexture.width, rawTexture.height) == rawSize;
                 Object.Destroy(rawTexture);
-                return result;
+                //NOTE: 通常はtrueになるはず(デカくできる見込みがあってデカくしているので)
+                return currentWidth != texture.width;
             }
             else
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryTextureResizer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryTextureResizer.cs
@@ -1,0 +1,62 @@
+using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Baku.VMagicMirror
+{
+    public static class AccessoryTextureResizer
+    {
+        //戻り値: 画像が生データのと同じ解像度ならtrue, 縮まっていればfalse
+        public static bool ResizeImage(
+            Texture2D texture, int maxSize, byte[] rawBytes, int rawSize)
+        {
+            if (rawBytes == null || rawBytes.Length == 0)
+            {
+                return false;
+            }
+
+            //分岐が微妙にムズい
+            // - 指定より小さい生画像を持っている -> そのままでOK
+            // - 生画像を持っており、縮小が必要 -> 手持ちテクスチャを縮める
+            // - 縮小した画像を使用中
+            //   - それよりmaxSizeが小さい -> さらに縮める
+            //   - 縮小画像を2倍以上に拡大してもOK -> デカくするために生画像を再度持ってくる
+
+            var size = Math.Max(texture.width, texture.height);
+            
+            if (size == rawSize)
+            {
+                if (rawSize <= maxSize)
+                {
+                    return true;
+                }
+                else
+                {
+                    TextureSizeUtil.GetSizeLimitedTexture(texture, maxSize);
+                    return false;
+                }
+            }
+
+            if (size > maxSize)
+            {
+                TextureSizeUtil.GetSizeLimitedTexture(texture, maxSize);
+                return false;
+            }
+            else if (size * 2 <= maxSize)
+            {
+                var rawTexture = new Texture2D(16, 16, TextureFormat.ARGB32, false);
+                rawTexture.LoadImage(rawBytes);
+                rawTexture.Apply();
+                TextureSizeUtil.GetSizeLimitedTexture(rawTexture, texture, maxSize);
+                var result = Math.Max(rawTexture.width, rawTexture.height) == rawSize;
+                Object.Destroy(rawTexture);
+                return result;
+            }
+            else
+            {
+                //今の圧縮状態がちょうどいい
+                return false;
+            }
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryTextureResizer.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryTextureResizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2df0895fb97edf64698d9a1f37247ea0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
@@ -64,7 +64,7 @@ namespace Baku.VMagicMirror
             {
                 //他に同じ画像があったら使い回す
                 var hasSameBinary = false;
-                for (var j = 0; j < i - 1; j++)
+                for (var j = 0; j < i; j++)
                 {
                     if (binaries[j].SequenceEqual(binaries[i]))
                     {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
@@ -29,6 +29,24 @@ namespace Baku.VMagicMirror
             public Texture2D Texture { get; }
         }
 
+        //NOTE: アプリの生存期間中この1枚しか使わないため、特にDestroyもしない
+        private static Texture2D _transparentTexture;
+        private static Texture2D LoadTransparentTexture()
+        {
+            if (_transparentTexture == null)
+            {
+                _transparentTexture = new Texture2D(16, 16, TextureFormat.ARGB32, false);
+                var colors = _transparentTexture.GetPixels32();
+                for (var i = 0; i < colors.Length; i++)
+                {
+                    colors[i] = new Color32(0, 0, 0, 0);
+                }
+                _transparentTexture.SetPixels32(colors);
+                _transparentTexture.Apply();
+            }
+            return _transparentTexture;
+        }
+
         public AnimatableImage(byte[][] binaries)
         {
             var rawTextures = binaries
@@ -142,6 +160,10 @@ namespace Baku.VMagicMirror
             if (Renderer != null)
             {
                 Renderer.material.mainTexture = CurrentTexture;
+                if (CurrentTexture == null)
+                {
+                    Renderer.material.mainTexture = LoadTransparentTexture();
+                }
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/GlbAccessoryActions.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/GlbAccessoryActions.cs
@@ -1,0 +1,26 @@
+namespace Baku.VMagicMirror
+{
+    public class GlbFileAccessoryActions : AccessoryFileActionsBase
+    {
+        public GlbFileAccessoryActions(UniGLTF.ImporterContext context, UniGLTF.RuntimeGltfInstance instance)
+        {
+            _context = context;
+            _instance = instance;
+        }
+        
+        private UniGLTF.ImporterContext _context;
+        private UniGLTF.RuntimeGltfInstance _instance;
+        
+        public override void Dispose()
+        {
+            _context?.Dispose();
+            _context = null;
+
+            if (_instance != null)
+            {
+                _instance.Dispose();
+            }
+            _instance = null;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/GlbAccessoryActions.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/GlbAccessoryActions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89c23ee2aed17184a8e270459b08e741
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace Baku.VMagicMirror
 {
     public interface IAccessoryFileActions
@@ -24,47 +22,5 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class EmptyFileActions : AccessoryFileActionsBase
     {
-    }
-    
-    public class ImageAccessoryActions : AccessoryFileActionsBase
-    {
-        public ImageAccessoryActions(Texture2D texture)
-        {
-            _texture = texture;
-        }
-        private Texture2D _texture;
-
-        public override void Dispose()
-        {
-            if (_texture != null)
-            {
-                Object.Destroy(_texture);                    
-            }
-            _texture = null;
-        }
-    }
-        
-    public class GlbFileAccessoryActions : AccessoryFileActionsBase
-    {
-        public GlbFileAccessoryActions(UniGLTF.ImporterContext context, UniGLTF.RuntimeGltfInstance instance)
-        {
-            _context = context;
-            _instance = instance;
-        }
-        
-        private UniGLTF.ImporterContext _context;
-        private UniGLTF.RuntimeGltfInstance _instance;
-        
-        public override void Dispose()
-        {
-            _context?.Dispose();
-            _context = null;
-
-            if (_instance != null)
-            {
-                _instance.Dispose();
-            }
-            _instance = null;
-        }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
@@ -18,6 +18,13 @@ namespace Baku.VMagicMirror
         public virtual void UpdateLayout(AccessoryItemLayout layout) { }
         public virtual void OnVisibilityChanged(bool isVisible) { }
     }
+
+    /// <summary>
+    /// ファイルの実態がなく、アクセサリーがロード出来なかったときにカラの実装を差し込む
+    /// </summary>
+    public class EmptyFileActions : AccessoryFileActionsBase
+    {
+    }
     
     public class ImageAccessoryActions : AccessoryFileActionsBase
     {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/ImageAccessoryActions.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/ImageAccessoryActions.cs
@@ -1,0 +1,40 @@
+using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Baku.VMagicMirror
+{
+    public class ImageAccessoryActions : AccessoryFileActionsBase
+    {
+        public ImageAccessoryActions(AccessoryFile file, Texture2D texture)
+        {
+            _file = file;
+            _texture = texture;
+            _rawSize = _texture != null ? Math.Max(_texture.width, _texture.height) : 0;
+        }
+        private readonly AccessoryFile _file;
+        private Texture2D _texture;
+        private int _rawSize;
+
+        public override void UpdateLayout(AccessoryItemLayout layout)
+        {
+            if (_file.Bytes == null || _file.Bytes.Length == 0)
+            {
+                return;
+            }
+
+            AccessoryTextureResizer.ResizeImage(
+                _texture, layout.GetResolutionLimitSize(), _file.Bytes, _rawSize
+                );
+        }
+
+        public override void Dispose()
+        {
+            if (_texture != null)
+            {
+                Object.Destroy(_texture);                    
+            }
+            _texture = null;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/ImageAccessoryActions.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/ImageAccessoryActions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47ef49aaae0bb1f49ae25b3e787ada78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/TextureSizeUtil.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/TextureSizeUtil.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Baku.VMagicMirror
+{
+    public static class TextureSizeUtil
+    {
+        /// <summary>
+        /// テクスチャの幅と高さの上限を抑えます。
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="maxSize"></param>
+        /// <returns></returns>
+        public static void GetSizeLimitedTexture(Texture2D source, int maxSize)
+        {
+            if (source.width <= maxSize && source.height <= maxSize)
+            {
+                return;
+            }
+
+            var width = source.width;
+            var height = source.height;
+            if (width > height)
+            {
+                height = Mathf.FloorToInt(height * maxSize * 1.0f / width);
+                width = maxSize;
+            }
+            else
+            {
+                width = Mathf.FloorToInt(width * maxSize * 1.0f / height);
+                height = maxSize;
+            }
+
+            //NOTE: アクセサリ画像用のはずなので、ARGB32で読んでるはず
+            var resized = new Texture2D(width, height, TextureFormat.ARGB32, false);
+            Graphics.ConvertTexture(source, resized);
+            source.Resize(width, height);
+            source.Apply();
+            Graphics.ConvertTexture(resized, source);
+            Object.Destroy(resized);
+        }
+
+        public static void GetSizeLimitedTexture(Texture2D source, Texture2D dest, int maxSize)
+        {
+            dest.Resize(source.width, source.height);
+            dest.Apply();
+            Graphics.ConvertTexture(source, dest);
+            Object.Destroy(source);
+            GetSizeLimitedTexture(dest, maxSize);
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/TextureSizeUtil.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/TextureSizeUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9aaf9f058652de45bc484e259685215
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WPF/VMagicMirrorConfig/Model/Entity/AccessorySetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/AccessorySetting.cs
@@ -11,6 +11,15 @@
         World = 6,
     }
 
+    public enum AccessoryImageResolutionLimit : int
+    {
+        None = 0,
+        Max1024 = 1,
+        Max512 = 2,
+        Max256 = 3,
+        Max128 = 4,
+    }
+
     public class AccessorySetting : SettingEntityBase
     {
         /// <summary>
@@ -30,7 +39,7 @@
         public AccessoryItemSetting[] Items { get; set; } = new AccessoryItemSetting[0];
     }
 
-    //TODO: 配列でデータ保持したい + シリアライズの瞬間だけjsonにしたい
+    //配列でデータ保持したい + シリアライズの瞬間だけjsonにしたい
     public class AccessoryItemSetting
     {
         public const char FolderIdSuffixChar = '>';
@@ -58,5 +67,7 @@
 
         // NOTE: 連番画像でのみ意味がある。Unity側は5 ~ 30の値の範囲が飛んでくることを期待している
         public int FramePerSecond { get; set; } = 15;
+
+        public AccessoryImageResolutionLimit ResolutionLimit { get; set; } = AccessoryImageResolutionLimit.None;
     }
 }

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/AccessorySettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/AccessorySettingModel.cs
@@ -103,6 +103,7 @@ namespace Baku.VMagicMirrorConfig
                 item.Rotation = Vector3.Zero();
                 item.Scale = Vector3.One();
                 item.Name = Path.GetFileNameWithoutExtension(item.FileId);
+                item.ResolutionLimit = AccessoryImageResolutionLimit.None;
                 ItemUpdated?.Invoke(item);
             }
             SerializedSetting = JsonConvert.SerializeObject(Items);
@@ -157,6 +158,7 @@ namespace Baku.VMagicMirrorConfig
             target.Position = item.Position;
             target.Rotation = item.Rotation;
             target.Scale = item.Scale;
+            target.ResolutionLimit = item.ResolutionLimit;
             ItemUpdated?.Invoke(target);
         }
 

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -151,6 +151,8 @@ Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Accessory_Item_Rotation">Rotation</sys:String>
     <sys:String x:Key="Accessory_Item_Scale">Scale</sys:String>
     <sys:String x:Key="Accessory_Item_Fps">FPS (for numbered png)</sys:String>
+    <sys:String x:Key="Accessory_Item_MaxTextureSize">Image max size</sys:String>
+    <sys:String x:Key="Accessory_Item_MaxTextureSize_Unlimited">Unlimited</sys:String>
 
     <!-- Settings General -->
     <sys:String x:Key="Setting_Color_Expander_Header">Edit Color (Click to Expand)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -151,7 +151,8 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Accessory_Item_Rotation">Rotation</sys:String>
     <sys:String x:Key="Accessory_Item_Scale">Scale</sys:String>
     <sys:String x:Key="Accessory_Item_Fps">FPS (連番画像のみ)</sys:String>
-
+    <sys:String x:Key="Accessory_Item_MaxTextureSize">画像のサイズ上限</sys:String>
+    <sys:String x:Key="Accessory_Item_MaxTextureSize_Unlimited">上限なし</sys:String>
     
     <!-- Settings General -->
     <sys:String x:Key="Setting_Color_Expander_Header">色を編集 (クリックで展開)</sys:String>

--- a/WPF/VMagicMirrorConfig/View/AccessoryParts/AccessoryPartItemView.xaml
+++ b/WPF/VMagicMirrorConfig/View/AccessoryParts/AccessoryPartItemView.xaml
@@ -6,14 +6,16 @@
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:view="clr-namespace:Baku.VMagicMirrorConfig.View"
+             xmlns:vmm="clr-namespace:Baku.VMagicMirrorConfig"
              xmlns:vm="clr-namespace:Baku.VMagicMirrorConfig.ViewModel"
              xmlns:ma="http://metro.mahapps.com/winfx/xaml/controls"
              mc:Ignorable="d" 
              d:DataContext="{d:DesignInstance vm:AccessoryItemViewModel}"
-             d:DesignHeight="270" d:DesignWidth="400">
+             d:DesignHeight="370" d:DesignWidth="400">
     <UserControl.Resources>
         <view:FileIdIndicationConverter x:Key="FileIdIndicationConverter"/>
         <view:BooleanReverseToVisibilityConverter x:Key="BooleanReverseToVisibilityConverter"/>
+        <view:AccessoryResolutionLimitToTextConverter x:Key="AccessoryResolutionLimitToTextConverter"/>
     </UserControl.Resources>
     <StackPanel>
 
@@ -97,6 +99,7 @@
                     <ColumnDefinition />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
@@ -249,6 +252,29 @@
                          Text="{Binding Value, ElementName=sliderItemFps}"
                          Visibility="{Binding CanEditFramePerSecond, Converter={StaticResource BooleanToVisibilityConverter}}"
                          />
+
+                <TextBlock Grid.Row="8" Grid.Column="0"
+                        Margin="0,0,20,0"
+                        HorizontalAlignment="Left"
+                        Text="{DynamicResource Accessory_Item_MaxTextureSize}" 
+                        Visibility="{Binding CanEditFramePerSecond, Converter={StaticResource BooleanToVisibilityConverter}}"
+                        />
+
+                <ComboBox Grid.Row="8" Grid.Column="2" Grid.ColumnSpan="2"
+                          Style="{StaticResource MahApps.Styles.ComboBox}"
+                          VerticalAlignment="Top"
+                          Height="25"
+                          Margin="0,2"
+                          Padding="0"
+                          SelectedItem="{Binding ResolutionLimit}"
+                          ItemsSource="{x:Static vm:AccessoryItemViewModel.AvailableResolutionLimits}"
+                          >
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate DataType="{x:Type vmm:AccessoryImageResolutionLimit}"> 
+                            <TextBlock Text="{Binding Path=., Converter={StaticResource AccessoryResolutionLimitToTextConverter}}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
             </Grid>
         </StackPanel>
 

--- a/WPF/VMagicMirrorConfig/View/Code/Converter/AccessoryResolutionLimitToTextConverter.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/Converter/AccessoryResolutionLimitToTextConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Baku.VMagicMirrorConfig.View
+{
+    public class AccessoryResolutionLimitToTextConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not AccessoryImageResolutionLimit limit)
+            {
+                return Binding.DoNothing;
+            }
+
+            return limit switch
+            {
+                AccessoryImageResolutionLimit.None => LocalizedString.GetString("Accessory_Item_MaxTextureSize_Unlimited"),
+                AccessoryImageResolutionLimit.Max1024 => "1024px",
+                AccessoryImageResolutionLimit.Max512 => "512px",
+                AccessoryImageResolutionLimit.Max256 => "256px",
+                AccessoryImageResolutionLimit.Max128 => "128px",
+                _ => "(unknown)",
+            };
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/AccessorySettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/AccessorySettingViewModel.cs
@@ -83,12 +83,18 @@ namespace Baku.VMagicMirrorConfig.ViewModel
     public class AccessoryItemViewModel : ViewModelBase
     {
         public static string[] AvailableAttachTargets { get; }
+
+        public static AccessoryImageResolutionLimit[] AvailableResolutionLimits { get; }
+
         static AccessoryItemViewModel()
         {
             //NOTE: 多言語化したいかどうか微妙なライン…ぶっちゃけ多言語化したくない…
             AvailableAttachTargets = Enum.GetValues<AccessoryAttachTarget>()
                 .Select(e => e.ToString())
                 .ToArray();
+
+            //こっちはConverterで多言語化
+            AvailableResolutionLimits = Enum.GetValues<AccessoryImageResolutionLimit>();
         }
 
 
@@ -170,6 +176,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 UpdateItemFromUi();
             });
 
+            _resolutionLimit = _item.ResolutionLimit;
+
             UpdateShowInvalidBillboardWarning();
         }
 
@@ -207,6 +215,25 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         public RProperty<bool> ShowInvalidBillboardWarning { get; } = new RProperty<bool>(false);
 
+
+        private AccessoryImageResolutionLimit _resolutionLimit = AccessoryImageResolutionLimit.None;
+        public AccessoryImageResolutionLimit ResolutionLimit
+        {
+            get => _resolutionLimit;
+            set
+            {
+                if (_resolutionLimit == value)
+                {
+                    return;
+                }
+
+                _resolutionLimit = value;
+                RaisePropertyChanged();
+                _item.ResolutionLimit = value;
+                UpdateItemFromUi();
+            }
+        }
+
         private void UpdateShowInvalidBillboardWarning()
         {
             ShowInvalidBillboardWarning.Value =
@@ -239,6 +266,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             RotZ.Value = _item.Rotation.Z;
             Scale.Value = _item.Scale.X;
             FramePerSecond.Value = _item.FramePerSecond;
+            ResolutionLimit = _item.ResolutionLimit;
 
             _isUpdatingByReceivedData = false;
         }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix
- [x] Improve existing feature

## What the PR does

fixed #847 

4つの対策を行っています。

- アクセサリについて、1回も表示しないものはファイルロードしないようにした
- 連番pngについて、完全に透明な画像は実質的に無視する
- 連番pngについて、完全に同じ画像が複数あったら冗長な画像データは破棄して使い回す
- 画像/連番pngアクセサリについて、解像度上限を設定できるオプションを追加した。値は以下の通りで、既定値は無制限
    - 無制限 / 1024px / 512px / 256px / 128px

逆に、この施策で特にやっていない対策としては以下が挙げられます。

- 一度表示してから非表示にしたアクセサリのデータ破棄
- 連番pngの高度な圧縮

## How to confirm

- [x] glbアクセサリの基本的な表示に支障がない
- [x] ファイルの再読み込みを行わずにアクセサリのファイルを削除し、その状態でアクセサリの表示を試みても破綻しない(単にアクセサリが表示されないだけで済む)
- [x] 画像アクセサリで解像度上限が適用されるのが確認できている 
- [x] 連番画像アクセサリで解像度上限が適用されるのが確認できている 

## Note

Please write something to be noted, if exists.

* *e.g. the point to be reviewed carefully, risk of the PR, etc.*

