### PR TITLE
Fix folder ref on batch build result

### DIFF
--- a/Batches/build_unity.cmd
+++ b/Batches/build_unity.cmd
@@ -39,6 +39,28 @@ if %1 == standard (
 set PROJ_PATH=%~dp0\..\VMagicMirror
 set SAVE_PATH=%~dp0\..\%BIN_FOLDER%
 
+REM 1: Set script symbol and exit, to apply symbol changes
+
+echo %time%
+echo "Build Unity: Setup script symbol..."
+
+%UNITY_EXE% ^
+-batchmode -quit ^
+-projectPath %PROJ_PATH% ^
+-SavePath=%SAVE_PATH% ^
+-Edition=%APP_EDITION% ^
+-Env=%APP_ENV% ^
+-executeMethod Baku.VMagicMirror.BuildHelper.DoPrepareScriptDefineSymbol
+
+echo %time%
+echo "Build Unity: Sleep 5sec, to wait script symbol update starts..."
+timeout /t 5 > nul
+
+REM 2: Run actual build
+
+echo %time%
+echo "Build Unity: Run build..."
+
 %UNITY_EXE% ^
 -batchmode -quit ^
 -projectPath %PROJ_PATH% ^

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/StartupLoadingCoverController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/StartupLoadingCoverController.cs
@@ -28,6 +28,11 @@ namespace Baku.VMagicMirror
         
         public override void Initialize()
         {
+            //NOTE: このクラスの仕事かというと微妙だが、ビルド設定を吐かせておく(不具合調査上都合がよいので)
+            LogOutput.Instance.Write(
+                $"Environment: Feature Lock = {FeatureLocker.IsFeatureLocked}, Dev = {SpecialFiles.UseDevFolder}"
+            );
+
             _vrmLoadable.LocalVrmLoadEnded += () => _localVrmLoadEndedAtLeastOnce.Value = true;
 
             _receiver.AssignCommandHandler(

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FileIo/SpecialFiles.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/FileIo/SpecialFiles.cs
@@ -12,7 +12,7 @@ namespace Baku.VMagicMirror
         private const string AutoSaveSettingFileName = "_autosave";
         private const string LogTextName = "log.txt";
         
-        private static bool IsDebugRun
+        public static bool UseDevFolder
         {
             get
             {
@@ -54,7 +54,7 @@ namespace Baku.VMagicMirror
         {
             RootDirectory = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), 
-                IsDebugRun ? "VMagicMirror_Dev_Files" : "VMagicMirror_Files"
+                UseDevFolder ? "VMagicMirror_Dev_Files" : "VMagicMirror_Files"
                 );
 
             ScreenShotDirectory = Path.Combine(RootDirectory, "Screenshots");


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fix #990 

Unity 2022へのアップデートによってスクリプトシンボルの反映タイミングが変化してしまったのがビルド結果に出たものと見られるため、ビルド処理をスクリプトシンボル更新 + ビルド実行の2ステップに区切って実行するようにしました。

## How to confirm

`StartupLoadingCoverController`に追加したコードの出力を通じて、各ビルドパターンについてUnity側のビルド結果が期待した構成になっているのが確認できること。

