### PR TITLE
Support to load VRM1.0 without thumbnail

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMPreviewPresenter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMPreviewPresenter.cs
@@ -57,6 +57,13 @@ namespace Baku.VMagicMirror
             if (_copiedThumbnail != null)
             {
                 Object.Destroy(_copiedThumbnail);
+                _copiedThumbnail = null;
+            }
+
+            //元画像が無いのでコピーも無しのままでよい
+            if (thumbnail == null)
+            {
+                return;
             }
 
             _copiedThumbnail = new Texture2D(thumbnail.width, thumbnail.height, thumbnail.format, false);


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #878 

v3.0.0の動作確認時、手元で使っていたVRM 1.0がサムネイルのあるものだけだったのが原因でした。

## How to confirm

- [x] issueに記載されたVRMCレポジトリのVRM(サムネイル無)がロードできること
- [x] VRoidベースのVRM1.0(サムネイル有)がロードできること
- [x] サムネイル有→無の順にモデルをロードしようとしたとき、最初に読み込んだサムネイルが残ってしまわないこと

