### PR TITLE
Add explicit sleep proc for UDP receive

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapReceiver.cs
@@ -21,8 +21,8 @@ namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
 
         private const int SleepMsDefault = 12;
         private const int SleepMsLowerLimit = 4;
-        //この回数だけUDP受信すると、そのたびに受信FPSを計算する
-        private const int ReceiveFpsCountInterval = 500;
+        //この回数で正常にUDP受信するたびに受信FPSを確認する
+        private const int ReceiveFpsCountInterval = 400;
         
         //テキストのGCAllocを避けるやつ
         private readonly StringBuilder _sb = new StringBuilder(2048);
@@ -371,10 +371,9 @@ namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
                 }
                 catch (Exception)
                 {
-                    //iFacialMocap側が完全に止まった可能性が高いので、FPSの測定をリセット
+                    //iFacialMocap側が停止した可能性が高いので、FPSの測定をリセット
                     receiveCount = 0;
                     sw.Restart();
-                    //Do nothing
                 }
 
                 if (receiveCount >= ReceiveFpsCountInterval)
@@ -386,7 +385,7 @@ namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
                     //FPSが低い、という判定はそこそこ厳しく取る。互換性の観点で言うと基本SleepMsが短い方がよい、というのを踏まえてる
                     if (fps < 50)
                     {
-                        sleepMs--;
+                        sleepMs -= 2;
                         sleepMsReachedLowerLimit = sleepMs <= SleepMsLowerLimit;
                         LogOutput.Instance.Write($"iFacialMocap receive fps({fps}) is low, set sleep time to {sleepMs}ms");
                     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapReceiver.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapReceiver.cs
@@ -3,11 +3,13 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using DG.Tweening;
 using DG.Tweening.Core;
 using DG.Tweening.Plugins.Options;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
 {
@@ -17,6 +19,11 @@ namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
         private const float CalibrateReflectDuration = 0.6f;
         private const int PortNumber = 49983;
 
+        private const int SleepMsDefault = 12;
+        private const int SleepMsLowerLimit = 4;
+        //この回数だけUDP受信すると、そのたびに受信FPSを計算する
+        private const int ReceiveFpsCountInterval = 500;
+        
         //テキストのGCAllocを避けるやつ
         private readonly StringBuilder _sb = new StringBuilder(2048);
         
@@ -335,6 +342,20 @@ namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
                 LogOutput.Instance.Write(log);
             }
 
+            // Receiveのサボり方
+            // 前提:
+            // - iFacialMocapは60FPSでデータを送信してくる
+            // - VMagicMirrorの受信処理は極めて短時間で済むよう設計されてる
+            // やっていること:
+            // - 投機的に、受信のたびにThread.Sleepで休む
+            // - データの受信FPSが低い場合、Sleepが長すぎる可能性があるので徐々にSleepの長さを減らしていく
+
+            var sleepMsReachedLowerLimit = false;
+            var sleepMs = SleepMsDefault;
+            var receiveCount = 0;
+
+            var sw = new Stopwatch();
+            sw.Start();
             while (!token.IsCancellationRequested)
             {
                 try
@@ -343,13 +364,39 @@ namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
                     byte[] data = client.Receive(ref remoteEndPoint);
                     string message = Encoding.ASCII.GetString(data);
                     RawMessage = message;
+                    if (!sleepMsReachedLowerLimit)
+                    {
+                        receiveCount++;
+                    }
                 }
                 catch (Exception)
                 {
+                    //iFacialMocap側が完全に止まった可能性が高いので、FPSの測定をリセット
+                    receiveCount = 0;
+                    sw.Restart();
                     //Do nothing
                 }
+
+                if (receiveCount >= ReceiveFpsCountInterval)
+                {
+                    receiveCount = 0;
+                    var elapsed = sw.ElapsedMilliseconds;
+
+                    var fps = ReceiveFpsCountInterval * 1000 / elapsed ;
+                    //FPSが低い、という判定はそこそこ厳しく取る。互換性の観点で言うと基本SleepMsが短い方がよい、というのを踏まえてる
+                    if (fps < 50)
+                    {
+                        sleepMs--;
+                        sleepMsReachedLowerLimit = sleepMs <= SleepMsLowerLimit;
+                        LogOutput.Instance.Write($"iFacialMocap receive fps({fps}) is low, set sleep time to {sleepMs}ms");
+                    }
+                    sw.Restart();
+                }
+                
+                Thread.Sleep(sleepMs);
             }
 
+            sw.Stop();
             try
             {
                 clientV4?.Close();


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #885 

iFacialMocapのデータ送信頻度が60FPSであることを前提としてThread.Sleepを追加しています。

- 投機的に、受信のたびに12msのSleepを行う
- 約8秒ごとにデータ受信のFPSを検証し、60FPSより明らかに低頻度の受信となっている場合はSleepの長さを縮める
- 受信が完全に止まっている場合、Sleepの長さを縮める処理は省く

## How to confirm

自宅環境で、このコードが入ったビルドを使ったとき、
- [x] Unity側のログファイルにFPS不足でSleep時間を短縮した旨のログが表示されないこと。
- [x] リリース済みのv3.0.1に比べてCPU usageが明らかに増えてはいないこと。

## Note

手元だとCPU利用率が目に見えて改善したのは観測できてないが、まあevilなコードでもないし入れちゃうか…というくらいの温度感
