### PR TITLE
まばたきによって連番画像アクセサリを表示できる

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -38,7 +38,7 @@ namespace Baku.VMagicMirror
         private bool _firstEnabledCalled;
         public Action<AccessoryItem> FirstEnabled;
         
-        private CancellationTokenSource _blinkCts;
+        private readonly CancellationTokenSource _blinkCts = new CancellationTokenSource();
 
         private bool _visibleByWordToMotion;
         public bool VisibleByWordToMotion
@@ -162,7 +162,7 @@ namespace Baku.VMagicMirror
         public void RunBlinkTrigger()
         {
             if (_file == null || _animator == null || ItemLayout == null ||
-                !ItemLayout.UseAsBlinkEffect || 
+                !ItemLayout.UseAsBlinkEffect ||
                 VisibleByBlinkTrigger
                 )
             {
@@ -181,9 +181,6 @@ namespace Baku.VMagicMirror
             _fileActions.ClampEndUntilHidden();
             VisibleByBlinkTrigger = true;
             
-            _blinkCts?.Cancel();
-            _blinkCts?.Dispose();
-            _blinkCts = new CancellationTokenSource();
             TurnOffBlinkTriggerBasedAccessory(duration, _blinkCts.Token).Forget();
         }
 
@@ -227,8 +224,8 @@ namespace Baku.VMagicMirror
 
         private void OnDestroy()
         {
-            _blinkCts?.Cancel();
-            _blinkCts?.Dispose();
+            _blinkCts.Cancel();
+            _blinkCts.Dispose();
 
             if (transformControl != null)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -177,8 +177,7 @@ namespace Baku.VMagicMirror
             }
 
             _fileActions.ResetTime();
-            //NOTE: Clampを指定することで、アクセサリを非表示にするのが1フレーム遅れたときに最初の画像が2回見えるのを防ぐため
-            _fileActions.ClampEndUntilHidden();
+            _fileActions.SetClampEndEnable(true);
             VisibleByBlinkTrigger = true;
             
             TurnOffBlinkTriggerBasedAccessory(duration, _blinkCts.Token).Forget();
@@ -188,6 +187,7 @@ namespace Baku.VMagicMirror
         {
             await UniTask.Delay(TimeSpan.FromSeconds(delay), cancellationToken: cancellationToken);
             VisibleByBlinkTrigger = false;
+            _fileActions?.SetClampEndEnable(false);
         }
 
         private void Start()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -162,7 +162,8 @@ namespace Baku.VMagicMirror
         public void RunBlinkTrigger()
         {
             if (_file == null || _animator == null || ItemLayout == null ||
-                !ItemLayout.UseAsBlinkEffect
+                !ItemLayout.UseAsBlinkEffect || 
+                VisibleByBlinkTrigger
                 )
             {
                 return;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -37,7 +37,8 @@ namespace Baku.VMagicMirror
             IMessageSender sender, 
             ExternalTrackerDataSource externalTrackerDataSource,
             DeviceTransformController deviceTransformController,
-            WordToMotionAccessoryRequest accessoryRequest
+            WordToMotionAccessoryRequest accessoryRequest,
+            BlinkTriggerDetector blinkTriggerDetector
             )
         {
             _cam = cam;
@@ -92,6 +93,10 @@ namespace Baku.VMagicMirror
             accessoryRequest.AccessoryRequest
                 .Subscribe(UpdateWordToMotionStatus)
                 .AddTo(this);
+
+            blinkTriggerDetector.BlinkDetected
+                .Subscribe(_ => FireBlinkTrigger())
+                .AddTo(this);
         }
 
         private void UpdateFaceSwitchStatus(string fileId)
@@ -108,6 +113,14 @@ namespace Baku.VMagicMirror
             foreach (var item in _items)
             {
                 item.VisibleByWordToMotion = item.FileId == fileId;
+            }
+        }
+
+        private void FireBlinkTrigger()
+        {
+            foreach (var item in _items)
+            {
+                item.RunBlinkTrigger();
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryLayout.cs
@@ -56,6 +56,13 @@ namespace Baku.VMagicMirror
         public int FramePerSecond;
         //画像または連番画像でのみ意味のある値 (※glTFのテクスチャに適用する手もあるが、面倒なので一旦パス)
         public AccessoryImageResolutionLimit ResolutionLimit;
+        //連番画像でのみ意味があるものとして扱う
+        public bool UseAsBlinkEffect;
+
+        public bool CheckIsBlinkEffect()
+        {
+            return UseAsBlinkEffect && FileId.EndsWith(AccessoryFile.FolderIdSuffix);
+        }
 
         public int GetResolutionLimitSize() => ResolutionLimit switch
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
@@ -207,9 +207,9 @@ namespace Baku.VMagicMirror
             SetCurrentTextureToRenderer();
         }
 
-        public void ClampEndUntilHidden()
+        public void SetClampEndEnable(bool clamp)
         {
-            _clampEnd = true;
+            _clampEnd = clamp;
         }
 
         public bool TryGetDuration(out float duration)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AnimatableImage.cs
@@ -220,7 +220,7 @@ namespace Baku.VMagicMirror
                 return false;
             }
 
-            duration = FramePerSecond * _textures.Length;
+            duration = _timePerFrame * _textures.Length;
             return true;
         }
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
@@ -7,6 +7,12 @@ namespace Baku.VMagicMirror
         void UpdateLayout(AccessoryItemLayout layout);
         //NOTE: isVisibleが切り替わってなくても呼ばれる事がある(現行実装では冗長に呼び出しても基本無害なので…)
         void OnVisibilityChanged(bool isVisible);
+
+        //NOTE: 連番画像にしか意味がない
+        //TODO: やっつけ感があるので何か直してほしい
+        bool TryGetDuration(out float duration);
+        void ResetTime();
+        void ClampEndUntilHidden();
     }
 
     public abstract class AccessoryFileActionsBase : IAccessoryFileActions
@@ -15,6 +21,13 @@ namespace Baku.VMagicMirror
         public virtual void Update(float deltaTime) { }
         public virtual void UpdateLayout(AccessoryItemLayout layout) { }
         public virtual void OnVisibilityChanged(bool isVisible) { }
+        public virtual bool TryGetDuration(out float duration)
+        {
+            duration = 0f;
+            return false;
+        }
+        public virtual void ResetTime() { }
+        public virtual void ClampEndUntilHidden() { }
     }
 
     /// <summary>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/IAccessoryFileActions.cs
@@ -12,7 +12,7 @@ namespace Baku.VMagicMirror
         //TODO: やっつけ感があるので何か直してほしい
         bool TryGetDuration(out float duration);
         void ResetTime();
-        void ClampEndUntilHidden();
+        void SetClampEndEnable(bool clamp);
     }
 
     public abstract class AccessoryFileActionsBase : IAccessoryFileActions
@@ -27,7 +27,7 @@ namespace Baku.VMagicMirror
             return false;
         }
         public virtual void ResetTime() { }
-        public virtual void ClampEndUntilHidden() { }
+        public virtual void SetClampEndEnable(bool clamp) { }
     }
 
     /// <summary>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
@@ -67,6 +67,7 @@ namespace Baku.VMagicMirror.ExternalTracker
                 command =>
                 {
                     IsActive = command.ToBoolean();
+                    _faceControlConfig.UsePerfectSync = IsActive;
                     //パーフェクトシンク中はまばたき目下げを切る: 切らないと動きすぎになる為
                     _faceControlConfig.ShouldStopEyeDownOnBlink = IsActive;
                 });

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
@@ -1,6 +1,5 @@
 ﻿using Baku.VMagicMirror.ExternalTracker;
 using UnityEngine;
-using UniVRM10;
 using Zenject;
 
 namespace Baku.VMagicMirror

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlinkTriggerDetector.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlinkTriggerDetector.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using UniRx;
+using UnityEngine;
+using UniVRM10;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// モードによらず(自動まばたき / iFacialMocap + パーフェクトシンクon/off)、まばたきの終了を検出するやつ
+    /// </summary>
+    public class BlinkTriggerDetector : IInitializable, ITickable
+    {
+        private const float OpenToCloseValue = 0.8f;
+        private const float CloseToOpenValue = 0.6f;
+
+        //閉じた後でゆっくり開くのはまばたきではない、とする。(これを通すのもアリだけどね)
+        private const float BlinkCountLimit = 0.5f;
+        
+        private readonly FaceControlConfiguration _config;
+        private readonly ExpressionAccumulator _accumulator;
+
+        private static readonly ExpressionKey BlinkLeft = ExpressionKey.BlinkLeft;
+        private static readonly ExpressionKey BlinkRight = ExpressionKey.BlinkRight;
+        private static readonly ExpressionKey PerfectSyncBlinkLeft = ExpressionKey.CreateCustom("EyeBlinkLeft");
+        private static readonly ExpressionKey PerfectSyncBlinkRight = ExpressionKey.CreateCustom("EyeBlinkRight");
+
+        //目が閉じてるかどうか。チャタリング防止のため、閾値だけではなくフラグも必要になっている
+        private bool _isEyesClosed;
+        private float _eyeCloseCount;
+
+        private Subject<Unit> _blinkDetected = new Subject<Unit>();
+        public IObservable<Unit> BlinkDetected => _blinkDetected;
+
+        public BlinkTriggerDetector(FaceControlConfiguration config, ExpressionAccumulator accumulator)
+        {
+            _config = config;
+            _accumulator = accumulator;
+        }
+        
+        //NOTE: めんどくさいのでつけっぱなしでいい
+        void IInitializable.Initialize()
+        {
+            _accumulator.PreApply += OnPreApplyBlendShape;
+        }
+
+        void ITickable.Tick()
+        {
+            if (_isEyesClosed)
+            {
+                _eyeCloseCount += Time.deltaTime;
+            }
+        }
+
+        private void OnPreApplyBlendShape(IReadOnlyDictionary<ExpressionKey, float> values)
+        {
+            var left = 0f;
+            var right = 0f;
+            if (_config.PerfectSyncActive)
+            {
+                left = _accumulator.GetValue(PerfectSyncBlinkLeft);
+                right = _accumulator.GetValue(PerfectSyncBlinkRight);
+            }
+            else
+            {
+                left = _accumulator.GetValue(BlinkLeft);
+                right = _accumulator.GetValue(BlinkRight);
+            }
+
+            if (!_isEyesClosed)
+            {
+                if (left > OpenToCloseValue && right > OpenToCloseValue)
+                {
+                    _isEyesClosed = true;
+                    _eyeCloseCount = 0f;
+                }
+            }
+            else
+            {
+                if (left < CloseToOpenValue && right < CloseToOpenValue)
+                {
+                    _isEyesClosed = false;
+                    if (_eyeCloseCount < BlinkCountLimit)
+                    {
+                        _blinkDetected.OnNext(Unit.Default);
+                    }
+                }
+            }
+            
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlinkTriggerDetector.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlinkTriggerDetector.cs
@@ -15,7 +15,7 @@ namespace Baku.VMagicMirror
         private const float OpenToCloseValue = 0.8f;
         private const float CloseToOpenValue = 0.6f;
         //まばたき直後、この秒数以内に目を閉じたら検出しなかった扱いに倒す
-        private const float BlinkReserveDuration = 0.3f;
+        private const float BlinkReserveDuration = 0.2f;
 
         //閉じた後でゆっくり開くのはまばたきではない、とする。(これを通すのもアリだけどね)
         private const float BlinkCountLimit = 0.5f;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlinkTriggerDetector.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlinkTriggerDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 675171ab6e31c9849a476b59e06c5e61
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/ExpressionAccumulator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/ExpressionAccumulator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UniVRM10;
 using Zenject;
@@ -16,6 +17,8 @@ namespace Baku.VMagicMirror
 
         private bool _hasModel;
         private Vrm10RuntimeExpression _expression;
+        
+        public event Action<IReadOnlyDictionary<ExpressionKey, float>> PreApply; 
 
         public ExpressionAccumulator(IVRMLoadable vrmLoadable)
         {
@@ -54,7 +57,11 @@ namespace Baku.VMagicMirror
             }
         }
 
-        public void Apply() => _expression?.SetWeights(_values);
+        public void Apply()
+        {
+            PreApply?.Invoke(_values);
+            _expression?.SetWeights(_values);
+        }
 
         public void ResetValues()
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceControlConfiguration.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceControlConfiguration.cs
@@ -17,6 +17,14 @@ namespace Baku.VMagicMirror
         /// </remarks>
         public FaceControlModes ControlMode { get; set; } = FaceControlModes.WebCam;
         
+        /// <summary>
+        /// パーフェクトシンクのon/offを取得、設定します。
+        /// このフラグがtrueであり、かつ<see cref="ControlMode"/>がExternalTrackerの場合はパーフェクトシンクがオンです。
+        /// </summary>
+        public bool UsePerfectSync { get; set; }
+
+        public bool PerfectSyncActive => ControlMode == FaceControlModes.ExternalTracker && UsePerfectSync;
+        
         #endregion
         
         #region 内部的に特定クラスがsetterを呼ぶ値で、読み取り側は直接使わないでOK

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/FaceControlInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/FaceControlInstaller.cs
@@ -23,6 +23,7 @@ namespace Baku.VMagicMirror.Installer
             container.BindInterfacesAndSelfTo<ExpressionAccumulator>().AsSingle();
             container.Bind<EyeLookAt>().AsSingle();
             container.BindInterfacesTo<EyeLookAtUpdater>().AsSingle();
+            container.BindInterfacesAndSelfTo<BlinkTriggerDetector>().AsSingle();
 
             //ブレンドシェイプの内訳の確認処理で、意味のある処理ではないけど一応つねに入れておく
             container.Bind<BlendShapeExclusivenessChecker>().AsSingle();

--- a/WPF/VMagicMirrorConfig/Model/Entity/AccessorySetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/AccessorySetting.cs
@@ -69,5 +69,9 @@
         public int FramePerSecond { get; set; } = 15;
 
         public AccessoryImageResolutionLimit ResolutionLimit { get; set; } = AccessoryImageResolutionLimit.None;
+
+        //連番画像アクセサリーでこの値がtrueになっていると、まばたきの直後に1サイクルぶん連番画像が再生される
+        public bool UseAsBlinkEffect { get; set; }
+
     }
 }

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/AccessorySettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/AccessorySettingModel.cs
@@ -104,6 +104,7 @@ namespace Baku.VMagicMirrorConfig
                 item.Scale = Vector3.One();
                 item.Name = Path.GetFileNameWithoutExtension(item.FileId);
                 item.ResolutionLimit = AccessoryImageResolutionLimit.None;
+                item.UseAsBlinkEffect = false;
                 ItemUpdated?.Invoke(item);
             }
             SerializedSetting = JsonConvert.SerializeObject(Items);

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -145,6 +145,7 @@ png image and 3D model by glb or gltf is available.</sys:String>
     <sys:String x:Key="Accessory_Item_DisplayName">Display Name</sys:String>
     <sys:String x:Key="Accessory_Item_AttachTarget">Attach to</sys:String>
     <sys:String x:Key="Accessory_Item_BillboardMode">2D Foreground Mode (image file only)</sys:String>
+    <sys:String x:Key="Accessory_Item_UseAsBlinkEffect">Use as Blink Effect (for numbered png)</sys:String>    
     <sys:String x:Key="Accessory_Item_BillboardMode_Warning" xml:space="preserve">*World attached Foreground 2D accessory is invalid.
 Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Accessory_Item_Position">Position</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -145,6 +145,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Accessory_Item_DisplayName">表示名</sys:String>
     <sys:String x:Key="Accessory_Item_AttachTarget">配置先</sys:String>
     <sys:String x:Key="Accessory_Item_BillboardMode">2Dのまま最前面に表示 (画像のみ)</sys:String>
+    <sys:String x:Key="Accessory_Item_UseAsBlinkEffect">まばたき時エフェクトに使用 (連番画像のみ)</sys:String>
     <sys:String x:Key="Accessory_Item_BillboardMode_Warning" xml:space="preserve">※World + 最前面表示の組み合わせは無効です。
 最前面表示をオフにするか、World以外にアクセサリを配置して下さい。</sys:String>
     <sys:String x:Key="Accessory_Item_Position">Position</sys:String>

--- a/WPF/VMagicMirrorConfig/View/AccessoryParts/AccessoryPartItemView.xaml
+++ b/WPF/VMagicMirrorConfig/View/AccessoryParts/AccessoryPartItemView.xaml
@@ -108,6 +108,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
@@ -275,6 +276,16 @@
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
+
+                <CheckBox Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="6"
+                          HorizontalAlignment="Left"
+                          VerticalContentAlignment="Center"
+                          Margin="5,0"
+                          Visibility="{Binding UseAsBlinkEffectSupported, Converter={StaticResource BooleanToVisibilityConverter}}"
+                          Content="{DynamicResource Accessory_Item_UseAsBlinkEffect}"
+                          IsChecked="{Binding UseAsBlinkEffect.Value}"
+                          />
+
             </Grid>
         </StackPanel>
 

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/AccessoryPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/AccessoryPanel.xaml
@@ -89,9 +89,6 @@
                                   Content="{DynamicResource Layout_DeviceFreeLayout}"
                                   IsChecked="{Binding EnableDeviceFreeLayout.Value}"
                                   />
-
-
-
                     </Grid>
 
                     <Border Margin="5"

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/AccessorySettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/AccessorySettingViewModel.cs
@@ -176,6 +176,15 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 UpdateItemFromUi();
             });
 
+            UseAsBlinkEffect = new RProperty<bool>(_item.UseAsBlinkEffect, v =>
+            {
+                _item.UseAsBlinkEffect = v;
+                UpdateItemFromUi();
+            });
+
+            //連番画像以外ではまばたき連動できない。この制限は緩和する可能性もあるが、一旦コレで。
+            UseAsBlinkEffectSupported = _item.FileId.EndsWith(AccessoryItemSetting.FolderIdSuffixChar);
+
             _resolutionLimit = _item.ResolutionLimit;
 
             UpdateShowInvalidBillboardWarning();
@@ -234,6 +243,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             }
         }
 
+        public bool UseAsBlinkEffectSupported { get; }
+        public RProperty<bool> UseAsBlinkEffect { get; }
+
         private void UpdateShowInvalidBillboardWarning()
         {
             ShowInvalidBillboardWarning.Value =
@@ -267,6 +279,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             Scale.Value = _item.Scale.X;
             FramePerSecond.Value = _item.FramePerSecond;
             ResolutionLimit = _item.ResolutionLimit;
+            UseAsBlinkEffect.Value = _item.UseAsBlinkEffect;
 
             _isUpdatingByReceivedData = false;
         }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature

## What the PR does

#832

- 位置づけとしてはexperimental
- アクセサリーの個別オプションに入れた + 連番画像にしか対応してないのは一時的なつもり
    - 画像を勝手に動かすとか、ビルトインパーティクルとか、他にもやりようがある
    - 特にビルトインパーティクル扱いする場合は、アクセサリーの個別アイテムの下位概念ではないということにしたい…

## How to confirm

- [x] 以下3ケースで瞬き後に連番画像アクセサリー(以下、acc)が1周ぶん動く
    - iFacialMocap連携なし
    - iFacialMocap連携あり、パーフェクトシンクなり
    - iFacialMocap連携あり、パーフェクトシンクあり
- [x] まばたき用エフェクトに指定していないaccが従来どおり動く
- [x] 特にiFacialMocap連携しているとき、ゆっくりまばたきするとaccが動かない
- [x] 特にiFacialMocap連携していないとき、連続で2回まばたきする場合には2回目の直後でのみaccが動く
- [x] accの再生時間が長い場合、その再生中に再度まばたきしても何も起きず、再生中のaccが引き続き再生される
- [x] WtMなどで表情が上書きされた状態の場合、まばたきしてもaccは再生されない
- [x] 片目閉じではaccは再生されない

## Note

