### PR TITLE
VMCProtocolで手の姿勢を受信時に「つねに手下げモード」だったら警告UIを出す

### DIFF
--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -144,8 +144,8 @@ VMagicMirror supports to receive:
     <sys:String x:Key="VMCP_ShouldApply">*There are unapplied changes.</sys:String>
     <sys:String x:Key="VMCP_Apply">Apply Changes</sys:String>
     <sys:String x:Key="VMCP_Revert">Revert</sys:String>    
-    <sys:String x:Key="VMCP_BodyMotionModeIncorrect" xml:space="preserve">*Body Motion Style is set to "Standing Only."
-You need to change the option to "Default" to apply hand pose based on VMC Protocol.</sys:String>
+    <sys:String x:Key="VMCP_BodyMotionModeIncorrect" xml:space="preserve">*Body Motion Style is now "Standing Only."
+Use "Default" to apply VMC Protocol based hand pose.</sys:String>
     <sys:String x:Key="VMCP_BodyMotionModeIncorrect_Fix">Use "Default" Option</sys:String>
     <sys:String x:Key="VMCP_AdvancedSetting_DisableCameraDuringActive">Disable Camera feature during VMCP is active</sys:String>    
     

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -727,7 +727,8 @@ VMCP receive settings is kept after the tab hidden.</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">Selected Mic Disconnected: {0}</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">Selected Mic Detected: {0}</sys:String>
     <sys:String x:Key="Snackbar_CameraReconnected_Format">Selected Camera Detected: {0}</sys:String>    
-    
+    <sys:String x:Key="Snackbar_VMCP_FixBodyMotionStyle_Completed">Body Motion Style is set to: "Default"</sys:String>
+
     <!-- Other: Not on Dialog, but used from code -->
     <sys:String x:Key="CommonUi_DoNothing">(Do Nothing)</sys:String>
     <sys:String x:Key="CommonUi_None">(None)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -144,6 +144,9 @@ VMagicMirror supports to receive:
     <sys:String x:Key="VMCP_ShouldApply">*There are unapplied changes.</sys:String>
     <sys:String x:Key="VMCP_Apply">Apply Changes</sys:String>
     <sys:String x:Key="VMCP_Revert">Revert</sys:String>    
+    <sys:String x:Key="VMCP_BodyMotionModeIncorrect" xml:space="preserve">*Body Motion Style is set to "Standing Only."
+You need to change the option to "Default" to apply hand pose based on VMC Protocol.</sys:String>
+    <sys:String x:Key="VMCP_BodyMotionModeIncorrect_Fix">Use "Default" Option</sys:String>
     <sys:String x:Key="VMCP_AdvancedSetting_DisableCameraDuringActive">Disable Camera feature during VMCP is active</sys:String>    
     
     <!-- HandTracking -->

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -160,6 +160,10 @@ Get Full Edition to remove the effect.</sys:String>
     <sys:String x:Key="HandTracking_ShowEffectDuringTracking">Show Effect During Hand Tracking</sys:String>
     <sys:String x:Key="HandTracking_DisableHorizontalFlip">Disable Horizontal Flip</sys:String>    
     <sys:String x:Key="HandTracking_ShowAreaChecker">Show Detection Status (*raw image is not displayed)</sys:String>    
+    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect" xml:space="preserve">*Body Motion Style is now "Standing Only."
+Use "Default" to apply hand tracking result.</sys:String>
+    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Fix">Use "Default" Option</sys:String>
+    
     <sys:String x:Key="HandTracking_DetectionResult">Detection Status:</sys:String>
     <sys:String x:Key="HandTracking_NotDetected">(Not Detected: Try raising hands next to the face)</sys:String>
     <sys:String x:Key="HandTracking_DetectionResult_Notice" xml:space="preserve">Tips:
@@ -727,7 +731,7 @@ VMCP receive settings is kept after the tab hidden.</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">Selected Mic Disconnected: {0}</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">Selected Mic Detected: {0}</sys:String>
     <sys:String x:Key="Snackbar_CameraReconnected_Format">Selected Camera Detected: {0}</sys:String>    
-    <sys:String x:Key="Snackbar_VMCP_FixBodyMotionStyle_Completed">Body Motion Style is set to: "Default"</sys:String>
+    <sys:String x:Key="Snackbar_BodyMotionStyle_Set_Default">Body Motion Style is set to: "Default"</sys:String>
 
     <!-- Other: Not on Dialog, but used from code -->
     <sys:String x:Key="CommonUi_DoNothing">(Do Nothing)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -144,6 +144,9 @@ VMagicMirrorは以下のモーションを受信して適用できます。
     <sys:String x:Key="VMCP_ShouldApply">*未適用の設定があります</sys:String>
     <sys:String x:Key="VMCP_Apply">変更を適用</sys:String>
     <sys:String x:Key="VMCP_Revert">キャンセル</sys:String>
+    <sys:String x:Key="VMCP_BodyMotionModeIncorrect" xml:space="preserve">*動きかたのオプションで「つねに手下げ」が選択されています。
+VMC Protocolによる手の姿勢を適用するには「デフォルト」に変更して下さい。</sys:String>
+    <sys:String x:Key="VMCP_BodyMotionModeIncorrect_Fix">オプションを「デフォルト」に変更</sys:String>
     <sys:String x:Key="VMCP_AdvancedSetting_DisableCameraDuringActive">VMCPの受信中はカメラ機能をオフ</sys:String>    
     
     <!-- HandTracking -->

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -159,6 +159,10 @@ VMC Protocolによる手の姿勢を適用するには「デフォルト」に�
     <sys:String x:Key="HandTracking_Enable">ハンドトラッキングを有効化</sys:String>
     <sys:String x:Key="HandTracking_ShowEffectDuringTracking">トラッキング中にエフェクトを適用</sys:String>
     <sys:String x:Key="HandTracking_DisableHorizontalFlip">左右反転をオフ</sys:String> 
+    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect" xml:space="preserve">*動きかたのオプションで「つねに手下げ」が選択されています。
+ハンドトラッキングの結果を適用するには「デフォルト」に変更して下さい。</sys:String>
+    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Fix">オプションを「デフォルト」に変更</sys:String>
+    
     <sys:String x:Key="HandTracking_ShowAreaChecker">手の検出状況を表示(※カメラ映像は表示されません)</sys:String> 
     <sys:String x:Key="HandTracking_DetectionResult">手の検出状況:</sys:String>
     <sys:String x:Key="HandTracking_DetectionResult_Notice" xml:space="preserve">ヒント:
@@ -733,8 +737,7 @@ VMCPのデータが受信中の場合、この操作で受信機能はオフに�
     <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">選択されたマイクが切断しました: {0}</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">選択されたマイクの接続を検出しました: {0}</sys:String>
     <sys:String x:Key="Snackbar_CameraReconnected_Format">選択されたカメラの接続を検出しました: {0}</sys:String>
-    <sys:String x:Key="Snackbar_VMCP_FixBodyMotionStyle_Completed">動きかたのオプションを「デフォルト」に変更しました</sys:String>
-    
+    <sys:String x:Key="Snackbar_BodyMotionStyle_Set_Default">動きかたのオプションを「デフォルト」に変更しました</sys:String>    
     
     <!-- Other: Not on Dialog, but used from code -->
     <sys:String x:Key="CommonUi_DoNothing">(何もしない)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -733,6 +733,8 @@ VMCPのデータが受信中の場合、この操作で受信機能はオフに�
     <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">選択されたマイクが切断しました: {0}</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">選択されたマイクの接続を検出しました: {0}</sys:String>
     <sys:String x:Key="Snackbar_CameraReconnected_Format">選択されたカメラの接続を検出しました: {0}</sys:String>
+    <sys:String x:Key="Snackbar_VMCP_FixBodyMotionStyle_Completed">動きかたのオプションを「デフォルト」に変更しました</sys:String>
+    
     
     <!-- Other: Not on Dialog, but used from code -->
     <sys:String x:Key="CommonUi_DoNothing">(何もしない)</sys:String>

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/HandTrackingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/HandTrackingPanel.xaml
@@ -98,6 +98,25 @@
                                 IsChecked="{Binding EnableSendHandTrackingResult.Value}"
                                 />
 
+                    <md:Card Margin="15,5,5,0" 
+                         Visibility="{Binding BodyMotionStyleIncorrectForHandTracking.Value,
+                                              Converter={StaticResource BooleanToVisibilityConverter}}"
+                         HorizontalAlignment="Stretch"
+                         Padding="3">
+                        <StackPanel HorizontalAlignment="Left">
+                            <TextBlock Text="{DynamicResource HandTracking_BodyMotionModeIncorrect}" 
+                                               TextWrapping="Wrap"
+                                               />
+                            <Button Style="{StaticResource MaterialDesignOutlinedButton}"
+                                Content="{DynamicResource HandTracking_BodyMotionModeIncorrect_Fix}"
+                                Command="{Binding FixBodyMotionStyleCommand}"
+                                HorizontalAlignment="Left"
+                                Padding="2"
+                                Margin="5"
+                                />
+                        </StackPanel>
+                    </md:Card>                    
+                    
                     <TextBlock Margin="15,20,15,0" 
                                Text="{DynamicResource HandTracking_DetectionResult}"
                                Opacity="{Binding EnableSendHandTrackingResult.Value,

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/VCMPControlPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/VCMPControlPanel.xaml
@@ -161,6 +161,25 @@
 
                     </StackPanel>
 
+                    <md:Card Margin="15,5,5,0" 
+                         Visibility="{Binding BodyMotionStyleIncorrectForHandTracking.Value,
+                                              Converter={StaticResource BooleanToVisibilityConverter}}"
+                         HorizontalAlignment="Stretch"
+                         Padding="3">
+                        <StackPanel HorizontalAlignment="Left">
+                            <TextBlock Text="{DynamicResource VMCP_BodyMotionModeIncorrect}" 
+                                               TextWrapping="Wrap"
+                                               />
+                            <Button Style="{StaticResource MaterialDesignOutlinedButton}"
+                                Content="{DynamicResource VMCP_BodyMotionModeIncorrect_Fix}"
+                                Command="{Binding FixBodyMotionStyleCommand}"
+                                HorizontalAlignment="Left"
+                                Padding="2"
+                                Margin="5"
+                                />
+                        </StackPanel>
+                    </md:Card>
+                    
                 </StackPanel>
             </Border>
 

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
@@ -164,6 +164,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         {
             _motionSettingModel.EnableNoHandTrackMode.Value = false;
             _motionSettingModel.EnableGameInputLocomotionMode.Value = false;
+            SnackbarWrapper.Enqueue(LocalizedString.GetString("Snackbar_VMCP_FixBodyMotionStyle_Completed"));
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
@@ -8,17 +8,23 @@ namespace Baku.VMagicMirrorConfig.ViewModel
     public class VMCPControlPanelViewModel : SettingViewModelBase
     {
         public VMCPControlPanelViewModel() : this(
-            ModelResolver.Instance.Resolve<VMCPSettingModel>())
+            ModelResolver.Instance.Resolve<VMCPSettingModel>(),
+            ModelResolver.Instance.Resolve<MotionSettingModel>())
         {
         }
 
-        internal VMCPControlPanelViewModel(VMCPSettingModel model)
+        internal VMCPControlPanelViewModel(
+            VMCPSettingModel model,
+            MotionSettingModel motionSettingModel)
         {
             _model = model;
+            _motionSettingModel = motionSettingModel;
+
             IsDirty = new RProperty<bool>(false, _ => UpdateInputValidity());
             ApplyChangeCommand = new ActionCommand(ApplyChange);
             RevertChangeCommand = new ActionCommand(RevertChange);
             OpenDocUrlCommand = new ActionCommand(OpenDocUrl);
+            FixBodyMotionStyleCommand = new ActionCommand(FixBodyMotionStyle);
 
             if (!IsInDesignMode)
             {
@@ -28,10 +34,14 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                     );
                 _model.SerializedVMCPSourceSetting.AddWeakEventHandler(OnSerializedVMCPSourceSettingChanged);
                 ApplyConnectionStatus();
+
+                UpdateBodyMotionStyleCorrectness();
+                _motionSettingModel.EnableNoHandTrackMode.AddWeakEventHandler(OnBodyMotionStyleCorrectnessMaybeChanged);
             }
         }
 
         private readonly VMCPSettingModel _model;
+        private readonly MotionSettingModel _motionSettingModel;
 
         public RProperty<bool> IsDirty { get; }
         public RProperty<bool> CanApply { get; } = new(false);
@@ -44,6 +54,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         public RProperty<bool> DisableCameraDuringVMCPActive => _model.DisableCameraDuringVMCPActive;
 
+        public RProperty<bool> BodyMotionStyleIncorrectForHandTracking { get; } = new(false);
+
         public void SetDirty()
         {
             IsDirty.Value = true;
@@ -54,6 +66,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand ApplyChangeCommand { get; }
         public ActionCommand RevertChangeCommand { get; }
         public ActionCommand OpenDocUrlCommand { get; }
+
+        public ActionCommand FixBodyMotionStyleCommand { get; }
 
         private void UpdateInputValidity()
         {
@@ -87,13 +101,15 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             RaisePropertyChanged(nameof(Source1));
             RaisePropertyChanged(nameof(Source2));
             RaisePropertyChanged(nameof(Source3));
+            UpdateBodyMotionStyleCorrectness();
             IsDirty.Value = false;
         }
 
-        private void OnSerializedVMCPSourceSettingChanged(object? sender, PropertyChangedEventArgs e)
-        {
-            LoadCurrentSettings();
-        }
+        private void OnSerializedVMCPSourceSettingChanged(object? sender, PropertyChangedEventArgs e) 
+            => LoadCurrentSettings();
+
+        private void OnBodyMotionStyleCorrectnessMaybeChanged(object? sender, PropertyChangedEventArgs e)
+            => UpdateBodyMotionStyleCorrectness();
 
         private void OnConnectedStatusChanged(object? sender, EventArgs e) => ApplyConnectionStatus();
 
@@ -124,10 +140,29 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private void RevertChange() => LoadCurrentSettings();
 
+        private void UpdateBodyMotionStyleCorrectness()
+        {
+            var sourceHasHandTrackingOption =
+                (!Source1.PortNumberIsInvalid.Value && Source1.ReceiveHandPose.Value) ||
+                (!Source2.PortNumberIsInvalid.Value && Source2.ReceiveHandPose.Value) ||
+                (!Source3.PortNumberIsInvalid.Value && Source3.ReceiveHandPose.Value);
+
+            BodyMotionStyleIncorrectForHandTracking.Value =
+                sourceHasHandTrackingOption &&
+                _model.VMCPEnabled.Value && 
+                _motionSettingModel.EnableNoHandTrackMode.Value;
+        }
+
         private void OpenDocUrl()
         {
             var url = LocalizedString.GetString("URL_docs_vmc_protocol");
             UrlNavigate.Open(url);
+        }
+
+        private void FixBodyMotionStyle()
+        {
+            _motionSettingModel.EnableNoHandTrackMode.Value = true;
+            _motionSettingModel.EnableGameInputLocomotionMode.Value = false;
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
@@ -36,6 +36,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 ApplyConnectionStatus();
 
                 UpdateBodyMotionStyleCorrectness();
+
+                _model.VMCPEnabled.AddWeakEventHandler(OnBodyMotionStyleCorrectnessMaybeChanged);
                 _motionSettingModel.EnableNoHandTrackMode.AddWeakEventHandler(OnBodyMotionStyleCorrectnessMaybeChanged);
             }
         }
@@ -66,7 +68,6 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand ApplyChangeCommand { get; }
         public ActionCommand RevertChangeCommand { get; }
         public ActionCommand OpenDocUrlCommand { get; }
-
         public ActionCommand FixBodyMotionStyleCommand { get; }
 
         private void UpdateInputValidity()
@@ -161,7 +162,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private void FixBodyMotionStyle()
         {
-            _motionSettingModel.EnableNoHandTrackMode.Value = true;
+            _motionSettingModel.EnableNoHandTrackMode.Value = false;
             _motionSettingModel.EnableGameInputLocomotionMode.Value = false;
         }
     }

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
@@ -164,7 +164,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         {
             _motionSettingModel.EnableNoHandTrackMode.Value = false;
             _motionSettingModel.EnableGameInputLocomotionMode.Value = false;
-            SnackbarWrapper.Enqueue(LocalizedString.GetString("Snackbar_VMCP_FixBodyMotionStyle_Completed"));
+            SnackbarWrapper.Enqueue(LocalizedString.GetString("Snackbar_BodyMotionStyle_Set_Default"));
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/VMCPControlPanelViewModel.cs
@@ -35,10 +35,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 _model.SerializedVMCPSourceSetting.AddWeakEventHandler(OnSerializedVMCPSourceSettingChanged);
                 ApplyConnectionStatus();
 
-                UpdateBodyMotionStyleCorrectness();
-
                 _model.VMCPEnabled.AddWeakEventHandler(OnBodyMotionStyleCorrectnessMaybeChanged);
                 _motionSettingModel.EnableNoHandTrackMode.AddWeakEventHandler(OnBodyMotionStyleCorrectnessMaybeChanged);
+                UpdateBodyMotionStyleCorrectness();
             }
         }
 

--- a/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
@@ -32,6 +32,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
             OpenFullEditionDownloadUrlCommand = new ActionCommand(() => UrlNavigate.Open("https://baku-dreameater.booth.pm/items/3064040"));
             OpenHandTrackingPageUrlCommand = new ActionCommand(() => UrlNavigate.Open(LocalizedString.GetString("URL_docs_hand_tracking")));
+            FixBodyMotionStyleCommand = new ActionCommand(FixBodyMotionStyle);
 
             if (!IsInDesignMode)
             {
@@ -42,6 +43,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                     nameof(receiver.ReceivedCommand),
                     OnReceivedCommand
                     );
+                _model.EnableImageBasedHandTracking.AddWeakEventHandler(BodyMotionStyleIncorrectMaybeChanged);
+                _model.EnableNoHandTrackMode.AddWeakEventHandler(BodyMotionStyleIncorrectMaybeChanged);
             }
         }
 
@@ -65,6 +68,23 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             CameraDeviceName.Value = _model.CameraDeviceName.Value;
         }
 
+        private void BodyMotionStyleIncorrectMaybeChanged(object? sender, PropertyChangedEventArgs e)
+            => UpdateBodyMotionStyleIncorrect();
+
+        private void UpdateBodyMotionStyleIncorrect()
+        {
+            BodyMotionStyleIncorrectForHandTracking.Value =
+                _model.EnableImageBasedHandTracking.Value &&
+                _model.EnableNoHandTrackMode.Value;
+        }
+
+        private void FixBodyMotionStyle()
+        {
+            _model.EnableNoHandTrackMode.Value = false;
+            _model.EnableGameInputLocomotionMode.Value = false;
+            SnackbarWrapper.Enqueue(LocalizedString.GetString("Snackbar_BodyMotionStyle_Set_Default"));
+        }
+
         public RProperty<bool> EnableImageBasedHandTracking => _model.EnableImageBasedHandTracking;
         private readonly RProperty<bool> _alwaysOn = new RProperty<bool>(true);
         public RProperty<bool> ShowEffectDuringHandTracking => FeatureLocker.FeatureLocked
@@ -76,8 +96,11 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public HandTrackingResultViewModel HandTrackingResult { get; } = new HandTrackingResultViewModel();
         public ActionCommand OpenFullEditionDownloadUrlCommand { get; }
         public ActionCommand OpenHandTrackingPageUrlCommand { get; }
+        public ActionCommand FixBodyMotionStyleCommand { get; }
 
         public RProperty<string> CameraDeviceName { get; }
         public ReadOnlyObservableCollection<string> CameraNames => _deviceListSource.CameraNames;
+
+        public RProperty<bool> BodyMotionStyleIncorrectForHandTracking { get; } = new(false);
     }
 }

--- a/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
@@ -43,8 +43,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                     nameof(receiver.ReceivedCommand),
                     OnReceivedCommand
                     );
+
                 _model.EnableImageBasedHandTracking.AddWeakEventHandler(BodyMotionStyleIncorrectMaybeChanged);
                 _model.EnableNoHandTrackMode.AddWeakEventHandler(BodyMotionStyleIncorrectMaybeChanged);
+                UpdateBodyMotionStyleCorrectness();
             }
         }
 
@@ -69,9 +71,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         }
 
         private void BodyMotionStyleIncorrectMaybeChanged(object? sender, PropertyChangedEventArgs e)
-            => UpdateBodyMotionStyleIncorrect();
+            => UpdateBodyMotionStyleCorrectness();
 
-        private void UpdateBodyMotionStyleIncorrect()
+        private void UpdateBodyMotionStyleCorrectness()
         {
             BodyMotionStyleIncorrectForHandTracking.Value =
                 _model.EnableImageBasedHandTracking.Value &&

--- a/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
@@ -4,7 +4,6 @@ using System.Windows;
 
 namespace Baku.VMagicMirrorConfig.ViewModel
 {
-    //TODO: モデルに引っ張られてFaceとMotionが同一ViewModelになっちゃってるが、分けるべき
     public class HandTrackingViewModel : SettingViewModelBase
     {
         public HandTrackingViewModel() : this(


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #976

- 折角なのでハンドトラッキングのタブでも同様の配慮をしています。
- ハンドトラッキングとVMCPの手ポーズ受信が両方オンの場合はハンドトラッキング側に「VMCPが有効です」みたいな警告もあるのが望ましいですが、そこまではしていません。

## How to confirm

VMCPタブ

- [x] 設定を警告が出るべき状態と出ないべき状態で切り替えることで、実際に警告UIの表示/非表示が切り替わる
- [x] 警告UI内のボタンを押すと動きかたのオプションが「デフォルト」に戻り、その旨を知らせるsnackbarが表示され、警告UIが非表示になる

ハンドトラッキングタブ

- [x] 設定を警告が出るべき状態と出ないべき状態で切り替えることで、実際に警告UIの表示/非表示が切り替わる
- [x] 警告UI内のボタンを押すと動きかたのオプションが「デフォルト」に戻り、その旨を知らせるsnackbarが表示され、警告UIが非表示になる

## Note

#979 の問題があるため、この方法で動きかたを「デフォルト」にしてもハンドトラッキングが使えない場合がある。

この問題は別件なので別PRで対処する。
