### PR TITLE
Feature/support modifier key for game key input

### DIFF
--- a/WPF/VMagicMirrorConfig/View/Code/TextKeyDownBehaviorUtil.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/TextKeyDownBehaviorUtil.cs
@@ -5,7 +5,7 @@ namespace Baku.VMagicMirrorConfig.View
 {
     static class TextKeyDownBehaviorUtil
     {
-        public static void OnKeyDown(KeyEventArgs e, Action<Key> action)
+        public static void OnKeyDown(KeyEventArgs e, Action<Key> action, bool fireOnBasicModifierKeys = false)
         {
             if (e.Key == Key.Tab)
             {
@@ -13,13 +13,16 @@ namespace Baku.VMagicMirrorConfig.View
                 return;
             }
 
-            if (e.Key == Key.LeftShift || e.Key == Key.RightShift ||
-                e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl || 
-                e.Key == Key.LeftAlt || e.Key == Key.RightAlt || 
-                e.Key == Key.LWin || e.Key == Key.RWin)
+            if (!fireOnBasicModifierKeys)
             {
-                e.Handled = true;
-                return;
+                if (e.Key == Key.LeftShift || e.Key == Key.RightShift ||
+                    e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl ||
+                    e.Key == Key.LeftAlt || e.Key == Key.RightAlt ||
+                    e.Key == Key.LWin || e.Key == Key.RWin)
+                {
+                    e.Handled = true;
+                    return;
+                }
             }
 
             //Lock系を含む、「さすがにそれは無いやろ」系のキーを無視

--- a/WPF/VMagicMirrorConfig/View/Code/TextPreviewKeyDownBehavior.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/TextPreviewKeyDownBehavior.cs
@@ -40,7 +40,7 @@ namespace Baku.VMagicMirrorConfig.View
                 {
                     KeyDownCommand.Execute(key);
                 }
-            });
+            }, true);
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
@@ -91,7 +91,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 return "Num" + ((int)key - (int)Key.NumPad0).ToString();
             }
 
-            return key.ToString().ToUpper();
+            //アルファベットのキーは大文字にするが、それ以外はそのまま
+            var value = key.ToString();
+            return value.Length == 1 ? value.ToUpper() : value;
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/KeyAssign/GameInputKeyboardKeyAssignItemViewModel.cs
@@ -57,7 +57,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             }
 
             Key? nextKey = key;
-            if (key is Key.None or Key.Delete or Key.Back or Key.LeftAlt or Key.RightAlt)
+            if (key is Key.None or Key.Delete or Key.Back)
             {
                 nextKey = null;
             }
@@ -67,6 +67,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 return;
             }
 
+            //NOTE: (Left|Right)(Alt|Ctrl|Shift|Win)が入る事がある。はず。
             _key = nextKey;
             RegisteredKey.Value = CreateRegisteredKeyString();
             RegisteredKeyChanged?.Invoke(_key?.ToString() ?? "");

--- a/WPF/VMagicMirrorTest/ApiBehavior/KeyInteropTests.cs
+++ b/WPF/VMagicMirrorTest/ApiBehavior/KeyInteropTests.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using System.Windows.Input;
+
+namespace Baku.VMagicMirror.Test.ApiBehavior
+{
+    public class KeyInteropTests
+    {
+        [Test]
+        public void VirtualKeyFromKey_アルファベットは普通に通る()
+        {
+            //NOTE: 65 = Windows.Forms.Keys.A
+            const int Start = 65;
+            for (var i = 0; i < 26; i++)
+            {
+                var k = KeyInterop.VirtualKeyFromKey(Key.A + i);
+                Assert.AreEqual(k, Start + i);
+            }
+        }
+
+        [TestCase(Key.LWin, 91)]
+        [TestCase(Key.RWin, 92)]
+        [TestCase(Key.LeftShift, 160)]
+        [TestCase(Key.RightShift, 161)]
+        [TestCase(Key.LeftCtrl, 162)]
+        [TestCase(Key.RightCtrl, 163)]
+        [TestCase(Key.LeftAlt, 164)]
+        [TestCase(Key.RightAlt, 165)]
+        [Test]
+        public void VirtualKeyFromKey_特殊なキーが想定通りにマップされる(Key key, int num)
+        {
+            var k = KeyInterop.VirtualKeyFromKey(key);
+            Assert.AreEqual(num, k);
+        }
+    }
+}


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #942 

ゲーム入力のキー割り当てで(L/R)(Shift/Ctrl/Win)キーに対応しました。

意図した制約ではあったものの、ユーザーから見るとバグに見えてそうなため、バグ修正扱いとします。

※Altも対応したかったものの、雑なfixでは治らなさそうだったので対応外にしています。

## How to confirm

- LeftCtrl / LeftShift / LWinが指定できる
- 指定したキーが実際に使える
- アプリケーションの終了/再開をしても設定が保持される
