### PR TITLE
Add Keyboard key assign for game input

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputKeyAssign.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputKeyAssign.cs
@@ -1,5 +1,5 @@
 using System;
-using UnityEngine;
+using System.Windows.Forms;
 
 namespace Baku.VMagicMirror.GameInput
 {
@@ -17,17 +17,30 @@ namespace Baku.VMagicMirror.GameInput
         public bool UseShiftRun = true;
         public bool UseSpaceJump = true;
 
-        //NOTE: 初期リリース時点では以下の値は使用せず、boolのフラグで指定できる限定的な処理だけを行う
-
-        public string JumpKeyCode = nameof(KeyCode.Space);
-        //雑記: しれっと書いてるがShiftはLeftShift / RightShiftを区別しない必要があり、意外と面倒
-        public string RunKeyCode = "Shift";
+        //NOTE: ShiftとSpaceは上記のフラグで設定される場合、下記のキーコードで指定しなくても適用されるのがto-be
+        //これは後方互換性、およびShiftキーの取り回しがちょっと面倒=KeysではLShiftとRShiftが別扱いされてるのが理由
+        public string JumpKeyCode = nameof(Keys.Space);
+        public string RunKeyCode = "";
         public string CrouchKeyCode = "";
 
         public string TriggerKeyCode = "";
         public string PunchKeyCode = "";
 
         public static KeyboardGameInputKeyAssign LoadDefault() => new KeyboardGameInputKeyAssign();
+
+        public void OverwriteKeyCodeIntToKeyName()
+        {
+            JumpKeyCode = ParseIntToKeyName(JumpKeyCode);
+            RunKeyCode = ParseIntToKeyName(RunKeyCode);
+            CrouchKeyCode = ParseIntToKeyName(CrouchKeyCode);
+            TriggerKeyCode = ParseIntToKeyName(TriggerKeyCode);
+            PunchKeyCode = ParseIntToKeyName(PunchKeyCode);
+        }
+
+        private static string ParseIntToKeyName(string key) =>
+            string.IsNullOrEmpty(key) ? "" : 
+            int.TryParse(key, out var value) ? ((Keys)value).ToString() : 
+            "";
     }    
 }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputSource.cs
@@ -191,6 +191,7 @@ namespace Baku.VMagicMirror.GameInput
             try
             {
                 var setting = JsonUtility.FromJson<KeyboardGameInputKeyAssign>(json);
+                setting.OverwriteKeyCodeIntToKeyName();
                 ApplyKeyAssign(setting);
             }
             catch (Exception ex)
@@ -230,21 +231,34 @@ namespace Baku.VMagicMirror.GameInput
 
         private void OnKeyDown(string key)
         {
-            if (_useShiftRun && 
-                (key == nameof(Keys.ShiftKey) || key == nameof(Keys.LShiftKey) || key == nameof(Keys.RShiftKey))
-                )
+            if ((_useShiftRun && (key == nameof(Keys.ShiftKey) || key == nameof(Keys.LShiftKey) || key == nameof(Keys.RShiftKey))) || 
+                (_keyAssign.RunKeyCode == key))
             {
                 _isRunning.Value = true;
-                //shiftはコレ以外の入力に使ってないはずなので無視
-                return;
             }
 
-            if (_useSpaceJump && key == nameof(Keys.Space))
+            if (_keyAssign.CrouchKeyCode == key)
+            {
+                _isCrouching.Value = true;
+            }
+            
+            if (_keyAssign.TriggerKeyCode == key)
+            {
+                _gunFire.Value = true;
+            }
+
+            if ((_useSpaceJump && key == nameof(Keys.Space)) || 
+                _keyAssign.JumpKeyCode == key)
             {
                 //Spaceもこの用途でのみ使うはず
                 _jump.OnNext(Unit.Default);
-                return;
             }
+
+            if (_keyAssign.PunchKeyCode == key)
+            {
+                _punch.OnNext(Unit.Default);
+            }
+
 
             if (_useWasdMove)
             {
@@ -268,12 +282,20 @@ namespace Baku.VMagicMirror.GameInput
 
         private void OnKeyUp(string key)
         {
-            if (_useShiftRun && 
-                (key == nameof(Keys.ShiftKey) || key == nameof(Keys.LShiftKey) || key == nameof(Keys.RShiftKey))
-               )
+            if ((_useShiftRun && (key == nameof(Keys.ShiftKey) || key == nameof(Keys.LShiftKey) || key == nameof(Keys.RShiftKey))) || 
+                (_keyAssign.RunKeyCode == key))
             {
                 _isRunning.Value = false;
-                return;
+            }
+
+            if (_keyAssign.CrouchKeyCode == key)
+            {
+                _isCrouching.Value = false;
+            }
+            
+            if (_keyAssign.TriggerKeyCode == key)
+            {
+                _gunFire.Value = false;
             }
 
             if (_useWasdMove)

--- a/WPF/VMagicMirrorConfig/Model/Entity/GameInputSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/GameInputSetting.cs
@@ -1,6 +1,8 @@
-﻿namespace Baku.VMagicMirrorConfig
-{
+﻿using System;
+using System.Windows.Input;
 
+namespace Baku.VMagicMirrorConfig
+{
     public enum GameInputStickAction
     {
         None,
@@ -92,6 +94,7 @@
         public bool UseShiftRun { get; set; } = true;
         public bool UseSpaceJump { get; set; } = true;
 
+        //NOTE: これらのxxxKeyCodeにはSystem.Windows.Forms.KeyをToStringしたものが入る。カラの場合、アサインが無いことを示す
         public string JumpKeyCode { get; set; } = "Space";
         public string RunKeyCode { get; set; } = "Shift";
         public string CrouchKeyCode { get; set; } = "C";
@@ -100,6 +103,48 @@
         public string PunchKeyCode { get; set; } = "";
 
         public static GameInputKeyboardKeyAssign LoadDefault() => new();
+
+        //Unityに投げつける用に前処理したデータを生成する
+        public GameInputKeyboardKeyAssign GetKeyCodeTranslatedData()
+        {
+            var result = new GameInputKeyboardKeyAssign()
+            {
+                UseMouseLookAround = UseMouseLookAround,
+                LeftClick = LeftClick,
+                RightClick = RightClick,
+                MiddleClick = MiddleClick,
+                UseWasdMove = UseWasdMove,
+                UseArrowKeyMove = UseArrowKeyMove,
+                UseShiftRun = UseShiftRun,
+                UseSpaceJump = UseSpaceJump,
+            };
+
+            result.JumpKeyCode = TranslateKeyCode(JumpKeyCode);
+            result.RunKeyCode = TranslateKeyCode(RunKeyCode);
+            result.CrouchKeyCode = TranslateKeyCode(CrouchKeyCode);
+            result.TriggerKeyCode = TranslateKeyCode(TriggerKeyCode);
+            result.PunchKeyCode = TranslateKeyCode(PunchKeyCode);
+
+            return result;
+        }
+
+        private static string TranslateKeyCode(string wpfKey)
+        {
+            if (string.IsNullOrEmpty(wpfKey))
+            {
+                return "";
+            }
+
+            if (!Enum.TryParse<Key>(wpfKey, out var key))
+            {
+                return "";
+            }
+
+            //渋い気もするが、このkの整数値をテキストで書き込む
+            // -> Unity側はこの整数値をWindows.Forms.Keyとして解釈する
+            var k = KeyInterop.VirtualKeyFromKey(key);
+            return k.ToString();
+        }
     }
 
 

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/GameInputSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/GameInputSettingModel.cs
@@ -227,24 +227,6 @@ namespace Baku.VMagicMirrorConfig
             KeyboardKeyAssignUpdated?.Invoke(this, new KeyboardKeyAssignUpdateEventArgs(KeyboardKeyAssign));
         }
 
-        private readonly List<string> _validatedCodesCache = new();
-        public string ValidateKeyCodes(string keyCodes)
-        {
-            _validatedCodesCache.Clear();
-            
-            var rawCodes = keyCodes.Split(',');
-            foreach (var code in rawCodes)
-            {
-                var res = GameInputKeyCodeValidator.TryValidate(code, out var validatedCode);
-                if (res != KeyCodeValidateResult.Failed)
-                {
-                    _validatedCodesCache.Add(validatedCode);
-                }
-            }
-
-            return string.Join(",", _validatedCodesCache);
-        }
-
         public void SetKeyAction(GameInputButtonAction action, string key)
         {
             var current = action switch

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -555,6 +555,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Keyboard_ArrowMove">矢印キーで移動</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Keyboard_ShiftRun">Shiftキーでダッシュ</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Keyboard_SpaceJump">Spaceキーでジャンプ</sys:String>
+    <sys:String x:Key="GameInputKeyAssign_Keyboard_AdvancedAssign">その他のキーアサイン:</sys:String>
 
     <sys:String x:Key="GameInputKeyAssign_Mouse_Section">マウス:</sys:String>
     <sys:String x:Key="GameInputKeyAssign_Mouse_UseLookAround">マウス移動で見回し</sys:String>

--- a/WPF/VMagicMirrorConfig/View/Code/TextKeyDownBehaviorUtil.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/TextKeyDownBehaviorUtil.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Baku.VMagicMirrorConfig.View
+{
+    static class TextKeyDownBehaviorUtil
+    {
+        public static void OnKeyDown(KeyEventArgs e, Action<Key> action)
+        {
+            if (e.Key == Key.Tab)
+            {
+                //タブはショートカットとしては認めず、ナビゲーション用の入力として流す
+                return;
+            }
+
+            if (e.Key == Key.LeftShift || e.Key == Key.RightShift ||
+                e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl || 
+                e.Key == Key.LeftAlt || e.Key == Key.RightAlt || 
+                e.Key == Key.LWin || e.Key == Key.RWin)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            //Lock系を含む、「さすがにそれは無いやろ」系のキーを無視
+            if (e.Key == Key.NumLock || e.Key == Key.CapsLock || e.Key == Key.PrintScreen)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            action(e.Key);
+            e.Handled = true;
+        }
+    }
+}

--- a/WPF/VMagicMirrorConfig/View/Code/TextPreviewKeyDownBehavior.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/TextPreviewKeyDownBehavior.cs
@@ -5,10 +5,7 @@ using System.Windows.Input;
 
 namespace Baku.VMagicMirrorConfig.View
 {
-    /// <summary>
-    /// Hot Keyの編集をするためのテキストボックスからKeyDown情報をコマンド的に送信するやつ
-    /// </summary>
-    public class TextKeyDownBehavior : Behavior<TextBox>
+    public class TextPreviewKeyDownBehavior : Behavior<TextBox>
     {
         public ICommand KeyDownCommand
         {
@@ -20,22 +17,21 @@ namespace Baku.VMagicMirrorConfig.View
             = DependencyProperty.RegisterAttached(
                 nameof(KeyDownCommand),
                 typeof(ICommand),
-                typeof(TextKeyDownBehavior)
+                typeof(TextPreviewKeyDownBehavior)
                 );
 
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.KeyDown += OnKeyDown;
+            AssociatedObject.PreviewKeyDown += OnKeyDown;
         }
 
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.KeyDown -= OnKeyDown;
+            AssociatedObject.PreviewKeyDown -= OnKeyDown;
         }
 
-        //NOTE: 必要ならpreviewにするのもあり
         private void OnKeyDown(object sender, KeyEventArgs e)
         {
             TextKeyDownBehaviorUtil.OnKeyDown(e, key =>

--- a/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
+++ b/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
@@ -19,9 +19,8 @@
         <TextBlock Grid.Column="0" Text="{Binding Label.Value}" />
 
         <TextBox Grid.Column="1"
-                Text="{Binding RegisteredKeyInput.Value, UpdateSourceTrigger=PropertyChanged}"
-                 HorizontalContentAlignment="Center"
-                 md:HintAssist.Hint="Press Key..."
+                Text="{Binding RegisteredKeyInput.Value}"
+                HorizontalContentAlignment="Center"
                 >
             <i:Interaction.Behaviors>
                 <view:TextKeyDownBehavior KeyDownCommand="{Binding KeyDownCommand}" />

--- a/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
+++ b/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
@@ -20,15 +20,18 @@
 
         <TextBox Grid.Column="1"
                 Text="{Binding RegisteredKeyInput.Value, UpdateSourceTrigger=PropertyChanged}"
+                 HorizontalContentAlignment="Center"
+                 md:HintAssist.Hint="Press Key..."
                 >
             <i:Interaction.Behaviors>
                 <view:TextKeyDownBehavior KeyDownCommand="{Binding KeyDownCommand}" />
             </i:Interaction.Behaviors>
         </TextBox>
         <TextBlock Grid.Column="1"
+                   HorizontalAlignment="Center"
                    IsHitTestVisible="False"
-                    Text="{Binding RegisteredKey.Value}"
-                    />
+                   Text="{Binding RegisteredKey.Value}"
+                   />
 
         <Button Grid.Column="2" Style="{StaticResource MaterialDesignFlatButton}" 
                 Width="30" Height="30"  Margin="0" Padding="0"

--- a/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
+++ b/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
@@ -23,7 +23,7 @@
                 HorizontalContentAlignment="Center"
                 >
             <i:Interaction.Behaviors>
-                <view:TextKeyDownBehavior KeyDownCommand="{Binding KeyDownCommand}" />
+                <view:TextPreviewKeyDownBehavior KeyDownCommand="{Binding KeyDownCommand}" />
             </i:Interaction.Behaviors>
         </TextBox>
         <TextBlock Grid.Column="1"

--- a/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
+++ b/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml
@@ -1,0 +1,39 @@
+﻿<UserControl x:Class="Baku.VMagicMirrorConfig.View.GameInputKeyAssignItem"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+             xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:view="clr-namespace:Baku.VMagicMirrorConfig.View"             
+             xmlns:vm="clr-namespace:Baku.VMagicMirrorConfig.ViewModel"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance vm:GameInputKeyAssignItemViewModel}"
+             d:DesignHeight="40" d:DesignWidth="450">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="100"/>
+            <ColumnDefinition Width="100"/>
+            <ColumnDefinition Width="40"/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Grid.Column="0" Text="{Binding Label.Value}" />
+
+        <TextBox Grid.Column="1"
+                Text="{Binding RegisteredKeyInput.Value, UpdateSourceTrigger=PropertyChanged}"
+                >
+            <i:Interaction.Behaviors>
+                <view:TextKeyDownBehavior KeyDownCommand="{Binding KeyDownCommand}" />
+            </i:Interaction.Behaviors>
+        </TextBox>
+        <TextBlock Grid.Column="1"
+                   IsHitTestVisible="False"
+                    Text="{Binding RegisteredKey.Value}"
+                    />
+
+        <Button Grid.Column="2" Style="{StaticResource MaterialDesignFlatButton}" 
+                Width="30" Height="30"  Margin="0" Padding="0"
+                Command="{Binding ClearInputCommand}">
+            <md:PackIcon Kind="Refresh"/>
+        </Button>
+    </Grid>
+</UserControl>

--- a/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml.cs
+++ b/WPF/VMagicMirrorConfig/View/GameInput/GameInputKeyAssignItem.xaml.cs
@@ -1,0 +1,9 @@
+﻿using System.Windows.Controls;
+
+namespace Baku.VMagicMirrorConfig.View
+{
+    public partial class GameInputKeyAssignItem : UserControl
+    {
+        public GameInputKeyAssignItem() => InitializeComponent();
+    }
+}

--- a/WPF/VMagicMirrorConfig/View/GameInput/KeyAssignPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/GameInput/KeyAssignPanel.xaml
@@ -11,7 +11,7 @@
              MinWidth="600"
              d:DataContext="{d:DesignInstance vm:KeyAssignViewModel}"
              d:DesignWidth="700"
-             d:DesignHeight="1100"
+             d:DesignHeight="1500"
              AllowDrop="True"
              >
     <UserControl.Resources>
@@ -345,6 +345,34 @@
                               IsChecked="{Binding UseSpaceJump.Value, Mode=TwoWay}"
                               IsEnabled="{Binding KeyboardEnabled.Value}"
                               />
+
+                    <TextBlock Text="{DynamicResource GameInputKeyAssign_Keyboard_AdvancedAssign}"
+                               Margin="25,15,25,5"
+                               />
+
+                    <ItemsControl ItemsSource="{Binding KeyAssigns}"
+                                  Margin="45,5"
+                                  HorizontalAlignment="Left">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type vm:GameInputKeyAssingInputViewModel}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="120"/>
+                                        <ColumnDefinition Width="240"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Label.Value}" />
+
+                                    <TextBox Grid.Column="1"
+                                             Text="{Binding Key.Value}"
+                                             >
+                                        <i:Interaction.Behaviors>
+                                            <view:TextKeyDownBehavior KeyDownCommand="{Binding KeyDownCommand}" />
+                                        </i:Interaction.Behaviors>
+                                    </TextBox>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
 
                     <TextBlock Text="{DynamicResource GameInputKeyAssign_Mouse_Section}"
                                Margin="10,15,5,5"

--- a/WPF/VMagicMirrorConfig/View/GameInput/KeyAssignPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/GameInput/KeyAssignPanel.xaml
@@ -354,22 +354,8 @@
                                   Margin="45,5"
                                   HorizontalAlignment="Left">
                         <ItemsControl.ItemTemplate>
-                            <DataTemplate DataType="{x:Type vm:GameInputKeyAssingInputViewModel}">
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="120"/>
-                                        <ColumnDefinition Width="240"/>
-                                    </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" Text="{Binding Label.Value}" />
-
-                                    <TextBox Grid.Column="1"
-                                             Text="{Binding Key.Value}"
-                                             >
-                                        <i:Interaction.Behaviors>
-                                            <view:TextKeyDownBehavior KeyDownCommand="{Binding KeyDownCommand}" />
-                                        </i:Interaction.Behaviors>
-                                    </TextBox>
-                                </Grid>
+                            <DataTemplate DataType="{x:Type vm:GameInputKeyAssignItemViewModel}">
+                                <view:GameInputKeyAssignItem />
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Input;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    public class GameInputKeyAssingInputViewModel
+    {
+        public GameInputKeyAssingInputViewModel(GameInputButtonAction action, string key)
+        {
+            _actionItem = GameInputButtonActionItemViewModel.AvailableItems.FirstOrDefault(item => item.Action == action)
+                ?? new GameInputButtonActionItemViewModel(GameInputButtonAction.None, "");
+
+            KeyDownCommand = new ActionCommand<object>(OnKeyDown);
+            SetKey(key);
+        }
+
+        //NOTE: nullになるのはアクションにキーが割当たってない状態
+        private Key? _key;
+
+        private readonly GameInputButtonActionItemViewModel _actionItem;
+        public GameInputButtonAction Action => _actionItem.Action;
+        public RProperty<string> Label => _actionItem.Label;
+
+        public RProperty<string> RegisteredKey { get; } = new RProperty<string>("");
+
+        public ActionCommand<object> KeyDownCommand { get; }
+
+        public event Action<string>? RegisteredKeyChanged;
+
+        public void SetKey(string key)
+        {
+            Key? nextKey = Enum.TryParse<Key>(key, out var result) ? result : null;
+            if (_key == nextKey)
+            {
+                return;
+            }
+
+            _key = nextKey;
+            RegisteredKey.Value = CreateRegisteredKeyString();
+        }
+
+        private void OnKeyDown(object? obj)
+        {
+            if (obj is not Key key)
+            {
+                return;
+            }
+
+            Key? nextKey = key;
+            if (key == Key.Delete || key == Key.Back)
+            {
+                nextKey = null;
+            }
+
+            if (_key == nextKey)
+            {
+                return;
+            }
+
+            _key = key;
+            RegisteredKey.Value = CreateRegisteredKeyString();
+            RegisteredKeyChanged?.Invoke(_key?.ToString() ?? "");
+        }
+
+        private string CreateRegisteredKeyString()
+        {
+            if (_key == null)
+            {
+                return "";
+            }
+
+            var key = _key.Value;
+
+            //ラクにケアできる範囲で、数字キーのみ区別する
+            if (key >= Key.NumPad0 && key <= Key.NumPad9)
+            {
+                return "Num" + ((int)key - (int)Key.NumPad0).ToString();
+            }
+
+            return new string(new char[] { KeyToStringUtil.GetCharFromKey(key) });
+        }
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
@@ -56,10 +56,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 return;
             }
 
-            LogOutput.Instance.Write($"key down in game input text, key={key}");
-
             Key? nextKey = key;
-            if (key is Key.None or Key.Delete or Key.Back)
+            if (key is Key.None or Key.Delete or Key.Back or Key.LeftAlt or Key.RightAlt)
             {
                 nextKey = null;
             }
@@ -69,7 +67,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 return;
             }
 
-            _key = key;
+            _key = nextKey;
             RegisteredKey.Value = CreateRegisteredKeyString();
             RegisteredKeyChanged?.Invoke(_key?.ToString() ?? "");
         }
@@ -92,7 +90,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 return "Num" + ((int)key - (int)Key.NumPad0).ToString();
             }
 
-            return new string(new char[] { KeyToStringUtil.GetCharFromKey(key) });
+            return key.ToString().ToUpper();
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
@@ -4,15 +4,22 @@ using System.Windows.Input;
 
 namespace Baku.VMagicMirrorConfig.ViewModel
 {
-    public class GameInputKeyAssingInputViewModel
+    public class GameInputKeyAssignItemViewModel
     {
-        public GameInputKeyAssingInputViewModel(GameInputButtonAction action, string key)
+        public GameInputKeyAssignItemViewModel(GameInputButtonAction action, string key)
         {
             _actionItem = GameInputButtonActionItemViewModel.AvailableItems.FirstOrDefault(item => item.Action == action)
                 ?? new GameInputButtonActionItemViewModel(GameInputButtonAction.None, "");
 
             KeyDownCommand = new ActionCommand<object>(OnKeyDown);
+            ClearInputCommand = new ActionCommand(ClearInput);
             SetKey(key);
+
+            //入力文字列は常にカラに戻す。入力欄は単にキー入力を受けるためだけに使われる
+            RegisteredKeyInput.PropertyChanged += (_, __) =>
+            {
+                RegisteredKeyInput.Value = "";
+            };
         }
 
         //NOTE: nullになるのはアクションにキーが割当たってない状態
@@ -22,9 +29,11 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public GameInputButtonAction Action => _actionItem.Action;
         public RProperty<string> Label => _actionItem.Label;
 
+        public RProperty<string> RegisteredKeyInput { get; } = new RProperty<string>("");
         public RProperty<string> RegisteredKey { get; } = new RProperty<string>("");
 
         public ActionCommand<object> KeyDownCommand { get; }
+        public ActionCommand ClearInputCommand { get; }
 
         public event Action<string>? RegisteredKeyChanged;
 
@@ -47,8 +56,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 return;
             }
 
+            LogOutput.Instance.Write($"key down in game input text, key={key}");
+
             Key? nextKey = key;
-            if (key == Key.Delete || key == Key.Back)
+            if (key is Key.None or Key.Delete or Key.Back)
             {
                 nextKey = null;
             }
@@ -62,6 +73,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             RegisteredKey.Value = CreateRegisteredKeyString();
             RegisteredKeyChanged?.Invoke(_key?.ToString() ?? "");
         }
+
+        //NOTE: 横着でこう書いてるが、別にOnKeyDownに帰着させないでも動くならOK
+        private void ClearInput() => OnKeyDown(Key.None);
 
         private string CreateRegisteredKeyString()
         {

--- a/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/KeyAssignViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/KeyAssignViewModel.cs
@@ -66,7 +66,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 () => UrlNavigate.Open(LocalizedString.GetString("URL_docs_game_input"))
                 );
 
-            KeyAssigns = Array.Empty<GameInputKeyAssingInputViewModel>();
+            KeyAssigns = Array.Empty<GameInputKeyAssignItemViewModel>();
 
             if (!IsInDesignMode)
             {
@@ -91,7 +91,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                         (GameInputButtonAction.Punch, _model.KeyboardKeyAssign.PunchKeyCode),
                     }.Select(pair =>
                     {
-                        var vm = new GameInputKeyAssingInputViewModel(pair.action, pair.keyCode);
+                        var vm = new GameInputKeyAssignItemViewModel(pair.action, pair.keyCode);
                         vm.RegisteredKeyChanged += key => _model.SetKeyAction(pair.action, key);
                         return vm;
                     })
@@ -142,7 +142,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand LoadSettingFileCommand { get; }
         public ActionCommand OpenDocUrlCommand { get; }
 
-        public GameInputKeyAssingInputViewModel[] KeyAssigns { get; }
+        public GameInputKeyAssignItemViewModel[] KeyAssigns { get; }
 
         public GameInputStickActionItemViewModel[] StickActions => GameInputStickActionItemViewModel.AvailableItems;
         public GameInputButtonActionItemViewModel[] ButtonActions => GameInputButtonActionItemViewModel.AvailableItems;


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #918 

TextBoxを選択して使いたいキーを押すとアサインされる。
Shift/Alt/Ctrlなどの補助キーは対象外とする。

- v3.1.1で導入済みのチェックボックスは併設する。つまり、ShiftダッシュとSpaceジャンプは個別のキーアサインとは別に残る(し、前後左右についてはWASD and/or ARROWの選択しかない状態になる…というのもそのまま。
    - Shiftについては、「Shiftでダッシュ」でシフトキーが使える挙動はそのままキープ

## How to confirm

- [x] A~Zキーを走り、しゃがみ、ジャンプ、銃撃、パンチに割り当てられること
- [x] Spaceキーや数字キー(テンキーとそれ以外)が利用可能
