### PR TITLE
Fix condition to show particle effect when using arcade stick mode

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
@@ -97,8 +97,11 @@ namespace Baku.VMagicMirror.IK
                 if (dependency.Config.RightTarget.Value == HandTargetType.ArcadeStick)
                 {
                     dependency.Reactions.ArcadeStickFinger.ButtonDown(key);
-                    var (pos, rot) = _stickProvider.GetRightHandRaw(key);
-                    dependency.Reactions.ParticleStore.RequestArcadeStickParticleStart(pos, rot);
+                    if (CheckKeySupportReactionEffect(key))
+                    {
+                        var (pos, rot) = _stickProvider.GetRightHandRaw(key);
+                        dependency.Reactions.ParticleStore.RequestArcadeStickParticleStart(pos, rot);
+                    }
                 }
             };
 
@@ -119,7 +122,17 @@ namespace Baku.VMagicMirror.IK
                 }
             };
         }
-        
+
+        private bool CheckKeySupportReactionEffect(GamepadKey key)
+        {
+            //NOTE: 意図はコメントアウトしてるほうのが近いが、数値比較のほうがシンプルなので…
+            return key >= GamepadKey.A && key <= GamepadKey.LTrigger;
+            // return 
+            //     key is GamepadKey.A || key is GamepadKey.B || key is GamepadKey.X || key is GamepadKey.Y ||
+            //     key is GamepadKey.LTrigger || key is GamepadKey.RTrigger || 
+            //     key is GamepadKey.LShoulder || key is GamepadKey.RShoulder;
+        }
+
         public override void Start()
         {
             //NOTE: 初期値が原点とかだと流石にキツいので、値を拾わせておく

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
@@ -16,7 +16,6 @@ namespace Baku.VMagicMirror.IK
         
         //ボタンを押すとき手ごと下に下げる移動量。
         private const float ButtonDownY = 0.01f;
-
         
         //右手の5本の指について、手首から指先までのオフセットを大まかにチェックしたもの。
         //指に対してはIKをあまり使いたくないため、FKを大まかに合わせるのに使う
@@ -80,7 +79,6 @@ namespace Baku.VMagicMirror.IK
                 }
             };
 
-            
             dependency.Events.GamepadButtonDown += key =>
             {
                 ButtonDown(key);
@@ -167,8 +165,8 @@ namespace Baku.VMagicMirror.IK
             (_latestButtonPos, _latestButtonRot) = _stickProvider.GetRightHand(key);
 
             //NOTE: 指をだいたい揃えるためにズラす動きがコレ
-            int fingerNumber = ArcadeStickFingerController.KeyToFingerNumber(key);
-            int offsetIndex = fingerNumber - 5;
+            var fingerNumber = ArcadeStickFingerController.KeyToFingerNumber(key);
+            var offsetIndex = fingerNumber - 5;
             //1倍ぴったりを適用すると指の曲げのぶんのズレで絵面がイマイチになる可能性もあるが、
             //余程手が大きくなければ大丈夫なはず
             _latestButtonPos -= _latestButtonRot * _wristToFingerOffsets[offsetIndex];

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
@@ -147,18 +147,10 @@ namespace Baku.VMagicMirror
                     ? Observable.Empty<Unit>()
                     : Observable.Timer(TimeSpan.FromSeconds(15f)).AsUnitObservable())
                 .Switch()
-                .Subscribe(_ =>
-                {
-                    Debug.Log("force zero jitter when inactive");
-                    _inactiveJitter.ForceGoalZero = true;
-                })
+                .Subscribe(_ => _inactiveJitter.ForceGoalZero = true)
                 .AddTo(this);
             _useActiveJitter.Where(v => v)
-                .Subscribe(_ =>
-                {
-                    Debug.Log("force non-zero jitter when inactive");
-                    _inactiveJitter.ForceGoalZero = false;
-                })
+                .Subscribe(_ => _inactiveJitter.ForceGoalZero = false)
                 .AddTo(this);
 
             _inactiveJitter.AngleRange = new Vector3(4f, 4f, 4f);


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #955 

十字キー/menu/startキーについて、アーケードスティックモードの場合はそもそも押しても反応しないので、エフェクトも発生しないようにしました。

## How to confirm

Editor上で、

- [x] 上記ボタンの実行時はエフェクトが発生しない
- [x] ABXYと、LRのTrigger/Buttonではエフェクトが発生する
