### PR TITLE
アンチエイリアス(MSAA)をサポート

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/AntiAliasSettingSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/AntiAliasSettingSetter.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.Rendering.PostProcessing;
+
+namespace Baku.VMagicMirror
+{
+    public class AntiAliasSettingSetter : PresenterBase
+    {
+        private readonly Camera _mainCamera;
+        private readonly IMessageReceiver _receiver;
+        private PostProcessLayer _postProcessLayer;
+        
+        public AntiAliasSettingSetter(Camera mainCamera, IMessageReceiver receiver)
+        {
+            _mainCamera = mainCamera;
+            _receiver = receiver;
+        }
+
+        public override void Initialize()
+        {
+            _postProcessLayer = _mainCamera.GetComponent<PostProcessLayer>();
+            _receiver.AssignCommandHandler(
+                VmmCommands.SetAntiAliasStyle, 
+                command => SetAntiAliasStyle(command.ToInt())
+                );
+        }
+        
+        private void SetAntiAliasStyle(int value)
+        {
+            if (value < 0 || value > (int)AntiAliasStyles.High)
+            {
+                return;
+            }
+
+            var style = (AntiAliasStyles)value;
+
+            _postProcessLayer.antialiasingMode = style == AntiAliasStyles.None
+                ? PostProcessLayer.Antialiasing.None
+                : PostProcessLayer.Antialiasing.SubpixelMorphologicalAntialiasing;
+
+            _postProcessLayer.subpixelMorphologicalAntialiasing.quality = style switch
+            {
+                AntiAliasStyles.High => SubpixelMorphologicalAntialiasing.Quality.High,
+                AntiAliasStyles.Mid => SubpixelMorphologicalAntialiasing.Quality.Medium,
+                _ => SubpixelMorphologicalAntialiasing.Quality.Low
+            };
+        }
+    }
+
+    public enum AntiAliasStyles
+    {
+        None = 0,
+        Low = 1,
+        Mid = 2,
+        High = 3,
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/AntiAliasSettingSetter.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/AntiAliasSettingSetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b20c8f4cfd854894a8b2618003e99291
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/EnvironmentInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/EnvironmentInstaller.cs
@@ -17,6 +17,8 @@ namespace Baku.VMagicMirror.Installer
             container.Bind<PostProcessLayer>().FromMethod(_ => GetComponent<PostProcessLayer>()).AsCached();
             container.BindInterfacesTo<CameraFovController>().AsSingle();
             container.Bind<CameraUtilWrapper>().AsSingle();
+
+            container.BindInterfacesTo<AntiAliasSettingSetter>().AsSingle();
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -150,6 +150,7 @@
 
         // Image Quality
         public const string SetImageQuality = nameof(SetImageQuality);
+        public const string SetAntiAliasStyle = nameof(SetAntiAliasStyle);
         public const string SetHalfFpsMode = nameof(SetHalfFpsMode);
 
         // Lighting 

--- a/VMagicMirror/ProjectSettings/QualitySettings.asset
+++ b/VMagicMirror/ProjectSettings/QualitySettings.asset
@@ -201,7 +201,7 @@ QualitySettings:
     skinWeights: 255
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 4
+    antiAliasing: 8
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 0

--- a/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
@@ -12,6 +12,7 @@
 
         #region Image Quality
 
+        public int AntiAliasStyle { get; set; } = 0;
         public bool HalfFpsMode { get; set; } = false;
         public bool UseFrameReductionEffect { get; set; } = false;
         
@@ -61,5 +62,13 @@
 
         #endregion
 
+    }
+
+    public enum AntiAliasStyles
+    {
+        None = 0,
+        Low = 1,
+        Mid = 2,
+        High = 3,
     }
 }

--- a/WPF/VMagicMirrorConfig/Model/Entity/WindowSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/WindowSetting.cs
@@ -26,7 +26,6 @@
         public int SpoutResolutionType { get; set; } = 0;
     }
 
-    //NOTE: 「概念的にそうだから」という事で定義してるが、実際には使ってない
     public enum SpoutResolutionType
     {
         SameAsWindow = 0,

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -258,6 +258,7 @@ namespace Baku.VMagicMirrorConfig
         /// <returns></returns>
         public Message GetQualitySettingsInfo() => NoArg();
         public Message SetImageQuality(string name) => WithArg(name);
+        public Message SetAntiAliasStyle(int style) => WithArg(style);
         public Message SetHalfFpsMode(bool enable) => WithArg(enable);
         public Message UseFrameReductionEffect(bool enable) => WithArg(enable);
 

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -18,6 +18,7 @@ namespace Baku.VMagicMirrorConfig
             var factory = MessageFactory.Instance;
 
             //エフェクト関係は設定項目がシンプルなため、例外はほぼ無い(色関係のメッセージ送信がちょっと特殊なくらい)
+            AntiAliasStyle = new RProperty<int>(s.AntiAliasStyle, i => SendMessage(factory.SetAntiAliasStyle(i)));
             HalfFpsMode = new RProperty<bool>(s.HalfFpsMode, v => SendMessage(factory.SetHalfFpsMode(v)));
             UseFrameReductionEffect = new RProperty<bool>(
                 s.UseFrameReductionEffect, v => SendMessage(factory.UseFrameReductionEffect(v)));
@@ -55,6 +56,7 @@ namespace Baku.VMagicMirrorConfig
 
         #region Image Quality
 
+        public RProperty<int> AntiAliasStyle { get; }
         public RProperty<bool> HalfFpsMode { get; }
         public RProperty<bool> UseFrameReductionEffect { get; }
 

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -394,6 +394,11 @@ Translate (2 way):
     
     <sys:String x:Key="ImageQuality">Image Quality</sys:String>
     <sys:String x:Key="ImageQuality_CurrentQuality">Quality</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias">Anti Alias</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_None">Off</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_Low">Low</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_Mid">Mid</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_High">High</sys:String>
     <sys:String x:Key="ImageQuality_HalfFpsMode">Half FPS (Medium or higher quality)</sys:String>
     <sys:String x:Key="ImageQuality_UseBoneFrameReduction">Low FPS for Bone Motion</sys:String>
     

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -393,8 +393,13 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Effect_Header">エフェクト</sys:String>       
 
     <sys:String x:Key="ImageQuality">画質</sys:String>
-    <sys:String x:Key="ImageQuality_CurrentQuality">現在の設定</sys:String>
+    <sys:String x:Key="ImageQuality_CurrentQuality">ベースの画質</sys:String>
     <sys:String x:Key="ImageQuality_HalfFpsMode">FPSを半減 (Medium以上で有効)</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias">アンチエイリアス</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_None">オフ</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_Low">Low</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_Mid">Mid</sys:String>
+    <sys:String x:Key="ImageQuality_AntiAlias_High">High</sys:String>
     <sys:String x:Key="ImageQuality_UseBoneFrameReduction">ボーンのみ低FPS化</sys:String>
 
     <sys:String x:Key="Light">ライト</sys:String>

--- a/WPF/VMagicMirrorConfig/View/Code/Converter/AntiAliasStyleToTextConverter.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/Converter/AntiAliasStyleToTextConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Baku.VMagicMirrorConfig.View
+{
+    public class AntiAliasStyleToTextConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not AntiAliasStyles style)
+            {
+                return Binding.DoNothing;
+            }
+
+            return style switch
+            {
+                AntiAliasStyles.None => LocalizedString.GetString("ImageQuality_AntiAlias_None"),
+                AntiAliasStyles.Low => LocalizedString.GetString("ImageQuality_AntiAlias_Low"),
+                AntiAliasStyles.Mid => LocalizedString.GetString("ImageQuality_AntiAlias_Mid"),
+                AntiAliasStyles.High => LocalizedString.GetString("ImageQuality_AntiAlias_High"),
+                _ => "",
+            };
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+}

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -15,6 +15,7 @@
     </UserControl.DataContext>
     <UserControl.Resources>
         <view:WhiteSpaceStringToNullConverter x:Key="WhiteSpaceStringToNullConverter"/>
+        <view:AntiAliasStyleToTextConverter x:Key="AntiAliasStyleToTextConverter"/>
         <Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
             <Setter Property="Margin" Value="20,5"/>
         </Style>
@@ -66,6 +67,28 @@
                                   />
                     </Grid>
 
+                    <Grid Margin="0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="100"/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0"
+                                   Text="{DynamicResource ImageQuality_AntiAlias}"/>
+
+                        <ComboBox Grid.Column="1"
+                                  Margin="5,0"
+                                  ItemsSource="{Binding AvailableAntiAliasStyle}"
+                                  SelectedItem="{Binding AntiAliasStyle.Value}"
+                                  md:HintAssist.Hint="Choose..."
+                                  >
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Path={}, Converter={StaticResource AntiAliasStyleToTextConverter}}"/>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </Grid>
                     <CheckBox Margin="10,5"
                               Content="{DynamicResource ImageQuality_HalfFpsMode}"
                               IsChecked="{Binding HalfFpsMode.Value}"

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -22,6 +22,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             _model = model;
             _imageQuality = imageQuality;
 
+            AntiAliasStyle = new RProperty<AntiAliasStyles>(
+                GetAntiAliasStyle(_model.AntiAliasStyle.Value)
+                );
+
             ResetLightSettingCommand = new ActionCommand(
                 () => SettingResetUtils.ResetSingleCategoryAsync(async () =>
                 {
@@ -41,6 +45,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
             if (!IsInDesignMode)
             {
+                model.AntiAliasStyle.AddWeakEventHandler(ApplyAntiAliasStyle);
+
                 model.LightR.AddWeakEventHandler(UpdateLightColor);
                 model.LightG.AddWeakEventHandler(UpdateLightColor);
                 model.LightB.AddWeakEventHandler(UpdateLightColor);
@@ -56,11 +62,39 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         public RProperty<string> ImageQuality => _imageQuality.ImageQuality;
         public ReadOnlyObservableCollection<string> ImageQualityNames => _imageQuality.ImageQualityNames;
+
+        public RProperty<AntiAliasStyles> AntiAliasStyle { get; }
+        public AntiAliasStyles[] AvailableAntiAliasStyle { get; } = new[]
+        {
+            AntiAliasStyles.None,
+            AntiAliasStyles.Low,
+            AntiAliasStyles.Mid,
+            AntiAliasStyles.High,
+        };
+
         public RProperty<bool> HalfFpsMode => _model.HalfFpsMode;
         public RProperty<bool> UseFrameReductionEffect => _model.UseFrameReductionEffect;
 
         void UpdateLightColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(LightColor));
         void UpdateBloomColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(BloomColor));
+
+        void ApplyAntiAliasStyle(object? sender, PropertyChangedEventArgs e) 
+            => AntiAliasStyle.Value = GetAntiAliasStyle(_model.AntiAliasStyle.Value);
+
+        void NotifyAntiAliasStyleChanged(object? sender, PropertyChangedEventArgs e)
+            => _model.AntiAliasStyle.Value = (int)AntiAliasStyle.Value;
+
+        static AntiAliasStyles GetAntiAliasStyle(int value)
+        {
+            if (value >= 0 && value <= (int)AntiAliasStyles.High)
+            {
+                return (AntiAliasStyles)value;
+            }
+            else
+            {
+                return AntiAliasStyles.None;
+            }
+        }
 
         #region Light
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -45,6 +45,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
             if (!IsInDesignMode)
             {
+                AntiAliasStyle.AddWeakEventHandler(NotifyAntiAliasStyleChanged);
                 model.AntiAliasStyle.AddWeakEventHandler(ApplyAntiAliasStyle);
 
                 model.LightR.AddWeakEventHandler(UpdateLightColor);


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature

## What the PR does

fixed #941

- 画質設定の一環としてアンチエイリアスを有効にできるようにしました。
- Ultra画質のアンチエイリアスが強めにかかるようにしました。

補足

- 同じPost Process LayerのAAでもFXAAやTAAでは透過表示が正しく動かなくなるため、消去法でMSAAを採用しています。
- MSAAは重たいこと、および後方互換性を踏まえて、デフォルトでは無効にしています。

## How to confirm

- [x] Editor + buildしたWPFで、GUI側の設定を改変したときEditor側のPost Process Layerに変更反映される
- [x] ビルドを用いたとき、背景を透過し、アンチエイリアスが有効/無効いずれでもおかしくならない
