### PR TITLE
「移動は常にダッシュ」を「移動はデフォルトでダッシュ」に変更して歩けるようにする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/GameInputBodyMotionController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/GameInputBodyMotionController.cs
@@ -44,8 +44,7 @@ namespace Baku.VMagicMirror
         private Vector2 _rawMoveInput;
         private Vector2 _rawLookAroundInput;
         private bool _isCrouching;
-        //NOTE: alwaysRun == trueのときはalwaysRunのほうが優先
-        private bool _isRunning;
+        private bool _isRunWalkToggleActive;
         private bool _gunFire;
         private Vector2 _moveInput;
         private Vector2 _lookAroundInput;
@@ -109,9 +108,9 @@ namespace Baku.VMagicMirror
                 .AddTo(this);
 
             Observable.Merge(
-                _sourceSet.Sources.Select(s => s.IsRunning)
+                _sourceSet.Sources.Select(s => s.IsRunWalkToggleActive)
                 )
-                .Subscribe(v => _isRunning = v)
+                .Subscribe(v => _isRunWalkToggleActive = v)
                 .AddTo(this);
             
             Observable.Merge(
@@ -223,7 +222,11 @@ namespace Baku.VMagicMirror
             _animator.SetFloat(MoveRight, _moveInput.x);
             _animator.SetFloat(MoveForward, _moveInput.y);
             _animator.SetBool(Crouch, _isCrouching);
-            _animator.SetBool(Run, _alwaysRun || _isRunning);
+            //NOTE: XORでも書けるが読み味がどっちもどっちなので…要は以下どっちかなら走るという事
+            // - 基本歩き + 「ダッシュ」ボタンがオン
+            // - 基本ダッシュ + 「歩く」ボタンがオフ
+            _animator.SetBool(Run, 
+                (!_alwaysRun && _isRunWalkToggleActive) || (_alwaysRun && !_isRunWalkToggleActive));
             _animator.SetBool(GunFire, _gunFire);
 
             _rootYaw = Mathf.SmoothDamp(

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/GamepadGameInputSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/GamepadGameInputSource.cs
@@ -14,7 +14,7 @@ namespace Baku.VMagicMirror.GameInput
         IObservable<Vector2> IGameInputSource.MoveInput => _moveInput;
         IObservable<Vector2> IGameInputSource.LookAroundInput => _lookAroundInput;
         IObservable<bool> IGameInputSource.IsCrouching => _isCrouching;
-        IObservable<bool> IGameInputSource.IsRunning => _isRunning;
+        IObservable<bool> IGameInputSource.IsRunWalkToggleActive => _isRunning;
         IObservable<bool> IGameInputSource.GunFire => _gunFire;
         IObservable<Unit> IGameInputSource.Jump => _jump;
         IObservable<Unit> IGameInputSource.Punch => _punch;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/IGameInputSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/IGameInputSource.cs
@@ -22,7 +22,8 @@ namespace Baku.VMagicMirror.GameInput
         /// </summary>
         IObservable<Vector2> LookAroundInput { get; }
         IObservable<bool> IsCrouching { get; }
-        IObservable<bool> IsRunning { get; }
+        //NOTE: I/Fの実装ではデフォルトが歩きか走りか考慮しないでOKで、切り替え指示が出てる…ということのみを通知する
+        IObservable<bool> IsRunWalkToggleActive { get; }
         IObservable<bool> GunFire { get; }
 
         IObservable<Unit> Jump { get; }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputSource.cs
@@ -18,7 +18,7 @@ namespace Baku.VMagicMirror.GameInput
         IObservable<Vector2> IGameInputSource.LookAroundInput => _lookAroundInput;
 
         IObservable<bool> IGameInputSource.IsCrouching => _isCrouching;
-        IObservable<bool> IGameInputSource.IsRunning => _isRunning;
+        IObservable<bool> IGameInputSource.IsRunWalkToggleActive => _isRunning;
         IObservable<bool> IGameInputSource.GunFire => _gunFire;
         IObservable<Unit> IGameInputSource.Jump => _jump;
         IObservable<Unit> IGameInputSource.Punch => _punch;

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -532,7 +532,8 @@ Setting applied when "Body Motion Style" is set to "Game Locomotion" mode.
     <sys:String x:Key="GameInputKeyAssign_Keyboard">Keyboard / Mouse</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Keyboard_Enable">Use Keyboard / Mouse</sys:String>
     
-    <sys:String x:Key="GameInputKeyAssign_Option_AlwaysRun">Always Run</sys:String>
+    <sys:String x:Key="GameInputKeyAssign_Option_AlwaysRun">Run by Default</sys:String>
+    <sys:String x:Key="GameInputKeyAssign_Option_AlwaysRun_Note">*When enabled, "Run" button works as "Walk"</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Option_AlwaysAim">Always Aim</sys:String>
 
     <sys:String x:Key="GameInputKeyAssign_Keyboard_Section">Keyboard:</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -536,7 +536,8 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Keyboard">キーボード・マウス</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Keyboard_Enable">キーボード・マウス入力を使用</sys:String>
     
-    <sys:String x:Key="GameInputKeyAssign_Option_AlwaysRun">移動は常にダッシュ</sys:String>
+    <sys:String x:Key="GameInputKeyAssign_Option_AlwaysRun">移動はデフォルトでダッシュ</sys:String>
+    <sys:String x:Key="GameInputKeyAssign_Option_AlwaysRun_Note">※オンの場合、かわりに「ダッシュ」ボタンで歩くようになります</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Option_AlwaysAim">つねに銃を構える</sys:String>
 
     <sys:String x:Key="GameInputKeyAssign_Action_None">(なし)</sys:String>

--- a/WPF/VMagicMirrorConfig/View/GameInput/KeyAssignPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/GameInput/KeyAssignPanel.xaml
@@ -112,8 +112,11 @@
                                     />
                     </StackPanel>
                     <CheckBox Content="{DynamicResource GameInputKeyAssign_Option_AlwaysRun}"
-                              Margin="10"
+                              Margin="10,10,10,5"
                               IsChecked="{Binding AlwaysRun.Value, Mode=TwoWay}"
+                              />
+                    <TextBlock Text="{DynamicResource GameInputKeyAssign_Option_AlwaysRun_Note}"
+                              Margin="20,0,25,10"
                               />
                 </StackPanel>
             </Border>


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #914 

「常にダッシュ」オプションを「デフォルトでダッシュ」に変更し、このオプションの状態でダッシュボタンを押すと逆に歩くようにしました。

## How to confirm

- [x] Editor + Gamepadで、「デフォルトでダッシュ」のオフ/オン時にダッシュボタンの押す/押さないを行い、計4種類の組み合わせの挙動がおかしくないこと
