### PR TITLE
Update lipsync dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ WindowsでVRMを表示し、追加のデバイスなしで動かせるアプリ�
 
 [Booth](https://booth.pm/ja/items/1272298)から取得可能です。
 
-Windows 10環境でお使いいただけます。
+Windows 10/11環境でお使いいただけます。
 
 操作方法については[マニュアル](https://malaybaku.github.io/VMagicMirror/)をご覧下さい。
 
@@ -67,7 +67,7 @@ Unity 2020.3系でUnityプロジェクト(本レポジトリの`VMagicMirror`フ
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
 * [OpenCV for Unity](https://assetstore.unity.com/packages/tools/integration/opencv-for-unity-21088)
-* [OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/)
+* [Oculus LipSync Unity Integration v29](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/)
 * [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI/releases) v0.3
 * [Zenject](https://github.com/svermeulen/Extenject) (アセットストアから)
 * SharpDX.DirectInput 4.2.0

--- a/README_en.md
+++ b/README_en.md
@@ -37,7 +37,7 @@ It will be helpful in the following situations.
 
 [Booth](https://booth.pm/en/items/1272298).
 
-Run on Windows 10.
+Run on Windows 10 and Windows 11.
 
 Please see [Manual](https://malaybaku.github.io/VMagicMirror/) for the detail.
 
@@ -68,7 +68,7 @@ Maintainer's environment is as following.
 * [FinalIK](https://assetstore.unity.com/packages/tools/animation/final-ik-14290)
 * [Dlib FaceLandmark Detector](https://assetstore.unity.com/packages/tools/integration/dlib-facelandmark-detector-64314)
 * [OpenCV for Unity](https://assetstore.unity.com/packages/tools/integration/opencv-for-unity-21088)
-* [OVRLipSync v1.28.0](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/1.28.0/)
+* [Oculus LipSync Unity Integration v29](https://developer.oculus.com/downloads/package/oculus-lipsync-unity/)
 * [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI/releases) v0.3
 * [Zenject](https://github.com/svermeulen/Extenject) (from Asset Store)
 * SharpDX.DirectInput 4.2.0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/AnimMorphEasedTargetV2.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/AnimMorphEasedTargetV2.cs
@@ -1,0 +1,229 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UniVRM10;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    public class AnimMorphEasedTargetV2 : MonoBehaviour
+    {
+        [Tooltip("主要な母音音素(aa, E, ih, oh, ou)に対してBlendShapeを動かすカーブ")]
+        public AnimationCurve transitionCurves = new AnimationCurve(new[]
+        {
+            new Keyframe(0.0f, 0.0f),
+            new Keyframe(0.1f, 1.0f),
+        });
+
+        [Tooltip("発音しなくなった母音のBlendShapeをゼロに近づける際の速度を表す値")]
+        public float cancelSpeedFactor = 8.0f;
+
+        [Range(0.0f, 100.0f), Tooltip("この閾値未満の音素の重みは無視する")]
+        public float weightThreshold = 2.0f;
+
+        [Tooltip("OVRLipSyncに渡すSmoothing amountの値")]
+        public int smoothAmount = 65;
+        
+        private bool _shouldReceiveData = true;
+        public bool ShouldReceiveData
+        {
+            get => _shouldReceiveData;
+            set
+            {
+                if (_shouldReceiveData == value)
+                {
+                    return;
+                }
+
+                _shouldReceiveData = value;
+                if (!value)
+                {
+                    UpdateToClosedMouth();
+                }
+            }
+        }
+
+        private readonly RecordLipSyncSource _lipSyncSource = new RecordLipSyncSource();
+        public IMouthLipSyncSource LipSyncSource => _lipSyncSource;
+
+        private readonly Dictionary<ExpressionKey, float> _blendShapeWeights = new Dictionary<ExpressionKey, float>
+        {
+            [ExpressionKey.Aa] = 0f,
+            [ExpressionKey.Ee] = 0f,
+            [ExpressionKey.Ih] = 0f,
+            [ExpressionKey.Oh] = 0f,
+            [ExpressionKey.Ou] = 0f,
+        };
+
+        private readonly ExpressionKey[] _keys = {
+            ExpressionKey.Aa,
+            ExpressionKey.Ee, 
+            ExpressionKey.Ih, 
+            ExpressionKey.Oh, 
+            ExpressionKey.Ou, 
+        };
+
+        private VmmLipSyncContextBase _context;
+        private bool _adjustLipSyncByVolume = true;
+        private OVRLipSync.Viseme _previousViseme = OVRLipSync.Viseme.sil;
+        private float _transitionTimer = 0.0f;
+
+        [Inject]
+        public void Initialize(IMessageReceiver receiver)
+        {
+            receiver.AssignCommandHandler(
+                VmmCommands.AdjustLipSyncByVolume,
+                command => _adjustLipSyncByVolume = command.ToBoolean());
+        }
+        
+        private void Start()
+        {
+            _context = GetComponent<VmmLipSyncContextBase>();
+            if (_context == null)
+            {
+                LogOutput.Instance.Write("同じGameObjectにOVRLipSyncContextBaseを継承したクラスが見つかりません。");
+            }
+            _context.Smoothing = smoothAmount;
+        }
+
+        private float[] weights = new float[5];
+        private void Update()
+        {
+            if (Application.isEditor)
+            {
+                _context.Smoothing = smoothAmount;
+            }
+            
+            //口閉じの場合: とにかく閉じるのが良いので閉じて終わり
+            if (!ShouldReceiveData)
+            {
+                UpdateToClosedMouth();
+                return;
+            }
+
+            if (!_context.enabled || !(_context.GetCurrentPhonemeFrame() is { } frame))
+            {
+                return;
+            }
+
+            _transitionTimer += Time.deltaTime;
+
+            // 最大の重みを持つ音素を探す。子音は無視
+            var maxVisemeIndex = 0;
+            var maxVisemeWeight = 0.0f;
+
+            var weightIndex = 0;
+            for (var i = (int)OVRLipSync.Viseme.aa; i < frame.Visemes.Length; i++)
+            {
+                if (frame.Visemes[i] > maxVisemeWeight)
+                {
+                    maxVisemeWeight = frame.Visemes[i];
+                    maxVisemeIndex = i;
+                }
+
+                weights[weightIndex] = frame.Visemes[i];
+                weightIndex++;
+            }
+
+            Debug.Log(
+                $"{Time.frameCount}, v={(OVRLipSync.Viseme)maxVisemeIndex}, w=({string.Join(",", weights.Select(w => (int)(w * 100)))})"
+                );
+
+            if (maxVisemeIndex == 0)
+            {
+                foreach (var k in _keys)
+                {
+                    _blendShapeWeights[k] = 0f;
+                }
+            }
+            else
+            {
+                var index = maxVisemeIndex - (int)OVRLipSync.Viseme.aa;
+                for (var i = 0; i < _keys.Length; i++)
+                {
+                    _blendShapeWeights[_keys[i]] =
+                        i == index ? maxVisemeWeight : 0f;
+                }
+            }
+            
+            // 音素の重みが小さすぎる場合は口を閉じる
+            if (maxVisemeWeight * 100.0f < weightThreshold)
+            {
+                _transitionTimer = 0.0f;
+            }
+
+            // 音素の切り替わりでタイマーをリセットする
+            if (_previousViseme != (OVRLipSync.Viseme)maxVisemeIndex)
+            {
+                _transitionTimer = 0.0f;
+                _previousViseme = (OVRLipSync.Viseme)maxVisemeIndex;
+            }
+
+            int visemeIndex = maxVisemeIndex - (int)OVRLipSync.Viseme.aa;
+            bool hasValidMaxViseme = (visemeIndex >= 0);
+
+            for(int i = 0; i < _keys.Length; i++)
+            {
+                var key = _keys[i];
+
+                _blendShapeWeights[key] = Mathf.Lerp(
+                    _blendShapeWeights[key],
+                    0.0f,
+                    Time.deltaTime * cancelSpeedFactor
+                    );
+
+                //減衰中の値のほうが大きければそっちを採用する。
+                //「あぁあぁぁあ」みたいな声の出し方した場合にEvaluateだけ使うとヘンテコになる可能性が高い為。
+                if (hasValidMaxViseme && i == visemeIndex)
+                {
+                    _blendShapeWeights[key] = Mathf.Max(
+                        _blendShapeWeights[key],
+                        transitionCurves.Evaluate(_transitionTimer)
+                        );
+                }
+            }
+
+            var factor = _adjustLipSyncByVolume ? GetLipSyncFactorByVolume() : 1f;
+            //順番に注意: visemeのキーに合わせてます
+            _lipSyncSource.A = _blendShapeWeights[_keys[0]] * factor;
+            _lipSyncSource.E = _blendShapeWeights[_keys[1]] * factor;
+            _lipSyncSource.I = _blendShapeWeights[_keys[2]] * factor;
+            _lipSyncSource.O = _blendShapeWeights[_keys[3]] * factor;
+            _lipSyncSource.U = _blendShapeWeights[_keys[4]] * factor;
+        }
+
+        private float GetLipSyncFactorByVolume()
+        {
+            //-40dBで口が開きはじめ、-20dBになると完全に開く
+            const int MinLevel = 10;
+            const int MaxLevel = 30;
+            
+            var rawResult = 
+                Mathf.Clamp(_context.CurrentVolumeLevel - MinLevel, 0, MaxLevel - MinLevel) * 1.0f / (MaxLevel - MinLevel);
+
+            if (_context.CurrentVolumeLevel > MinLevel)
+            {
+                return Mathf.Clamp(rawResult, 0.3f, 1f);
+            }
+            else
+            {
+                //ここでパキっと0になることはそんなに多くなくて、動くの渋いかなあ…うーん…
+                return 0f;
+            }
+        }
+        
+        private void UpdateToClosedMouth()
+        {
+            foreach(var key in _keys)
+            {
+                _blendShapeWeights[key] = 0.0f;
+            }
+
+            _lipSyncSource.A = 0;
+            _lipSyncSource.I = 0;
+            _lipSyncSource.U = 0;
+            _lipSyncSource.E = 0;
+            _lipSyncSource.O = 0;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/AnimMorphEasedTargetV2.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/LIpSync/AnimMorphEasedTargetV2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 914cb9b0b3b83d142a1ae54a5c514871
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
@@ -22,8 +22,6 @@ VRMLoaderUI: https://github.com/m2wasabi/VRMLoaderUI
 
 Newtonsoft.Json: https://www.newtonsoft.com/json
         
-OVRLipSync: https://developer.oculus.com/licenses/audio-3.2.2/
-        
 Oculus LipSync Unity Integration v29: https://developer.oculus.com/downloads/package/oculus-lipsync-unity/
         
 SimpleAnimation: https://github.com/Unity-Technologies/SimpleAnimation

--- a/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
@@ -24,6 +24,8 @@ Newtonsoft.Json: https://www.newtonsoft.com/json
         
 OVRLipSync: https://developer.oculus.com/licenses/audio-3.2.2/
         
+Oculus LipSync Unity Integration v29: https://developer.oculus.com/downloads/package/oculus-lipsync-unity/
+        
 SimpleAnimation: https://github.com/Unity-Technologies/SimpleAnimation
 
 Zenject: https://github.com/svermeulen/Extenject

--- a/docs/credit_license.md
+++ b/docs/credit_license.md
@@ -44,6 +44,8 @@ In VMagicMirror, the materials are replaced for the visual consistency.
 
 [OVRLipSync](https://developer.oculus.com/licenses/audio-3.2.2/)
 
+[Oculus LipSync Unity Integration](https://developer.oculus.com/licenses/audio-3.2.2/), with Caffe 0.8.1 and Caffe2 1.2.2
+
 [SimpleAnimation](https://github.com/Unity-Technologies/SimpleAnimation)
 
 [Zenject](https://github.com/svermeulen/Extenject)


### PR DESCRIPTION
## PR category

- [x] Documentation fix / update
- [x] Improve existing feature

## What the PR does

PR is about #898 

古いOVRLipSyncへの依存をやめるPRです。

#898 で指摘したリップシンクそのものの安定性は解決しておらず、単にOculus Lipsync Unity Integration v29への乗り換えのみを行っています。

## How to confirm

- リリースされたv3.0.2と本PRが適用されたビルドに同一マイク入力を入れて同一のVRoidアバターでリップシンクを目視し、明らかに挙動が悪化したりしていないこと。
