### PR TITLE
ウィンドウ位置の復元手順を2点修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -522,6 +522,7 @@ namespace Baku.VMagicMirror
         private const string InitialPositionYKey = "InitialPositionY";
         private const string InitialWidthKey = "InitialWidth";
         private const string InitialHeightKey = "InitialHeight";
+        private const string SavedWindowSizeReferenceDpi = "SavedWindowSizeReferenceDpi";
 
         private Vector2Int _prevWindowPosition = Vector2Int.zero;
         
@@ -534,8 +535,8 @@ namespace Baku.VMagicMirror
             if (PlayerPrefs.HasKey(InitialPositionXKey) && PlayerPrefs.HasKey(InitialPositionYKey))
             {
 #if !UNITY_EDITOR
-                int x = PlayerPrefs.GetInt(InitialPositionXKey);
-                int y = PlayerPrefs.GetInt(InitialPositionYKey);
+                var x = PlayerPrefs.GetInt(InitialPositionXKey);
+                var y = PlayerPrefs.GetInt(InitialPositionYKey);
                 _prevWindowPosition = new Vector2Int(x, y);
                 SetUnityWindowPosition(x, y);
 #endif
@@ -549,8 +550,18 @@ namespace Baku.VMagicMirror
 #endif
             }
 
-            int width = PlayerPrefs.GetInt(InitialWidthKey, 0);
-            int height = PlayerPrefs.GetInt(InitialHeightKey, 0);
+            var width = PlayerPrefs.GetInt(InitialWidthKey, 0);
+            var height = PlayerPrefs.GetInt(InitialHeightKey, 0);
+            var dpi = PlayerPrefs.GetFloat(SavedWindowSizeReferenceDpi, 0f);
+            if (dpi > 0f)
+            {
+                var currentDpi = Screen.dpi;
+                //正値になってても極端な値はいちおう弾きたい
+                var dpiFactor = Mathf.Clamp(currentDpi / dpi, 0.1f, 10f);
+                width = (int)(width * dpiFactor);
+                height = (int)(height * dpiFactor);
+            }
+
             if (width > 100 && height > 100)
             {
 #if !UNITY_EDITOR
@@ -586,6 +597,7 @@ namespace Baku.VMagicMirror
                 PlayerPrefs.SetInt(InitialPositionYKey, rect.top);
                 PlayerPrefs.SetInt(InitialWidthKey, rect.right - rect.left);
                 PlayerPrefs.SetInt(InitialHeightKey, rect.bottom - rect.top);
+                PlayerPrefs.SetFloat(SavedWindowSizeReferenceDpi, Screen.dpi);
 #endif
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -607,17 +607,18 @@ namespace Baku.VMagicMirror
 
         private bool CheckWindowPositionValidity(RECT selfRect, List<RECT> monitorRects)
         {
-            //ウィンドウ位置を正常値とみなす条件: ウィンドウの左上、右上、中央の3点全てが、どれかのモニターの内側に含まれる
+            //ウィンドウ位置を正常とみなす条件: ウィンドウの「(左上 or 右上) + 中央上 + 中央」が、どれかのモニターの内側に含まれる
             var leftTop = new Vector2Int(selfRect.left, selfRect.top);
             var rightTop = new Vector2Int(selfRect.right, selfRect.top);
+            var centerTop = new Vector2Int((selfRect.left + selfRect.right) / 2, selfRect.top);
             var center = new Vector2Int(
                 (selfRect.left + selfRect.right) / 2,
                 (selfRect.top + selfRect.bottom) / 2
             );
 
             return
-                IsInsideSomeRect(leftTop, monitorRects) &&
-                IsInsideSomeRect(rightTop, monitorRects) &&
+                (IsInsideSomeRect(leftTop, monitorRects) || IsInsideSomeRect(rightTop, monitorRects)) &&
+                IsInsideSomeRect(centerTop, monitorRects) &&
                 IsInsideSomeRect(center, monitorRects);
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -551,7 +551,8 @@ namespace Baku.VMagicMirror
 #endif
             }
 
-            //モニター間でDPI差がある環境では、ウィンドウが完全に移動するまで待つ必要がある
+            //前回起動時と同じモニター内にウィンドウを配置し終わってからサイズを適用するために待つ。
+            //こうしないと、モニター間のDPI差がある環境で再起動のたびにウィンドウサイズがずれてしまう
             await UniTask.DelayFrame(6, cancellationToken: cancellationToken);
             
             var width = PlayerPrefs.GetInt(InitialWidthKey, 0);


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #933 

fixed #939

## How to confirm

解像度倍率が異なるモニター2枚(メイン:右、サブ:左)が並んだ環境 + buildで確認し、

1. 以下の条件でVMMを終了/再起動すると、同一ディスプレイ、同一位置、同一サイズでウィンドウが配置されること。

- [x] メインディスプレイの右下にキャラクターウィンドウを配置し、ウィンドウの中央はモニター内に収まるが、ウィンドウの右上はモニター領域からはみ出す
- [x] メインディスプレイの左下にキャラクターウィンドウを配置し、ウィンドウの中央はモニター内に収まる。ウィンドウの左上はメインディスプレイではなく、サブディスプレイ上に映る
- [x] サブディスプレイの右下にキャラクターウィンドウを配置し、ウィンドウの中央はモニター内に収まるが、ウィンドウの右上端はメインディスプレイ側にはみ出す
- [x] サブディスプレイの左下にキャラクターウィンドウを配置し、ウィンドウの中央はモニター内に収まるが、ウィンドウの左上端がモニター領域からはみ出す

2. 以下の条件でVMMを終了/再起動すると、メインディスプレイ側でウィンドウ全体がモニター内に収まるような配置にキャラクターウィンドウが戻されること。

- [x] メインディスプレイの右下にキャラクターウィンドウを配置し、ウィンドウの中央がモニターの下端をはみ出すよう下にウィンドウを配置
- [x] メインディスプレイの右下にキャラクターウィンドウを配置し、ウィンドウの中央がモニターの右端をはみ出すよう右にウィンドウを配置
- [x] サブディスプレイの左下にキャラクターウィンドウを配置し、ウィンドウの中央がモニターの下端をはみ出すよう下にウィンドウを配置
- [x] サブディスプレイの左下にキャラクターウィンドウを配置し、ウィンドウの中央がモニターの左端をはみ出すよう左にウィンドウを配置

## Note

- Delayによる見栄えの悪影響は目視では体感できなかったため、無視できる程度の問題であるとみなしています。
- ウィンドウ位置のValidityを判定する前に更にDelayを挟むほうが安定するかもしれませんが、まあそこまでせんでも…ということで省いています。
- #939 には`Screen.dpi`を使った改修方法の案が記載されていますが、この方式は期待通りに動かなかったためボツ案としています。