### PR TITLE
Add missing commit about #870

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
@@ -146,7 +146,7 @@ namespace Baku.VMagicMirror
 
         //NOTE: nullを戻す事があるのはby-design
         public Texture2D FirstValidTexture 
-            => _textures.FirstOrDefault(t => t.Type != TextureTypes.Empty).Texture;
+            => _textures.FirstOrDefault(t => t.Type != TextureTypes.Empty)?.Texture;
 
         public Renderer Renderer { get; set; }
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

タイトル通りで、動作確認した #870 のコミットのうちNullReferenceException対策のコミットが漏れてたのを修正しています。

## How to confirm

#870 の下記で確認済み。とくに、連番画像アクセサリでのみ頻繁にNullReferenceExceptionが出続けるようになっていたのが本PRのcommitで修正されます。

- ファイルの再読み込みを行わずにアクセサリのファイルを削除し、その状態でアクセサリの表示を試みても破綻しない(単にアクセサリが表示されないだけで済む)

