### PR TITLE
Fix hand IK switch between hand down mode / VMC Protocol based mode

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandIkGeneratorBase.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandIkGeneratorBase.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using UnityEngine;
 
 namespace Baku.VMagicMirror.IK
 {
-    public abstract class HandIkGeneratorBase
+    public abstract class HandIkGeneratorBase : IDisposable
     {
         public HandIkGeneratorBase(HandIkGeneratorDependency dependency)
         {
@@ -29,6 +30,10 @@ namespace Baku.VMagicMirror.IK
 
         /// <summary> HandIKIntegratorのLateUpdate内部で呼ばれます。 </summary>
         public virtual void LateUpdate()
+        {
+        }
+
+        public virtual void Dispose()
         {
         }
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #979 

2つの問題を修正した。

- いちどVMCPの手が適用されると、「手下げモード」にしても手が下がらない
- 「手下げモード」が選択された状態でVMCPの手の姿勢を受信開始したあとで手下げモードを解除してもVMCPの手の姿勢が効かない

## How to confirm

Editorで下記を確認

- VMCPの手の姿勢適用後、動きかたを「つねに手下げ」にすると手が下がる
- つねに手下げの状態でVMCPの手の姿勢を受信しておき、その後に動きかたを「デフォルト」に変えると、VMCPの手の姿勢が適用され始める
