### PR TITLE
glbのアニメーションが再生されない場合があるのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFile.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFile.cs
@@ -185,7 +185,6 @@ namespace Baku.VMagicMirror
                 }
                 else if (files.Length > 0 && files.All(f => Path.GetExtension(f) == ".png"))
                 {
-                    var binaries = files.OrderBy(f => f).Select(File.ReadAllBytes).ToArray();
                     result.Add(new AccessoryFile(AccessoryType.NumberedPng, childDir, childDir));
                 }
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
@@ -86,6 +86,10 @@ namespace Baku.VMagicMirror
                 renderer.shadowCastingMode = ShadowCastingMode.Off;
                 renderer.receiveShadows = false;
             }
+            
+            //NOTE: オフ→オンしないとAnimationが正しく動かないので、わざと一回切る
+            instance.Root.SetActive(false);
+            instance.Root.SetActive(true);
             return new AccessoryFileContext<GameObject>(instance.Root, new GlbFileAccessoryActions(context, instance));
         }
     }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #880 

- 真因: v3.0.1にて、「glbは最初に表示したくなった時点でロードし、直ちにactiveな状態で使う」とした事で、アニメーションが再生されなくなった
- v3.0.1での回避方法: 該当アクセサリーをオフ→オンにすると、2回目の表示からはアニメーションが動く
- このPRでの対策: ロードしたオブジェクトを一旦無効にして直ちに有効化すると動く

## How to confirm

ユーザー報告のあったglb(アニメーション定義済)を用いたとき、

- [x] 起動前の時点で非表示扱いになっているglbを表示するとアニメーションが再生されること。また、それをオフ→オンしてもやはりアニメーションが再生されること。
- [x] あらかじめ表示する扱いにしたglbアクセサリーについて、VMMの起動後の表示とともにアニメーションが再生されること
- [x] そのglbをコピーして「再読み込み」したとき、再読み込みで追加で認識されたアクセサリーのアニメーションも再生されること

