### PR TITLE
Disable camera-independent head motion after certain time elapsed

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/Jitter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/Jitter.cs
@@ -28,6 +28,8 @@ namespace Baku.VMagicMirror
         public Quaternion CurrentRotation { get; private set; } = Quaternion.identity;
         
         private float _count = 0.0f;
+        
+        public bool ForceGoalZero { get; set; }
 
         public void Reset()
         {
@@ -45,13 +47,20 @@ namespace Baku.VMagicMirror
             if (_count < 0)
             {
                 _count = Random.Range(ChangeTimeMin, ChangeTimeMax);
-                var goalEuler = new Vector3(
-                    Random.Range(-AngleRange.x, +AngleRange.x),
-                    Random.Range(-AngleRange.y, +AngleRange.y), 
-                    UseZAngle ? Random.Range(-AngleRange.z, +AngleRange.z) : 0f
+                if (ForceGoalZero)
+                {
+                    _goalRotationEuler = Vector3.zero;
+                }
+                else
+                {
+                    var goalEuler = new Vector3(
+                        Random.Range(-AngleRange.x, +AngleRange.x),
+                        Random.Range(-AngleRange.y, +AngleRange.y), 
+                        UseZAngle ? Random.Range(-AngleRange.z, +AngleRange.z) : 0f
                     );
-                _goalRotationEuler = goalEuler;
-                JitterTargetEulerUpdated?.Invoke(goalEuler);
+                    _goalRotationEuler = goalEuler;
+                }
+                JitterTargetEulerUpdated?.Invoke(_goalRotationEuler);
             }
 
             //ゴール自体をLerpする: ゴールが急にジャンプすると力学ライクな計算してもカクカクしちゃうので


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #960

入力が全くない状態で多少動く事について、動いてる理由がピンと来なくてネガのほうが大きそうなのでやめる…というPRです。

revertする可能性も多少ありますが、単に変更をrevertするよりは退屈ポーズが入るとかの方向で改修する可能性があります。

## How to confirm

マイク入力で頭が動く状態にしたあと、マイク入力をやめて十数秒待つと、アバターの頭が正面向きに戻って特に動かなくなること

