### PR TITLE
Feature/rest position control

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/IK Targets.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/IK Targets.prefab
@@ -76,7 +76,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   global: 0
-  useDistance: 0
+  useDistance: 1
   distance: 12
   xyPlaneMode: 0
   gizmoRenderer: {fileID: 0}
@@ -170,7 +170,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   global: 0
-  useDistance: 0
+  useDistance: 1
   distance: 12
   xyPlaneMode: 0
   gizmoRenderer: {fileID: 0}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/IK Targets.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/IK Targets.prefab
@@ -1,5 +1,99 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &37285441425996432
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3629974543253739537}
+  m_Layer: 0
+  m_Name: GizmoImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3629974543253739537
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 37285441425996432}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 303702880965066003}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1009745881067083495
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 303702880965066003}
+  - component: {fileID: 5879314087457661568}
+  - component: {fileID: 3998390410401398488}
+  m_Layer: 0
+  m_Name: LeftHandDownPoseTarget
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &303702880965066003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1009745881067083495}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.2, y: 1, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3629974543253739537}
+  m_Father: {fileID: 7220499517351026418}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5879314087457661568
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1009745881067083495}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  global: 0
+  useDistance: 0
+  distance: 12
+  xyPlaneMode: 0
+  gizmoRenderer: {fileID: 0}
+--- !u!114 &3998390410401398488
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1009745881067083495}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0832c12cef2adb47ad80a88214a0538, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handImageGizmo: {fileID: 37285441425996432}
+  transformControl: {fileID: 5879314087457661568}
 --- !u!1 &2026465566758330141
 GameObject:
   m_ObjectHideFlags: 0
@@ -30,6 +124,70 @@ Transform:
   m_Father: {fileID: 7220499517351026418}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6179000882620333244
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4519926354364588533}
+  - component: {fileID: 6424636812989539530}
+  - component: {fileID: 1771108102995737168}
+  m_Layer: 0
+  m_Name: RightHandDownPoseTarget
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4519926354364588533
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6179000882620333244}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.2, y: 1, z: 0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3736577104217786014}
+  m_Father: {fileID: 7220499517351026418}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6424636812989539530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6179000882620333244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  global: 0
+  useDistance: 0
+  distance: 12
+  xyPlaneMode: 0
+  gizmoRenderer: {fileID: 0}
+--- !u!114 &1771108102995737168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6179000882620333244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0832c12cef2adb47ad80a88214a0538, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handImageGizmo: {fileID: 8523932535829481958}
+  transformControl: {fileID: 6424636812989539530}
 --- !u!1 &6437777465248540157
 GameObject:
   m_ObjectHideFlags: 0
@@ -126,6 +284,8 @@ Transform:
   - {fileID: 7220499518504390859}
   - {fileID: 3611953369045485159}
   - {fileID: 857609006226922207}
+  - {fileID: 4519926354364588533}
+  - {fileID: 303702880965066003}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -148,6 +308,8 @@ MonoBehaviour:
   body: {fileID: 7220499516820559165}
   leftFoot: {fileID: 3611953369045485159}
   rightFoot: {fileID: 857609006226922207}
+  leftHandDown: {fileID: 3998390410401398488}
+  rightHandDown: {fileID: 1771108102995737168}
 --- !u!114 &6602645436930946104
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -280,4 +442,34 @@ Transform:
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8523932535829481958
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3736577104217786014}
+  m_Layer: 0
+  m_Name: GizmoImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &3736577104217786014
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8523932535829481958}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4519926354364588533}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/UI/TransformControlCanvasRoot.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/UI/TransformControlCanvasRoot.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 3949628796980592695}
   - component: {fileID: 63078896318268246}
   - component: {fileID: 4136669779275994853}
-  - component: {fileID: 5838226657027795473}
   m_Layer: 5
   m_Name: TransformControlCanvasRoot
   m_TagString: Untagged
@@ -68,15 +67,3 @@ MonoBehaviour:
   refMidiPosition: {x: 0, y: 0.92, z: 0.27}
   refMidiRotation: {x: 0, y: 0, z: 0}
   refMidiScale: {x: 0.35, y: 0.35, z: 0.35}
---- !u!114 &5838226657027795473
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3543419340843832733}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ce11c87738fe47419d2d3f83dddc0ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/CustomizableHandIkTarget.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/CustomizableHandIkTarget.cs
@@ -1,0 +1,15 @@
+using mattatz.TransformControl;
+using UnityEngine;
+
+namespace Baku.VMagicMirror.IK
+{
+    public class CustomizableHandIkTarget : MonoBehaviour
+    {
+        [SerializeField] private GameObject handImageGizmo;
+        [SerializeField] private TransformControl transformControl;
+
+        public void SetGizmoImageActiveness(bool active) => handImageGizmo.SetActive(active);
+        public TransformControl TransformControl => transformControl;
+        public Transform TargetTransform => transform;
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/CustomizableHandIkTarget.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/CustomizableHandIkTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0832c12cef2adb47ad80a88214a0538
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -170,7 +170,8 @@ namespace Baku.VMagicMirror
             ArcadeStickProvider arcadeStickProvider,
             PenTabletProvider penTabletProvider,
             HandTracker handTracker,
-            ColliderBasedAvatarParamLoader colliderBasedAvatarParamLoader
+            ColliderBasedAvatarParamLoader colliderBasedAvatarParamLoader,
+            HandDownIkCalculator handDownIkCalculator
             )
         {
             _reactionSources = new HandIkReactionSources(
@@ -206,7 +207,7 @@ namespace Baku.VMagicMirror
                 );
             Presentation = new PresentationHandIKGenerator(dependency, vrmLoadable, cam);
             _arcadeStickHand = new ArcadeStickHandIKGenerator(dependency, vrmLoadable, arcadeStickProvider);
-            _downHand = new AlwaysDownHandIkGenerator(dependency, vrmLoadable);
+            _downHand = new AlwaysDownHandIkGenerator(dependency, handDownIkCalculator);
             _penTablet = new PenTabletHandIKGenerator(dependency, vrmLoadable, penTabletProvider);
             ClapMotion = new ClapMotionHandIKGenerator(dependency, vrmLoadable, elbowMotionModifier, colliderBasedAvatarParamLoader);
             barracudaHand.SetupDependency(dependency);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -171,7 +171,7 @@ namespace Baku.VMagicMirror
             PenTabletProvider penTabletProvider,
             HandTracker handTracker,
             ColliderBasedAvatarParamLoader colliderBasedAvatarParamLoader,
-            HandDownIkCalculator handDownIkCalculator
+            SwitchableHandDownIkData switchableHandDownIk
             )
         {
             _reactionSources = new HandIkReactionSources(
@@ -207,7 +207,7 @@ namespace Baku.VMagicMirror
                 );
             Presentation = new PresentationHandIKGenerator(dependency, vrmLoadable, cam);
             _arcadeStickHand = new ArcadeStickHandIKGenerator(dependency, vrmLoadable, arcadeStickProvider);
-            _downHand = new AlwaysDownHandIkGenerator(dependency, handDownIkCalculator);
+            _downHand = new AlwaysDownHandIkGenerator(dependency, switchableHandDownIk);
             _penTablet = new PenTabletHandIKGenerator(dependency, vrmLoadable, penTabletProvider);
             ClapMotion = new ClapMotionHandIKGenerator(dependency, vrmLoadable, elbowMotionModifier, colliderBasedAvatarParamLoader);
             barracudaHand.SetupDependency(dependency);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Data;
 using UniRx;
 using UnityEngine;
 
@@ -17,7 +16,7 @@ namespace Baku.VMagicMirror.IK
         private const float ReferenceArmLength = 0.37f;
 
         // 腕のピンと張る度合いがこの値になるように手IKのy座標を調整する
-        private const float ArmRelaxFactor = 0.98f;
+        private const float ArmRelaxFactor = 0.99f;
 
         private readonly IKDataRecord _leftHand = new IKDataRecord();
         public IIKData LeftHand => _leftHand;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using UniRx;
 using UnityEngine;
 
@@ -8,92 +7,23 @@ namespace Baku.VMagicMirror.IK
     /// <summary>常に手を下げた姿勢になるような手IKの生成処理。</summary>
     public sealed class AlwaysDownHandIkGenerator : HandIkGeneratorBase
     {
-        // ハンドトラッキングがロスしたときにAポーズへ落とし込むときの、腕の下げ角度(手首の曲げもコレに準拠します
-        private const float APoseArmDownAngleDeg = 70f;
-        // Aポーズから少しだけ手首の位置を斜め前方上にズラすオフセット。肘をピンと伸ばすのを避けるために使う。身長に比例してスケールした値を用いる。
-        private readonly Vector3 APoseHandPosOffsetBase = new Vector3(0f, 0.01f, 0.03f);
-        // リファレンスモデル(Megumi Baxterさん)のUpperArmボーンからWristボーンまでの距離
-        private const float ReferenceArmLength = 0.37f;
-
-        // 腕のピンと張る度合いがこの値になるように手IKのy座標を調整する
-        private const float ArmRelaxFactor = 0.99f;
-
-        private readonly IKDataRecord _leftHand = new IKDataRecord();
-        public IIKData LeftHand => _leftHand;
-        private readonly IKDataRecord _rightHand = new IKDataRecord();
-        public IIKData RightHand => _rightHand;
-
-        private bool _hasModel = false;
-
-        private Transform _hips;
-        private Transform _leftUpperArm;
-        private Transform _rightUpperArm;
-
-        private float _rightArmLength = 0.4f;
-        private float _leftArmLength = 0.4f;
-        private Vector3 _rightPosHipsOffset;
-        private Vector3 _leftPosHipsOffset;
-        private readonly Quaternion RightRot = Quaternion.Euler(0, 0, -APoseArmDownAngleDeg);
-        private readonly Quaternion LeftRot = Quaternion.Euler(0, 0, APoseArmDownAngleDeg);
+        private readonly HandDownIkCalculator _handDownIkCalculator;
+        public IIKData LeftHand => _handDownIkCalculator.LeftHand;
+        public IIKData RightHand => _handDownIkCalculator.RightHand;
 
         private readonly AlwaysHandDownState _leftHandState;
-        private readonly AlwaysHandDownState _rightHandState;
         public override IHandIkState LeftHandState => _leftHandState;
+
+        private readonly AlwaysHandDownState _rightHandState;
         public override IHandIkState RightHandState => _rightHandState; 
         
-        public AlwaysDownHandIkGenerator(HandIkGeneratorDependency dependency, IVRMLoadable vrmLoadable)
+        public AlwaysDownHandIkGenerator(
+            HandIkGeneratorDependency dependency, HandDownIkCalculator handDownIkCalculator)
             : base(dependency)
         {
-            _leftHand.Rotation = LeftRot;
-            _rightHand.Rotation = RightRot;
-
+            _handDownIkCalculator = handDownIkCalculator;
             _leftHandState = new AlwaysHandDownState(this, ReactedHand.Left);
             _rightHandState = new AlwaysHandDownState(this, ReactedHand.Right);
-
-            vrmLoadable.VrmLoaded += info =>
-            {
-                var animator = info.controlRig;
-
-                _hips = animator.GetBoneTransform(HumanBodyBones.Hips);
-                _rightUpperArm = animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
-                _leftUpperArm = animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-                
-                var rightUpperArmPos = _rightUpperArm.position;
-                var rightWristPos = animator.GetBoneTransform(HumanBodyBones.RightHand).position;
-                var leftUpperArmPos = _leftUpperArm.position;
-                var leftWristPos = animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
-                var hipsPos = _hips.position;
-                
-                _rightArmLength = Vector3.Distance(rightWristPos, rightUpperArmPos);
-                float rArmLengthFactor = Mathf.Clamp(_rightArmLength / ReferenceArmLength, 0.1f, 5f);
-                
-                _rightPosHipsOffset =
-                    rightUpperArmPos +
-                    Quaternion.AngleAxis(-APoseArmDownAngleDeg, Vector3.forward) * (rightWristPos - rightUpperArmPos) -
-                    hipsPos + 
-                    rArmLengthFactor * APoseHandPosOffsetBase;
-
-                _leftArmLength = Vector3.Distance(leftWristPos, leftUpperArmPos);
-                float lArmLengthFactor = Mathf.Clamp(_leftArmLength / ReferenceArmLength, 0.1f, 5f);
-                
-                _leftPosHipsOffset =
-                    leftUpperArmPos + 
-                    Quaternion.AngleAxis(APoseArmDownAngleDeg, Vector3.forward) * (leftWristPos - leftUpperArmPos) -
-                    hipsPos + 
-                    lArmLengthFactor * APoseHandPosOffsetBase;
-
-                _leftHand.Position = hipsPos + _leftPosHipsOffset;
-                _rightHand.Position = hipsPos + _rightPosHipsOffset;
-                _hasModel = true;
-            };
-            
-            vrmLoadable.VrmDisposing += () =>
-            {
-                _hasModel = false;
-                _hips = null;
-                _leftUpperArm = null;
-                _rightUpperArm = null;
-            };
 
             dependency.Config.IsAlwaysHandDown
                 .Subscribe(v =>
@@ -105,63 +35,16 @@ namespace Baku.VMagicMirror.IK
                     }
                 })
                 .AddTo(dependency.Component);
-
-            StartCoroutine(SetHandPositionsIfHasModel());
-        }
-
-        private IEnumerator SetHandPositionsIfHasModel()
-        {
-            var eof = new WaitForEndOfFrame();
-            while (true)
-            {
-                yield return eof;
-                if (!_hasModel)
-                {
-                    continue;
-                }
-
-                //やること: LateUpdateの時点で手の位置を合わせる。
-                //フレーム終わりじゃないと調整されたあとのボーン位置が拾えないので、このタイミングでわざわざやってます
-                
-                var hipsPos = _hips.position;
-
-                var leftUpperArmPos = _leftUpperArm.position;
-                var leftPos = hipsPos + _leftPosHipsOffset;
-
-                var leftTargetLength = _leftArmLength * ArmRelaxFactor;
-                //UpperArmとWristの距離が一定になるようY軸の調整をするとこういう式になる
-                leftPos.y = leftUpperArmPos.y - Mathf.Sqrt(
-                    leftTargetLength * leftTargetLength -
-                    (leftPos.x - leftUpperArmPos.x) * (leftPos.x - leftUpperArmPos.x) -
-                    (leftPos.z - leftUpperArmPos.z) * (leftPos.z - leftUpperArmPos.z)
-                );
-
-                var rightUpperArmPos = _rightUpperArm.position;
-                var rightPos = hipsPos + _rightPosHipsOffset;
-
-                var rightTargetLength = _rightArmLength * ArmRelaxFactor;
-                //UpperArmとWristの距離が一定になるようY軸の調整をするとこういう式になる
-                rightPos.y = rightUpperArmPos.y - Mathf.Sqrt(
-                    rightTargetLength * rightTargetLength -
-                    (rightPos.x - rightUpperArmPos.x) * (rightPos.x - rightUpperArmPos.x) -
-                    (rightPos.z - rightUpperArmPos.z) * (rightPos.z - rightUpperArmPos.z)
-                );
-
-                _leftHand.Position = leftPos;
-                _rightHand.Position = rightPos;
-            }
         }
 
         private class AlwaysHandDownState : IHandIkState
         {
             public AlwaysHandDownState(AlwaysDownHandIkGenerator parent, ReactedHand hand)
             {
-                _parent = parent;
                 Hand = hand;
-                _data = hand == ReactedHand.Right ? _parent._rightHand : _parent._leftHand;
+                _data = hand == ReactedHand.Right ? parent.RightHand : parent.LeftHand;
             }
 
-            private readonly AlwaysDownHandIkGenerator _parent;
             private readonly IIKData _data;
 
             public bool SkipEnterIkBlend => false;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/AlwaysDownHandIkGenerator.cs
@@ -7,9 +7,9 @@ namespace Baku.VMagicMirror.IK
     /// <summary>常に手を下げた姿勢になるような手IKの生成処理。</summary>
     public sealed class AlwaysDownHandIkGenerator : HandIkGeneratorBase
     {
-        private readonly HandDownIkCalculator _handDownIkCalculator;
-        public IIKData LeftHand => _handDownIkCalculator.LeftHand;
-        public IIKData RightHand => _handDownIkCalculator.RightHand;
+        private readonly SwitchableHandDownIkData _handDownIk;
+        public IIKData LeftHand => _handDownIk.LeftHand;
+        public IIKData RightHand => _handDownIk.RightHand;
 
         private readonly AlwaysHandDownState _leftHandState;
         public override IHandIkState LeftHandState => _leftHandState;
@@ -18,10 +18,10 @@ namespace Baku.VMagicMirror.IK
         public override IHandIkState RightHandState => _rightHandState; 
         
         public AlwaysDownHandIkGenerator(
-            HandIkGeneratorDependency dependency, HandDownIkCalculator handDownIkCalculator)
+            HandIkGeneratorDependency dependency, SwitchableHandDownIkData switchableHandDownIk)
             : base(dependency)
         {
-            _handDownIkCalculator = handDownIkCalculator;
+            _handDownIk = switchableHandDownIk;
             _leftHandState = new AlwaysHandDownState(this, ReactedHand.Left);
             _rightHandState = new AlwaysHandDownState(this, ReactedHand.Right);
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -150,6 +150,16 @@ namespace Baku.VMagicMirror
                 })
                 .AddTo(this);
 
+            // アプリ起動後で初めてこの機能を有効化した際に手が暴れないようにする
+            _enableCustomHandDownPose
+                .Subscribe(v =>
+                {
+                    if (v)
+                    {
+                        UpdateIk();
+                    }
+                });
+            
             //gizmoの操作が確定するとWPF側にも姿勢が送られる: ドラッグ操作の途中では内部的にのみ反映する
             _leftHandTarget.TransformControl.DragEnded += mode =>
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -197,8 +197,8 @@ namespace Baku.VMagicMirror
                 if (EnableCustomHandDownPose.Value)
                 {
                     var hipsPos = _hips.position;
-                    _leftUpperArmPosOffset = (hipsPos - _leftUpperArm.position) - _defaultHipsToLeftUpperArm;
-                    _rightUpperArmPosOffset = (hipsPos - _rightUpperArm.position) - _defaultHipsToRightUpperArm;
+                    _leftUpperArmPosOffset = (_leftUpperArm.position - hipsPos) - _defaultHipsToLeftUpperArm;
+                    _rightUpperArmPosOffset = (_rightUpperArm.position - hipsPos) - _defaultHipsToRightUpperArm;
                 }
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -1,0 +1,252 @@
+using System;
+using Baku.VMagicMirror.IK;
+using mattatz.TransformControl;
+using UniRx;
+using UnityEngine;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// 手をおろした状態の手の姿勢をカスタムできるようにするやつ
+    /// </summary>
+    public class CustomizedDownHandIk : MonoBehaviour
+    {
+        private CustomizableHandIkTarget leftHand;
+        private CustomizableHandIkTarget rightHand;
+        private HandDownIkCalculator _handDownIkCalculator;
+        private IMessageSender _sender;
+
+        private readonly ReactiveProperty<bool> _enableFreeLayoutMode = new ReactiveProperty<bool>(false);
+        private readonly ReactiveProperty<bool> _enableCustomHandDownPose = new ReactiveProperty<bool>(false);
+        public IReadOnlyReactiveProperty<bool> EnableCustomHandDownPose => _enableCustomHandDownPose;
+
+        private readonly ReactiveProperty<bool> _showGizmo = new ReactiveProperty<bool>(false);
+        private bool _hasModel;
+        private Transform _hips;
+
+        private readonly HandDownRestPose _currentPose = new HandDownRestPose();
+        private bool _leftControlIsActive;
+        private bool _rightControlIsActive;
+
+        [Inject]
+        public void Initialize(
+            IKTargetTransforms ikTargetTransforms, 
+            HandDownIkCalculator handDownIkCalculator,
+            IVRMLoadable vrmLoadable, 
+            IMessageReceiver receiver,
+            IMessageSender sender,
+            DeviceTransformController deviceTransformController
+            )
+        {
+            leftHand = ikTargetTransforms.LeftHandDown;
+            rightHand = ikTargetTransforms.RightHandDown;
+            _sender = sender;
+            _handDownIkCalculator = handDownIkCalculator;
+
+            receiver.AssignCommandHandler(
+                VmmCommands.EnableCustomHandDownPose,
+                command => _enableCustomHandDownPose.Value = command.ToBoolean()
+            );
+
+            receiver.AssignCommandHandler(
+                VmmCommands.EnableDeviceFreeLayout,
+                command => _enableFreeLayoutMode.Value = command.ToBoolean()
+            );
+
+            receiver.AssignCommandHandler(
+                VmmCommands.SetHandDownModeCustomPose,
+                command => ApplyHandDownPose(command.Content)
+            );
+
+            receiver.AssignCommandHandler(
+                VmmCommands.ResetCustomHandDownPose,
+                _ => ResetCustomHandDownPose()
+            );
+
+            vrmLoadable.VrmLoaded += info =>
+            {
+                _hips = info.animator.GetBoneTransform(HumanBodyBones.Hips);
+                leftHand.TargetTransform.SetParent(_hips);
+                rightHand.TargetTransform.SetParent(_hips);
+                _hasModel = true;
+            };
+
+            vrmLoadable.VrmDisposing += () =>
+            {
+                _hasModel = false;
+                leftHand.TargetTransform.SetParent(null);
+                rightHand.TargetTransform.SetParent(null);
+                _hips = null;
+            };
+
+            deviceTransformController.ControlRequested
+                .Subscribe(OnDeviceControlRequested)
+                .AddTo(this);
+        }
+
+        private void Start()
+        {
+            _enableFreeLayoutMode
+                .CombineLatest(EnableCustomHandDownPose, (x, y) => x && y)
+                .DistinctUntilChanged()
+                .Subscribe(gizmoVisible =>
+                {
+                    _showGizmo.Value = gizmoVisible;
+                    leftHand.SetGizmoImageActiveness(gizmoVisible);
+                    rightHand.SetGizmoImageActiveness(gizmoVisible);
+                    if (!gizmoVisible)
+                    {
+                        _leftControlIsActive = false;
+                        _rightControlIsActive = false;
+                    }
+                })
+                .AddTo(this);
+        }
+
+        //片方の手の位置を調整
+        private void Update()
+        {
+            if (!_showGizmo.Value)
+            {
+                return;
+            }
+
+            //左手のgizmoが操作され、確定した
+            if (_leftControlIsActive && !leftHand.TransformControl.IsDragging)
+            {
+                var pose = GetPoseFromTransform(leftHand.TargetTransform, true);
+                SetPosesToTransforms(pose);
+            }
+
+            if (_rightControlIsActive && !rightHand.TransformControl.IsDragging)
+            {
+                var pose = GetPoseFromTransform(rightHand.TargetTransform, false);
+                SetPosesToTransforms(pose);
+            }
+
+            _leftControlIsActive = leftHand.TransformControl.IsDragging;
+            _rightControlIsActive = rightHand.TransformControl.IsDragging;
+        }
+
+        private void OnDeviceControlRequested(TransformControlRequest request)
+        {
+            if (!_showGizmo.Value)
+            {
+                return;
+            }
+
+            var mode = request.Mode;
+            var useMode =
+                mode == TransformControl.TransformMode.Translate || 
+                mode == TransformControl.TransformMode.Rotate;
+            //scaleは許可されてないことに注意
+            leftHand.TransformControl.mode = useMode ? mode : TransformControl.TransformMode.None;
+        }
+
+        private void ApplyHandDownPose(string poseJson)
+        {
+            //無効なデータを渡されても上書きしない: 場合によってはコレで変になるが、まあ気にしない方向で…
+            if (string.IsNullOrEmpty(poseJson))
+            {
+                return;
+            }
+
+            try
+            {
+                var pose = JsonUtility.FromJson<HandDownRestPose>(poseJson);
+                SetPosesToTransforms(pose);
+            }
+            catch
+            {
+                //パースエラーのはずなので無視
+            }
+        }
+
+        private HandDownRestPose GetPoseFromTransform(Transform handIkTransform, bool isLeft)
+        {
+            if (!_hasModel)
+            {
+                return HandDownRestPose.Empty;
+            }
+
+            var position = handIkTransform.localPosition;
+            var rotation = handIkTransform.localRotation.eulerAngles;
+
+            if (!isLeft)
+            {
+                position = new Vector3(-position.x, position.y, position.z);
+                rotation = new Vector3(rotation.x, -rotation.y, -rotation.z);
+            }
+
+            return new HandDownRestPose()
+            {
+                IsValid = true,
+                LeftPosition = position,
+                LeftRotation = rotation,
+            };
+        }
+        
+        private void SetPosesToTransforms(HandDownRestPose pose)
+        {
+            if (!pose.IsValid)
+            {
+                return;
+            }
+
+            //結果的にtrueにしかならない
+            _currentPose.IsValid = pose.IsValid;
+            _currentPose.LeftPosition = pose.LeftPosition;
+            _currentPose.LeftRotation = pose.LeftRotation;
+
+            leftHand.TargetTransform.localPosition = _currentPose.LeftPosition;
+            leftHand.TargetTransform.localRotation = Quaternion.Euler(_currentPose.LeftRotation);
+
+            rightHand.TargetTransform.localPosition = new Vector3(
+                -_currentPose.LeftPosition.x,
+                _currentPose.LeftPosition.y,
+                _currentPose.LeftPosition.z
+            );
+
+            //TODO: これで合ってるかは要確認ですよ
+            rightHand.TargetTransform.localRotation = Quaternion.Euler(
+                _currentPose.LeftPosition.x,
+                -_currentPose.LeftPosition.y,
+                -_currentPose.LeftPosition.z
+            );
+        }
+        
+        private void SendPose()
+        {
+            _sender.SendCommand(
+                MessageFactory.Instance.UpdateHandDownRestPose(JsonUtility.ToJson(_currentPose))
+                );
+        }
+        
+        private void ResetCustomHandDownPose()
+        {
+            var ik = _handDownIkCalculator.LeftHandLocalToHip;
+            var pose = new HandDownRestPose()
+            {
+                IsValid = true,
+                LeftPosition = ik.Position,
+                LeftRotation = ik.Rotation.eulerAngles,
+            };
+            SetPosesToTransforms(pose);
+            SendPose();
+        }
+    }
+
+    [Serializable]
+    public class HandDownRestPose
+    {
+        public bool IsValid;
+        //NOTE: とりあえず左右対象の設定のみを保持する
+        public Vector3 LeftPosition;
+
+        //オイラー角で入れておく
+        public Vector3 LeftRotation;
+
+        public static HandDownRestPose Empty { get; } = new HandDownRestPose();
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -292,7 +292,7 @@ namespace Baku.VMagicMirror
         
         private void ResetCustomHandDownPose()
         {
-            var ik = _handDownIkCalculator.LeftHandLocalToHip;
+            var ik = _handDownIkCalculator.LeftHandLocalOnUpperArm;
             var pose = new HandDownRestPose()
             {
                 IsValid = true,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -329,7 +329,7 @@ namespace Baku.VMagicMirror
         private void SendPose()
         {
             _sender.SendCommand(
-                MessageFactory.Instance.UpdateHandDownRestPose(JsonUtility.ToJson(_currentPose))
+                MessageFactory.Instance.UpdateCustomHandDownPose(JsonUtility.ToJson(_currentPose))
                 );
         }
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ca3d19608c2d77478bfb3f61fb1b116
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
@@ -51,7 +51,6 @@ namespace Baku.VMagicMirror.IK
             _leftHand.Rotation = LeftRot;
             _rightHand.Rotation = RightRot;
             _leftHandLocalFromHips.Rotation = LeftRot;
-            _rightHandLocalFromHips.Rotation = RightRot;
         }
 
         void IInitializable.Initialize()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
@@ -27,6 +27,10 @@ namespace Baku.VMagicMirror.IK
         private readonly IKDataRecord _rightHand = new IKDataRecord();
         public IIKData RightHand => _rightHand;
 
+        //NOTE: 「カスタム姿勢は左右対称」という前提を置いているので、片腕ぶんだけ公開しておく
+        private readonly IKDataRecord _leftHandLocalFromHips = new IKDataRecord();
+        public IIKData LeftHandLocalToHip => _leftHandLocalFromHips;
+
         private readonly IVRMLoadable _vrmLoadable;
         private readonly ICoroutineSource _coroutineSource;
 
@@ -46,6 +50,8 @@ namespace Baku.VMagicMirror.IK
             _coroutineSource = coroutineSource;
             _leftHand.Rotation = LeftRot;
             _rightHand.Rotation = RightRot;
+            _leftHandLocalFromHips.Rotation = LeftRot;
+            _rightHandLocalFromHips.Rotation = RightRot;
         }
 
         void IInitializable.Initialize()
@@ -87,6 +93,10 @@ namespace Baku.VMagicMirror.IK
 
             _leftHand.Position = hipsPos + _leftPosHipsOffset;
             _rightHand.Position = hipsPos + _rightPosHipsOffset;
+
+            _leftHandLocalFromHips.Position = _hips.InverseTransformPoint(_leftHand.Position);
+            _leftHandLocalFromHips.Rotation = _leftHand.Rotation * Quaternion.Inverse(_hips.rotation);
+            
             _hasModel = true;
         }
 
@@ -140,36 +150,5 @@ namespace Baku.VMagicMirror.IK
                 _rightHand.Position = rightPos;
             }
         }
-
-        // private class AlwaysHandDownState : IHandIkState
-        // {
-        //     public AlwaysHandDownState(AlwaysDownHandIkGenerator parent, ReactedHand hand)
-        //     {
-        //         _parent = parent;
-        //         Hand = hand;
-        //         _data = hand == ReactedHand.Right ? _parent._rightHand : _parent._leftHand;
-        //     }
-        //
-        //     private readonly AlwaysDownHandIkGenerator _parent;
-        //     private readonly IIKData _data;
-        //
-        //     public bool SkipEnterIkBlend => false;
-        //     public void RaiseRequest() => RequestToUse?.Invoke(this);
-        //
-        //     public Vector3 Position => _data.Position;
-        //     public Quaternion Rotation => _data.Rotation;
-        //     public ReactedHand Hand { get; }
-        //     public HandTargetType TargetType => HandTargetType.AlwaysDown;
-        //     
-        //     public event Action<IHandIkState> RequestToUse;
-        //
-        //     public void Enter(IHandIkState prevState)
-        //     {
-        //     }
-        //
-        //     public void Quit(IHandIkState nextState)
-        //     {
-        //     }
-        // }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
@@ -26,10 +26,10 @@ namespace Baku.VMagicMirror.IK
         public IIKData LeftHand => _leftHand;
         private readonly IKDataRecord _rightHand = new IKDataRecord();
         public IIKData RightHand => _rightHand;
-
+        
         //NOTE: 「カスタム姿勢は左右対称」という前提を置いているので、片腕ぶんだけ公開しておく
-        private readonly IKDataRecord _leftHandLocalFromHips = new IKDataRecord();
-        public IIKData LeftHandLocalToHip => _leftHandLocalFromHips;
+        private readonly IKDataRecord _leftHandLocalFromUpperArm = new IKDataRecord();
+        public IIKData LeftHandLocalOnUpperArm => _leftHandLocalFromUpperArm;
 
         private readonly IVRMLoadable _vrmLoadable;
         private readonly ICoroutineSource _coroutineSource;
@@ -50,7 +50,7 @@ namespace Baku.VMagicMirror.IK
             _coroutineSource = coroutineSource;
             _leftHand.Rotation = LeftRot;
             _rightHand.Rotation = RightRot;
-            _leftHandLocalFromHips.Rotation = LeftRot;
+            _leftHandLocalFromUpperArm.Rotation = LeftRot;
         }
 
         void IInitializable.Initialize()
@@ -93,8 +93,8 @@ namespace Baku.VMagicMirror.IK
             _leftHand.Position = hipsPos + _leftPosHipsOffset;
             _rightHand.Position = hipsPos + _rightPosHipsOffset;
 
-            _leftHandLocalFromHips.Position = _hips.InverseTransformPoint(_leftHand.Position);
-            _leftHandLocalFromHips.Rotation = _leftHand.Rotation * Quaternion.Inverse(_hips.rotation);
+            _leftHandLocalFromUpperArm.Position = _leftUpperArm.InverseTransformPoint(_leftHand.Position);
+            _leftHandLocalFromUpperArm.Rotation = Quaternion.Inverse(_leftUpperArm.rotation) * _leftHand.Rotation;
             
             _hasModel = true;
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
@@ -1,0 +1,175 @@
+﻿using System.Collections;
+using UnityEngine;
+using Zenject;
+
+namespace Baku.VMagicMirror.IK
+{
+    /// <summary>
+    /// 手を下げた姿勢のデフォルト値(カスタム姿勢ではない)を計算できるやつ
+    /// </summary>
+    public class HandDownIkCalculator : IInitializable
+    {
+        // ハンドトラッキングがロスしたときにAポーズへ落とし込むときの、腕の下げ角度(手首の曲げもコレに準拠します
+        private const float APoseArmDownAngleDeg = 70f;
+        // リファレンスモデル(Megumi Baxterさん)のUpperArmボーンからWristボーンまでの距離
+        private const float ReferenceArmLength = 0.37f;
+        // 腕のピンと張る度合いがこの値になるように手IKのy座標を調整する
+        private const float ArmRelaxFactor = 0.99f;
+
+        // Aポーズから少しだけ手首の位置を斜め前方上にズラすオフセット。肘をピンと伸ばすのを避けるために使う。身長に比例してスケールした値を用いる。
+        private static readonly Vector3 APoseHandPosOffsetBase = new Vector3(0f, 0.01f, 0.03f);
+
+        private static readonly Quaternion RightRot = Quaternion.Euler(0, 0, -APoseArmDownAngleDeg);
+        private static readonly Quaternion LeftRot = Quaternion.Euler(0, 0, APoseArmDownAngleDeg);
+
+        private readonly IKDataRecord _leftHand = new IKDataRecord();
+        public IIKData LeftHand => _leftHand;
+        private readonly IKDataRecord _rightHand = new IKDataRecord();
+        public IIKData RightHand => _rightHand;
+
+        private readonly IVRMLoadable _vrmLoadable;
+        private readonly ICoroutineSource _coroutineSource;
+
+        private bool _hasModel = false;
+        private Transform _hips;
+        private Transform _leftUpperArm;
+        private Transform _rightUpperArm;
+
+        private float _rightArmLength = 0.4f;
+        private float _leftArmLength = 0.4f;
+        private Vector3 _rightPosHipsOffset;
+        private Vector3 _leftPosHipsOffset;
+
+        public HandDownIkCalculator(IVRMLoadable vrmLoadable, ICoroutineSource coroutineSource)
+        {
+            _vrmLoadable = vrmLoadable;
+            _coroutineSource = coroutineSource;
+            _leftHand.Rotation = LeftRot;
+            _rightHand.Rotation = RightRot;
+        }
+
+        void IInitializable.Initialize()
+        {
+            _vrmLoadable.VrmLoaded += info => SetupAvatar(info.animator);
+            _vrmLoadable.VrmDisposing += ClearAvatarReference;
+            _coroutineSource.AssociatedBehaviour.StartCoroutine(SetHandPositionsIfHasModel());
+        }
+
+        private void SetupAvatar(Animator animator)
+        {
+            _hips = animator.GetBoneTransform(HumanBodyBones.Hips);
+            _rightUpperArm = animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+            _leftUpperArm = animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
+
+            var rightUpperArmPos = _rightUpperArm.position;
+            var rightWristPos = animator.GetBoneTransform(HumanBodyBones.RightHand).position;
+            var leftUpperArmPos = _leftUpperArm.position;
+            var leftWristPos = animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
+            var hipsPos = _hips.position;
+
+            _rightArmLength = Vector3.Distance(rightWristPos, rightUpperArmPos);
+            var rArmLengthFactor = Mathf.Clamp(_rightArmLength / ReferenceArmLength, 0.1f, 5f);
+
+            _rightPosHipsOffset =
+                rightUpperArmPos +
+                Quaternion.AngleAxis(-APoseArmDownAngleDeg, Vector3.forward) * (rightWristPos - rightUpperArmPos) -
+                hipsPos +
+                rArmLengthFactor * APoseHandPosOffsetBase;
+
+            _leftArmLength = Vector3.Distance(leftWristPos, leftUpperArmPos);
+            var lArmLengthFactor = Mathf.Clamp(_leftArmLength / ReferenceArmLength, 0.1f, 5f);
+
+            _leftPosHipsOffset =
+                leftUpperArmPos +
+                Quaternion.AngleAxis(APoseArmDownAngleDeg, Vector3.forward) * (leftWristPos - leftUpperArmPos) -
+                hipsPos +
+                lArmLengthFactor * APoseHandPosOffsetBase;
+
+            _leftHand.Position = hipsPos + _leftPosHipsOffset;
+            _rightHand.Position = hipsPos + _rightPosHipsOffset;
+            _hasModel = true;
+        }
+
+        private void ClearAvatarReference()
+        {
+            _hasModel = false;
+            _hips = null;
+            _leftUpperArm = null;
+            _rightUpperArm = null;
+        }
+
+        private IEnumerator SetHandPositionsIfHasModel()
+        {
+            var eof = new WaitForEndOfFrame();
+            while (true)
+            {
+                yield return eof;
+                if (!_hasModel)
+                {
+                    continue;
+                }
+
+                //やること: LateUpdateの時点で手の位置を合わせる。
+                //フレーム終わりじゃないと調整されたあとのボーン位置が拾えないので、このタイミングでわざわざやってます
+                
+                var hipsPos = _hips.position;
+
+                var leftUpperArmPos = _leftUpperArm.position;
+                var leftPos = hipsPos + _leftPosHipsOffset;
+
+                var leftTargetLength = _leftArmLength * ArmRelaxFactor;
+                //UpperArmとWristの距離が一定になるようY軸の調整をするとこういう式になる
+                leftPos.y = leftUpperArmPos.y - Mathf.Sqrt(
+                    leftTargetLength * leftTargetLength -
+                    (leftPos.x - leftUpperArmPos.x) * (leftPos.x - leftUpperArmPos.x) -
+                    (leftPos.z - leftUpperArmPos.z) * (leftPos.z - leftUpperArmPos.z)
+                );
+
+                var rightUpperArmPos = _rightUpperArm.position;
+                var rightPos = hipsPos + _rightPosHipsOffset;
+
+                var rightTargetLength = _rightArmLength * ArmRelaxFactor;
+                //UpperArmとWristの距離が一定になるようY軸の調整をするとこういう式になる
+                rightPos.y = rightUpperArmPos.y - Mathf.Sqrt(
+                    rightTargetLength * rightTargetLength -
+                    (rightPos.x - rightUpperArmPos.x) * (rightPos.x - rightUpperArmPos.x) -
+                    (rightPos.z - rightUpperArmPos.z) * (rightPos.z - rightUpperArmPos.z)
+                );
+
+                _leftHand.Position = leftPos;
+                _rightHand.Position = rightPos;
+            }
+        }
+
+        // private class AlwaysHandDownState : IHandIkState
+        // {
+        //     public AlwaysHandDownState(AlwaysDownHandIkGenerator parent, ReactedHand hand)
+        //     {
+        //         _parent = parent;
+        //         Hand = hand;
+        //         _data = hand == ReactedHand.Right ? _parent._rightHand : _parent._leftHand;
+        //     }
+        //
+        //     private readonly AlwaysDownHandIkGenerator _parent;
+        //     private readonly IIKData _data;
+        //
+        //     public bool SkipEnterIkBlend => false;
+        //     public void RaiseRequest() => RequestToUse?.Invoke(this);
+        //
+        //     public Vector3 Position => _data.Position;
+        //     public Quaternion Rotation => _data.Rotation;
+        //     public ReactedHand Hand { get; }
+        //     public HandTargetType TargetType => HandTargetType.AlwaysDown;
+        //     
+        //     public event Action<IHandIkState> RequestToUse;
+        //
+        //     public void Enter(IHandIkState prevState)
+        //     {
+        //     }
+        //
+        //     public void Quit(IHandIkState nextState)
+        //     {
+        //     }
+        // }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
@@ -27,9 +27,8 @@ namespace Baku.VMagicMirror.IK
         private readonly IKDataRecord _rightHand = new IKDataRecord();
         public IIKData RightHand => _rightHand;
         
-        //NOTE: 「カスタム姿勢は左右対称」という前提を置いているので、片腕ぶんだけ公開しておく
-        private readonly IKDataRecord _leftHandLocalFromUpperArm = new IKDataRecord();
-        public IIKData LeftHandLocalOnUpperArm => _leftHandLocalFromUpperArm;
+        private readonly IKDataRecord _leftHandLocalFromHips = new IKDataRecord();
+        public IIKData LeftHandLocalFromHips => _leftHandLocalFromHips;
 
         private readonly IVRMLoadable _vrmLoadable;
         private readonly ICoroutineSource _coroutineSource;
@@ -50,14 +49,14 @@ namespace Baku.VMagicMirror.IK
             _coroutineSource = coroutineSource;
             _leftHand.Rotation = LeftRot;
             _rightHand.Rotation = RightRot;
-            _leftHandLocalFromUpperArm.Rotation = LeftRot;
+            _leftHandLocalFromHips.Rotation = LeftRot;
         }
 
         void IInitializable.Initialize()
         {
             _vrmLoadable.VrmLoaded += info => SetupAvatar(info.animator);
             _vrmLoadable.VrmDisposing += ClearAvatarReference;
-            _coroutineSource.AssociatedBehaviour.StartCoroutine(SetHandPositionsIfHasModel());
+            _coroutineSource.StartCoroutine(SetHandPositionsIfHasModel());
         }
 
         private void SetupAvatar(Animator animator)
@@ -93,9 +92,9 @@ namespace Baku.VMagicMirror.IK
             _leftHand.Position = hipsPos + _leftPosHipsOffset;
             _rightHand.Position = hipsPos + _rightPosHipsOffset;
 
-            _leftHandLocalFromUpperArm.Position = _leftUpperArm.InverseTransformPoint(_leftHand.Position);
-            _leftHandLocalFromUpperArm.Rotation = Quaternion.Inverse(_leftUpperArm.rotation) * _leftHand.Rotation;
-            
+            _leftHandLocalFromHips.Position = _hips.InverseTransformPoint(_leftHand.Position);
+            _leftHandLocalFromHips.Rotation = Quaternion.Inverse(_hips.rotation) * _leftHand.Rotation;
+
             _hasModel = true;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fa99ebc0520e0f46a59ddc21d3e8781
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/SwitchableHandDownIkData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/SwitchableHandDownIkData.cs
@@ -1,0 +1,49 @@
+using Baku.VMagicMirror.IK;
+using UniRx;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public class SwitchableHandDownIkData
+    {
+        private readonly SwitchIKData _leftHand;
+        public IIKData LeftHand => _leftHand;
+        private readonly SwitchIKData _rightHand;
+        public IIKData RightHand => _rightHand; 
+
+        public SwitchableHandDownIkData(
+            CustomizedDownHandIk customizedDownHandIk,
+            HandDownIkCalculator handDownIkCalculator)
+        {
+            _leftHand = new SwitchIKData(
+                customizedDownHandIk.LeftHand, 
+                handDownIkCalculator.LeftHand,
+                customizedDownHandIk.EnableCustomHandDownPose
+            );
+
+            _rightHand = new SwitchIKData(
+                customizedDownHandIk.RightHand, 
+                handDownIkCalculator.RightHand,
+                customizedDownHandIk.EnableCustomHandDownPose
+            );
+        }
+
+        class SwitchIKData : IIKData
+        {
+            private readonly IIKData _x;
+            private readonly IIKData _y;
+            //NOTE: Funcを持たすほどでもないので手抜きしてます
+            private readonly IReadOnlyReactiveProperty<bool> _useX;
+
+            public SwitchIKData(IIKData x, IIKData y, IReadOnlyReactiveProperty<bool> useX)
+            {
+                _x = x;
+                _y = y;
+                _useX = useX;
+            }
+
+            public Vector3 Position => _useX.Value ? _x.Position : _y.Position;
+            public Quaternion Rotation => _useX.Value ? _x.Rotation : _y.Rotation;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/SwitchableHandDownIkData.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/SwitchableHandDownIkData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3344ebe65fd3f2438e18fe485d19f7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IKTargetTransforms.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IKTargetTransforms.cs
@@ -8,13 +8,15 @@ namespace Baku.VMagicMirror.IK
     /// </summary>
     public class IKTargetTransforms : MonoBehaviour
     {
-        [SerializeField] private Transform lookAt = default;
-        [SerializeField] private Transform rightHand = default;
-        [SerializeField] private Transform leftHand = default;
-        [SerializeField] private Transform rightIndex = default;
-        [SerializeField] private Transform body = default;
-        [SerializeField] private Transform leftFoot = default;
-        [SerializeField] private Transform rightFoot = default;
+        [SerializeField] private Transform lookAt;
+        [SerializeField] private Transform rightHand;
+        [SerializeField] private Transform leftHand;
+        [SerializeField] private Transform rightIndex;
+        [SerializeField] private Transform body;
+        [SerializeField] private Transform leftFoot;
+        [SerializeField] private Transform rightFoot;
+        [SerializeField] private CustomizableHandIkTarget leftHandDown;
+        [SerializeField] private CustomizableHandIkTarget rightHandDown;
 
         public Transform LookAt => lookAt;
         public Transform RightHand => rightHand;
@@ -23,5 +25,8 @@ namespace Baku.VMagicMirror.IK
         public Transform Body => body;
         public Transform LeftFoot => leftFoot;
         public Transform RightFoot => rightFoot;
+
+        public CustomizableHandIkTarget LeftHandDown => leftHandDown;
+        public CustomizableHandIkTarget RightHandDown => rightHandDown;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
@@ -15,8 +15,8 @@ namespace Baku.VMagicMirror.Installer
 
         public override void Install(DiContainer container)
         {
-            container.Bind<HandDownIkCalculator>().AsSingle();
-            container.Bind<CustomizedDownHandIk>().AsSingle();
+            container.BindInterfacesAndSelfTo<HandDownIkCalculator>().AsSingle();
+            container.BindInterfacesAndSelfTo<CustomizedDownHandIk>().AsSingle();
             container.Bind<SwitchableHandDownIkData>().AsSingle();
             container.BindInstances(
                 handIKIntegrator,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
@@ -16,6 +16,8 @@ namespace Baku.VMagicMirror.Installer
         public override void Install(DiContainer container)
         {
             container.Bind<HandDownIkCalculator>().AsSingle();
+            container.Bind<CustomizedDownHandIk>().AsSingle();
+            container.Bind<SwitchableHandDownIkData>().AsSingle();
             container.BindInstances(
                 handIKIntegrator,
                 faceAttitude,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
@@ -15,6 +15,7 @@ namespace Baku.VMagicMirror.Installer
 
         public override void Install(DiContainer container)
         {
+            container.Bind<HandDownIkCalculator>().AsSingle();
             container.BindInstances(
                 handIKIntegrator,
                 faceAttitude,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/VMagicMirrorInstallerRoot.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/VMagicMirrorInstallerRoot.cs
@@ -24,7 +24,7 @@ namespace Baku.VMagicMirror.Installer
         {
             Container.BindInstance(loadingCoverController);
             Container.BindInterfacesTo<StartupLoadingCoverController>().AsSingle();
-            Container.Bind<CoroutineSource>().FromNewComponentOnNewGameObject();
+            Container.Bind<ICoroutineSource>().To<CoroutineSource>().FromNewComponentOnNewGameObject().AsSingle();
 
             foreach (var installer in new InstallerBase[]
                 {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/VMagicMirrorInstallerRoot.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/VMagicMirrorInstallerRoot.cs
@@ -24,6 +24,7 @@ namespace Baku.VMagicMirror.Installer
         {
             Container.BindInstance(loadingCoverController);
             Container.BindInterfacesTo<StartupLoadingCoverController>().AsSingle();
+            Container.Bind<CoroutineSource>().FromNewComponentOnNewGameObject();
 
             foreach (var installer in new InstallerBase[]
                 {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
@@ -53,6 +53,8 @@ namespace Baku.VMagicMirror
         public Message UpdateAccessoryLayouts(string json) => WithArg(json);
 
         public Message VRM10SpecifiedButNotSupported(string pathOrModelName) => WithArg(pathOrModelName);
+
+        public Message UpdateHandDownRestPose(string json) => WithArg(json);
         
         #region VRoid
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/MessageFactory.cs
@@ -54,7 +54,7 @@ namespace Baku.VMagicMirror
 
         public Message VRM10SpecifiedButNotSupported(string pathOrModelName) => WithArg(pathOrModelName);
 
-        public Message UpdateHandDownRestPose(string json) => WithArg(json);
+        public Message UpdateCustomHandDownPose(string json) => WithArg(json);
         
         #region VRoid
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -51,7 +51,10 @@
 
         public const string SetKeyboardAndMouseMotionMode = nameof(SetKeyboardAndMouseMotionMode);
         public const string SetGamepadMotionMode = nameof(SetGamepadMotionMode);
-
+        public const string EnableCustomHandDownPose = nameof(EnableCustomHandDownPose);
+        public const string SetHandDownModeCustomPose = nameof(SetHandDownModeCustomPose);
+        public const string ResetCustomHandDownPose = nameof(ResetCustomHandDownPose);
+            
         // Motion, Wait
         public const string EnableWaitMotion = nameof(EnableWaitMotion);
         public const string WaitMotionScale = nameof(WaitMotionScale);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/CoroutineSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/CoroutineSource.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public interface ICoroutineSource
+    {
+        MonoBehaviour AssociatedBehaviour { get; }
+    }
+
+    public class CoroutineSource : MonoBehaviour, ICoroutineSource
+    {
+        public MonoBehaviour AssociatedBehaviour => this;
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/CoroutineSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/CoroutineSource.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 namespace Baku.VMagicMirror
@@ -10,5 +11,13 @@ namespace Baku.VMagicMirror
     public class CoroutineSource : MonoBehaviour, ICoroutineSource
     {
         public MonoBehaviour AssociatedBehaviour => this;
+    }
+
+    public static class CoroutineSourceExtension
+    {
+        public static void StartCoroutine(this ICoroutineSource source, IEnumerator coroutine)
+        {
+            source.AssociatedBehaviour.StartCoroutine(coroutine);
+        }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/CoroutineSource.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/CoroutineSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1088b45a102778a488d741c13fe4fb8f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -20,6 +20,11 @@
 
         public bool EnableTwistBodyMotion { get; set; } = false;
 
+        public bool EnableCustomHandDownPose { get; set; } = false;
+
+        //NOTE: jsonがUnityから飛んでくるのを保持するだけ
+        public string CustomHandDownPose { get; set; } = "";
+
         #endregion
 
         #region Face
@@ -190,6 +195,9 @@
         public void ResetToDefault()
         {
             EnableNoHandTrackMode = false;
+            EnableTwistBodyMotion = false;
+            EnableCustomHandDownPose = false;
+            CustomHandDownPose = "";
             ResetFaceBasicSetting();
             ResetFaceEyeSetting();
             ResetFaceBlendShapeSetting();

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -78,9 +78,9 @@ namespace Baku.VMagicMirrorConfig
         public Message EnableNoHandTrackMode(bool enable) => WithArg(enable);
         public Message EnableTwistBodyMotion(bool enable) => WithArg(enable);
 
-        public Message EnableHandDownModeCustomPose(bool enable) => WithArg(enable);
+        public Message EnableCustomHandDownPose(bool enable) => WithArg(enable);
         public Message SetHandDownModeCustomPose(string poseJson) => WithArg(poseJson);
-        public Message ResetHandDownModeCustomPose() => NoArg();
+        public Message ResetCustomHandDownPose() => NoArg();
 
 
         public Message LengthFromWristToTip(int lengthCentimeter) => WithArg(lengthCentimeter);

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -78,6 +78,11 @@ namespace Baku.VMagicMirrorConfig
         public Message EnableNoHandTrackMode(bool enable) => WithArg(enable);
         public Message EnableTwistBodyMotion(bool enable) => WithArg(enable);
 
+        public Message EnableHandDownModeCustomPose(bool enable) => WithArg(enable);
+        public Message SetHandDownModeCustomPose(string poseJson) => WithArg(poseJson);
+        public Message ResetHandDownModeCustomPose() => NoArg();
+
+
         public Message LengthFromWristToTip(int lengthCentimeter) => WithArg(lengthCentimeter);
 
         public Message HandYOffsetBasic(int offsetCentimeter) => WithArg(offsetCentimeter);

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/ReceiveMessageNames.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/ReceiveMessageNames.cs
@@ -10,6 +10,7 @@
         public const string SetCalibrationFaceData = nameof(SetCalibrationFaceData);
         public const string AutoAdjustResults = nameof(AutoAdjustResults);
         public const string UpdateDeviceLayout = nameof(UpdateDeviceLayout);
+        public const string UpdateHandDownPose = nameof(UpdateHandDownPose);
         public const string MicrophoneVolumeLevel = nameof(MicrophoneVolumeLevel);
 
         public const string ExtraBlendShapeClipNames = nameof(ExtraBlendShapeClipNames);

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/ReceiveMessageNames.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/ReceiveMessageNames.cs
@@ -10,7 +10,7 @@
         public const string SetCalibrationFaceData = nameof(SetCalibrationFaceData);
         public const string AutoAdjustResults = nameof(AutoAdjustResults);
         public const string UpdateDeviceLayout = nameof(UpdateDeviceLayout);
-        public const string UpdateHandDownPose = nameof(UpdateHandDownPose);
+        public const string UpdateCustomHandDownPose = nameof(UpdateCustomHandDownPose);
         public const string MicrophoneVolumeLevel = nameof(MicrophoneVolumeLevel);
 
         public const string ExtraBlendShapeClipNames = nameof(ExtraBlendShapeClipNames);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -14,7 +14,7 @@ namespace Baku.VMagicMirrorConfig
         }
 
         public MotionSettingModel() : this(
-            ModelResolver.Instance.Resolve<IMessageSender>(), 
+            ModelResolver.Instance.Resolve<IMessageSender>(),
             ModelResolver.Instance.Resolve<IMessageReceiver>())
         {
         }
@@ -225,9 +225,9 @@ namespace Baku.VMagicMirrorConfig
 
         //NOTE: dB単位なので0がデフォルト。対数ベースのほうがレンジ取りやすい
         public RProperty<int> MicrophoneSensitivity { get; }
- 
+
         public RProperty<bool> AdjustLipSyncByVolume { get; }
-        
+
         #endregion
 
         #region Arm
@@ -243,7 +243,7 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<bool> ShowPresentationPointer { get; }
         public RProperty<int> PresentationArmRadiusMin { get; }
 
-        public bool PointerVisible => 
+        public bool PointerVisible =>
             KeyboardAndMouseMotionMode.Value == MotionSetting.KeyboardMouseMotionPresentation &&
             ShowPresentationPointer.Value;
 

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -29,7 +29,7 @@ namespace Baku.VMagicMirrorConfig
 
             EnableNoHandTrackMode = new RProperty<bool>(setting.EnableNoHandTrackMode, v => SendMessage(factory.EnableNoHandTrackMode(v)));
             EnableTwistBodyMotion = new RProperty<bool>(setting.EnableTwistBodyMotion, v => SendMessage(factory.EnableTwistBodyMotion(v)));
-            EnableCustomHandDownPose = new RProperty<bool>(setting.EnableCustomHandDownPose, v => SendMessage(factory.EnableHandDownModeCustomPose(v)));
+            EnableCustomHandDownPose = new RProperty<bool>(setting.EnableCustomHandDownPose, v => SendMessage(factory.EnableCustomHandDownPose(v)));
             CustomHandDownPose = new RProperty<string>(setting.CustomHandDownPose, v => SendMessage(factory.SetHandDownModeCustomPose(v)));
 
             EnableFaceTracking = new RProperty<bool>(setting.EnableFaceTracking, v => SendMessage(factory.EnableFaceTracking(v)));
@@ -142,7 +142,7 @@ namespace Baku.VMagicMirrorConfig
 
         private void OnReceiveCommand(object? sender, CommandReceivedEventArgs e)
         {
-            if (e.Command != ReceiveMessageNames.UpdateHandDownPose)
+            if (e.Command != ReceiveMessageNames.UpdateCustomHandDownPose)
             {
                 return;
             }
@@ -163,7 +163,7 @@ namespace Baku.VMagicMirrorConfig
 
         public RProperty<string> CustomHandDownPose { get; }
 
-        public void ResetCustomHandDownPose() => SendMessage(MessageFactory.Instance.ResetHandDownModeCustomPose());
+        public void ResetCustomHandDownPose() => SendMessage(MessageFactory.Instance.ResetCustomHandDownPose());
 
         #endregion
 

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -147,7 +147,7 @@ namespace Baku.VMagicMirrorConfig
                 return;
             }
 
-            CustomHandDownPose.Value = e.Args;
+            CustomHandDownPose.SilentSet(e.Args);
         }
 
         public RProperty<int> KeyboardAndMouseMotionMode { get; }

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -13,12 +13,14 @@ namespace Baku.VMagicMirrorConfig
             public const string UseLookAtPointMainCamera = nameof(UseLookAtPointMainCamera);
         }
 
-        public MotionSettingModel() : this(ModelResolver.Instance.Resolve<IMessageSender>())
+        public MotionSettingModel() : this(
+            ModelResolver.Instance.Resolve<IMessageSender>(), 
+            ModelResolver.Instance.Resolve<IMessageReceiver>())
         {
         }
 
 
-        public MotionSettingModel(IMessageSender sender) : base(sender)
+        public MotionSettingModel(IMessageSender sender, IMessageReceiver receiver) : base(sender)
         {
             var factory = MessageFactory.Instance;
             var setting = MotionSetting.Default;
@@ -27,6 +29,8 @@ namespace Baku.VMagicMirrorConfig
 
             EnableNoHandTrackMode = new RProperty<bool>(setting.EnableNoHandTrackMode, v => SendMessage(factory.EnableNoHandTrackMode(v)));
             EnableTwistBodyMotion = new RProperty<bool>(setting.EnableTwistBodyMotion, v => SendMessage(factory.EnableTwistBodyMotion(v)));
+            EnableCustomHandDownPose = new RProperty<bool>(setting.EnableCustomHandDownPose, v => SendMessage(factory.EnableHandDownModeCustomPose(v)));
+            CustomHandDownPose = new RProperty<string>(setting.CustomHandDownPose, v => SendMessage(factory.SetHandDownModeCustomPose(v)));
 
             EnableFaceTracking = new RProperty<bool>(setting.EnableFaceTracking, v => SendMessage(factory.EnableFaceTracking(v)));
             AutoBlinkDuringFaceTracking = new RProperty<bool>(setting.AutoBlinkDuringFaceTracking, v => SendMessage(factory.AutoBlinkDuringFaceTracking(v)));
@@ -131,6 +135,19 @@ namespace Baku.VMagicMirrorConfig
             GamepadMotionMode = new RProperty<int>(
                 setting.GamepadMotionMode, v => SendMessage(factory.SetGamepadMotionMode(v))
                 );
+
+            receiver.ReceivedCommand += OnReceiveCommand;
+        }
+
+
+        private void OnReceiveCommand(object? sender, CommandReceivedEventArgs e)
+        {
+            if (e.Command != ReceiveMessageNames.UpdateHandDownPose)
+            {
+                return;
+            }
+
+            CustomHandDownPose.Value = e.Args;
         }
 
         public RProperty<int> KeyboardAndMouseMotionMode { get; }
@@ -141,6 +158,12 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<bool> EnableNoHandTrackMode { get; }
 
         public RProperty<bool> EnableTwistBodyMotion { get; }
+
+        public RProperty<bool> EnableCustomHandDownPose { get; }
+
+        public RProperty<string> CustomHandDownPose { get; }
+
+        public void ResetCustomHandDownPose() => SendMessage(MessageFactory.Instance.ResetHandDownModeCustomPose());
 
         #endregion
 
@@ -323,6 +346,8 @@ namespace Baku.VMagicMirrorConfig
         {
             var setting = MotionSetting.Default;
             EnableNoHandTrackMode.Value = setting.EnableNoHandTrackMode;
+            EnableTwistBodyMotion.Value = setting.EnableTwistBodyMotion;
+            EnableCustomHandDownPose.Value = setting.EnableCustomHandDownPose;
             ResetFaceBasicSetting();
             ResetFaceEyeSetting();
             ResetFaceBlendShapeSetting();

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -188,6 +188,9 @@ Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode">Always-Hands-Down Mode (*Increase body move)</sys:String>    
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">Hands-Down Mode</sys:String>    
     <sys:String x:Key="Motion_FullBody_TwistBodyMotion">Enable Twist Motion</sys:String>    
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose">Custom Hand Down Pose</sys:String>    
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Notice">*Pose adjuster appears on Free Layout Mode</sys:String>
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Reset">Reset Hand Down Pose to Default</sys:String>
     
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">Arm</sys:String>    

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -190,6 +190,9 @@ Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Motion_FullBody_TwistBodyMotion">Enable Twist Motion</sys:String>    
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose">Custom Hand Down Pose</sys:String>    
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Notice">*Pose adjuster appears on Free Layout Mode</sys:String>
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_AlwaysDownWarning" xml:space="preserve">To edit hand pose,
+- Turn on "Always-Hands-Down Mode"
+- Turn on "Free Layout Mode"</sys:String>
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Reset">Reset Hand Down Pose to Default</sys:String>
     
     <!-- Motion : Arm -->

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -189,7 +189,9 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">つねに手下げモード</sys:String>    
     <sys:String x:Key="Motion_FullBody_TwistBodyMotion">ひねりモーション</sys:String>    
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose">手を下げた位置を手動で調整</sys:String>    
-    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Notice">* 手の位置はフリーレイアウトモードで編集できます</sys:String>
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_AlwaysDownWarning" xml:space="preserve">手の位置を編集するには
+「つねに手下げモード」がオンの状態で
+フリーレイアウトモードを有効にします</sys:String>
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Reset">手の位置をデフォルトにリセット</sys:String>
     
     <!-- Motion : Arm -->

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -188,6 +188,9 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode">つねに手下げモード (※体の動きが増えます)</sys:String>    
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">つねに手下げモード</sys:String>    
     <sys:String x:Key="Motion_FullBody_TwistBodyMotion">ひねりモーション</sys:String>    
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose">手を下げた位置を手動で調整</sys:String>    
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Notice">* 手の位置はフリーレイアウトモードで編集できます</sys:String>
+    <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Reset">手の位置をデフォルトにリセット</sys:String>
     
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">腕・ひじ</sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -117,7 +117,7 @@
                                   Margin="20,2,15,5"
                                   Visibility="{Binding EnableCustomHandDownPose.Value,
                                                       Converter={StaticResource BooleanToVisibilityConverter}}"
-                                  IsChecked="{Binding EnableFreeLayoutMode.Value}"
+                                  IsChecked="{Binding EnableDeviceFreeLayout.Value}"
                                   Content="{DynamicResource Layout_DeviceFreeLayout}"/>
                         <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
                                 Width="NaN"

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -53,6 +53,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -112,19 +113,40 @@
                                   Margin="5,15,5,0"
                                   IsChecked="{Binding EnableCustomHandDownPose.Value}"
                                   Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose}"/>
-                        <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
-                                   Margin="15,3"
-                                   Text="{DynamicResource Motion_FullBody_EnableCustomHandDownPose_Notice}"/>
+                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                                  Margin="20,2,15,5"
+                                  Visibility="{Binding EnableCustomHandDownPose.Value,
+                                                      Converter={StaticResource BooleanToVisibilityConverter}}"
+                                  IsChecked="{Binding EnableFreeLayoutMode.Value}"
+                                  Content="{DynamicResource Layout_DeviceFreeLayout}"/>
                         <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
                                 Width="NaN"
                                 HorizontalAlignment="Left"
-                                Margin="15,3"
+                                Margin="20,5"
                                 Visibility="{Binding EnableCustomHandDownPose.Value,
                                                      Converter={StaticResource BooleanToVisibilityConverter}}"
                                 Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose_Reset}"
                                 Command="{Binding ResetCustomHandDownPoseCommand}"
                                 />
-
+                        <Border Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
+                                Style="{StaticResource SideMarginSectionBorder}"
+                                HorizontalAlignment="Left"
+                                Margin="20,5,10,5"
+                                Padding="4"
+                                Visibility="{Binding EnableCustomHandDownPose.Value,
+                                                     Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <StackPanel Margin="2" Orientation="Horizontal">
+                                <md:PackIcon Kind="InformationOutline"
+                                             Margin="0"
+                                             VerticalAlignment="Center"
+                                             Foreground="{StaticResource PrimaryHueMidBrush}"
+                                             />
+                                <TextBlock Text="{DynamicResource Motion_FullBody_EnableCustomHandDownPose_AlwaysDownWarning}" 
+                                           Margin="10,0"
+                                           TextWrapping="Wrap"
+                                           />
+                            </StackPanel>
+                        </Border>
 
                     </Grid>
                 </StackPanel>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -50,6 +50,9 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -104,6 +107,25 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+
+                        <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                                  Margin="5,15,5,0"
+                                  IsChecked="{Binding EnableCustomHandDownPose.Value}"
+                                  Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose}"/>
+                        <TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Margin="15,3"
+                                   Text="{DynamicResource Motion_FullBody_EnableCustomHandDownPose_Notice}"/>
+                        <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
+                                Width="NaN"
+                                HorizontalAlignment="Left"
+                                Margin="15,3"
+                                Visibility="{Binding EnableCustomHandDownPose.Value,
+                                                     Converter={StaticResource BooleanToVisibilityConverter}}"
+                                Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose_Reset}"
+                                Command="{Binding ResetCustomHandDownPoseCommand}"
+                                />
+
+
                     </Grid>
                 </StackPanel>
             </Border>

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
@@ -13,7 +13,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         {
             _model = model;
 
-            ResetHandDownCustomPoseCommand = new ActionCommand(
+            ResetCustomHandDownPoseCommand = new ActionCommand(
                 () => _model.ResetCustomHandDownPose()
                 );
 
@@ -130,7 +130,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<int> WaitMotionPeriod => _model.WaitMotionPeriod;
 
 
-        public ActionCommand ResetHandDownCustomPoseCommand { get; }
+        public ActionCommand ResetCustomHandDownPoseCommand { get; }
         public ActionCommand ResetArmMotionSettingCommand { get; }
         public ActionCommand ResetHandMotionSettingCommand { get; }
         public ActionCommand ResetWaitMotionSettingCommand { get; }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
@@ -13,6 +13,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         {
             _model = model;
 
+            ResetHandDownCustomPoseCommand = new ActionCommand(
+                () => _model.ResetCustomHandDownPose()
+                );
+
             ResetArmMotionSettingCommand = new ActionCommand(
                  () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetArmSetting)
                  );
@@ -103,7 +107,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         
         public RProperty<bool> EnableNoHandTrackMode => _model.EnableNoHandTrackMode;
         public RProperty<bool> EnableTwistBodyMotion => _model.EnableTwistBodyMotion;
-
+        public RProperty<bool> EnableCustomHandDownPose => _model.EnableCustomHandDownPose;
 
         public RProperty<bool> EnableHidRandomTyping => _model.EnableHidRandomTyping;
         public RProperty<bool> EnableShoulderMotionModify => _model.EnableShoulderMotionModify;
@@ -126,6 +130,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<int> WaitMotionPeriod => _model.WaitMotionPeriod;
 
 
+        public ActionCommand ResetHandDownCustomPoseCommand { get; }
         public ActionCommand ResetArmMotionSettingCommand { get; }
         public ActionCommand ResetHandMotionSettingCommand { get; }
         public ActionCommand ResetWaitMotionSettingCommand { get; }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
@@ -5,13 +5,18 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 {
     public class MotionSettingViewModel : SettingViewModelBase
     {
-        public MotionSettingViewModel() : this(ModelResolver.Instance.Resolve<MotionSettingModel>())
+        public MotionSettingViewModel() : this(
+            ModelResolver.Instance.Resolve<MotionSettingModel>(),
+            ModelResolver.Instance.Resolve<LayoutSettingModel>()
+            )
         {
         }
 
-        internal MotionSettingViewModel(MotionSettingModel model)
+        internal MotionSettingViewModel(
+            MotionSettingModel model, LayoutSettingModel layoutModel)
         {
             _model = model;
+            _layoutModel = layoutModel;
 
             ResetCustomHandDownPoseCommand = new ActionCommand(
                 () => _model.ResetCustomHandDownPose()
@@ -39,6 +44,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         }
 
         private readonly MotionSettingModel _model;
+        private readonly LayoutSettingModel _layoutModel;
 
         private void OnKeyboardAndMouseMotionModeChanged(object? sender, PropertyChangedEventArgs e)
         {
@@ -108,6 +114,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<bool> EnableNoHandTrackMode => _model.EnableNoHandTrackMode;
         public RProperty<bool> EnableTwistBodyMotion => _model.EnableTwistBodyMotion;
         public RProperty<bool> EnableCustomHandDownPose => _model.EnableCustomHandDownPose;
+        public RProperty<bool> EnableDeviceFreeLayout => _layoutModel.EnableDeviceFreeLayout;
 
         public RProperty<bool> EnableHidRandomTyping => _model.EnableHidRandomTyping;
         public RProperty<bool> EnableShoulderMotionModify => _model.EnableShoulderMotionModify;


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature

## What the PR does

fixed #855 

Features: 

- Disabled by default
- Hand poses are always mirrored
- Free Layout Mode supports pose edit, and it requires "Always-Hands-Down" mode turned on. 
    - This is because of preview necessity of how hands are placed

## How to confirm

※ちゃんと書くのが面倒なので日本語で…

- [x] デフォルトでは機能は無効になっている
- [x] 詳細設定ウィンドウの「モーション」タブで有効にできる 
- [x] 有効にした直後はほぼ通常の手下げ状態と同じ位置に手が来る
- [x] 機能が有効、かつ「つねに手下げモード」がオン、かつフリーレイアウトがオンの場合のみ、手下げ位置の調整ギズモが出現し、調整できる。どれか1つでもオフにすると手下げ位置の調整ギズモは消える
- [x] 左右の手の姿勢はミラーリングされる
- [x] 「つねに手下げモード」がオンだが手下げ位置が保存されてないような状態を生成した場合、その時点でロードされているアバターに対してそれっぽい手下げ位置が適用される(=急に破綻しない)
- [x] 手下げ位置をリセットできる
- [x] この方法で調整した手下げ位置が、キーボード/マウス操作から一定時間が経つ、「つねに手下げモード」がオンである、その状態で何らかのモーションを実行した終了時、などの条件で実際に適用される