### PR TITLE
Fix HotKey enable UI translation

### DIFF
--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -499,6 +499,7 @@ Please test by typing "joy".</sys:String>
     <sys:String x:Key="Hotkey_Instruction" xml:space="preserve">This tab support hotkey (shortcut) edit.
 Input favorite key combination in text area.
 *You can disable hot key temporary, to prevent key input conflict with other foreground app.</sys:String>
+    <sys:String x:Key="Hotkey_Enable">Enable Hot Key</sys:String>
     <sys:String x:Key="Hotkey_Reset">Reset to Default</sys:String>
     <sys:String x:Key="Hotkey_Invalid_Key_Notice">*Failed to register key, try another keys.</sys:String>
 

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/HotKeySettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/HotKeySettingPanel.xaml
@@ -53,7 +53,7 @@
                     Content="{DynamicResource Hotkey_Reset}"
                     />
 
-            <CheckBox Content="Hot Keyを有効化"
+            <CheckBox Content="{DynamicResource Hotkey_Enable}"
                       IsChecked="{Binding EnableHotKey.Value}"
                       />
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #952 

## How to confirm

- ビルドで日本語/英語設定にしたとき、該当UIがそれぞれ「Hot Keyを有効化 / Enable Hot Key」という表記になる

