### PR TITLE
ゲーム入力 + VRM Animationの組み合わせバグをいくつか修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputKeyAssign.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputKeyAssign.cs
@@ -26,7 +26,7 @@ namespace Baku.VMagicMirror.GameInput
 
         public string CustomLeftClickKey => CustomLeftClick?.CustomKey ?? "";
         public string CustomRightClickKey => CustomRightClick?.CustomKey ?? "";
-        public string CustomMiddleClickKey => CustomLeftClick?.CustomKey ?? "";
+        public string CustomMiddleClickKey => CustomMiddleClick?.CustomKey ?? "";
 
         //よくあるやつなので + このキーアサインでは補助キーを無視したいのでShiftも特別扱い
         public bool UseWasdMove = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputKeyAssign.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputKeyAssign.cs
@@ -20,6 +20,14 @@ namespace Baku.VMagicMirror.GameInput
         public GameInputButtonAction RightClick;
         public GameInputButtonAction MiddleClick;
 
+        public GameInputCustomAction CustomLeftClick;
+        public GameInputCustomAction CustomRightClick;
+        public GameInputCustomAction CustomMiddleClick;
+
+        public string CustomLeftClickKey => CustomLeftClick?.CustomKey ?? "";
+        public string CustomRightClickKey => CustomRightClick?.CustomKey ?? "";
+        public string CustomMiddleClickKey => CustomLeftClick?.CustomKey ?? "";
+
         //よくあるやつなので + このキーアサインでは補助キーを無視したいのでShiftも特別扱い
         public bool UseWasdMove = true;
         public bool UseArrowKeyMove = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/KeyboardGameInputSource.cs
@@ -336,27 +336,27 @@ namespace Baku.VMagicMirror.GameInput
             switch (button)
             {
                 case MouseButtonEventNames.LDown:
-                    ApplyMouseInput(_keyAssign.LeftClick, true);
+                    ApplyMouseInput(_keyAssign.LeftClick, _keyAssign.CustomLeftClickKey, true);
                     return;
                 case MouseButtonEventNames.LUp:
-                    ApplyMouseInput(_keyAssign.LeftClick, false);
+                    ApplyMouseInput(_keyAssign.LeftClick, _keyAssign.CustomLeftClickKey, false);
                     return;
                 case MouseButtonEventNames.RDown:
-                    ApplyMouseInput(_keyAssign.RightClick, true);
+                    ApplyMouseInput(_keyAssign.RightClick, _keyAssign.CustomRightClickKey, true);
                     return;
                 case MouseButtonEventNames.RUp:
-                    ApplyMouseInput(_keyAssign.RightClick, false);
+                    ApplyMouseInput(_keyAssign.RightClick, _keyAssign.CustomRightClickKey, false);
                     return;
                 case MouseButtonEventNames.MDown:
-                    ApplyMouseInput(_keyAssign.MiddleClick, true);
+                    ApplyMouseInput(_keyAssign.MiddleClick, _keyAssign.CustomMiddleClickKey, true);
                     return;
                 case MouseButtonEventNames.MUp:
-                    ApplyMouseInput(_keyAssign.MiddleClick, false);
+                    ApplyMouseInput(_keyAssign.MiddleClick, _keyAssign.CustomMiddleClickKey, false);
                     return;
             }
         }
 
-        private void ApplyMouseInput(GameInputButtonAction action, bool pressed)
+        private void ApplyMouseInput(GameInputButtonAction action, string customActionKey, bool pressed)
         {
             if (action == GameInputButtonAction.None)
             {
@@ -388,6 +388,12 @@ namespace Baku.VMagicMirror.GameInput
                     return;
                 case GameInputButtonAction.Punch:
                     _punch.OnNext(Unit.Default);
+                    return;
+                case GameInputButtonAction.Custom:
+                    if (!string.IsNullOrEmpty(customActionKey))
+                    {
+                        _customMotion.OnNext(customActionKey);
+                    }
                     return;
             }
         }

--- a/WPF/VMagicMirrorConfig/Model/Entity/GameInputSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/GameInputSetting.cs
@@ -75,6 +75,11 @@ namespace Baku.VMagicMirrorConfig
     {
         //NOTE: string 1つなのにclass化するのはループとかマスクとかIKどうするとか設定したい可能性に配慮するため
         public string CustomKey { get; set; } = "";
+
+        public GameInputCustomAction CreateCopy() => new GameInputCustomAction()
+        {
+            CustomKey = CustomKey,
+        };
     }
 
     public class KeyboardKeyWithGameInputCustomAction
@@ -193,6 +198,9 @@ namespace Baku.VMagicMirrorConfig
                 LeftClick = LeftClick,
                 RightClick = RightClick,
                 MiddleClick = MiddleClick,
+                CustomLeftClick = CustomLeftClick.CreateCopy(),
+                CustomRightClick = CustomRightClick.CreateCopy(),
+                CustomMiddleClick = CustomMiddleClick.CreateCopy(),
                 UseWasdMove = UseWasdMove,
                 UseArrowKeyMove = UseArrowKeyMove,
                 UseShiftRun = UseShiftRun,

--- a/WPF/VMagicMirrorConfig/Model/GameInput/GamepadKeyAssignUtils.cs
+++ b/WPF/VMagicMirrorConfig/Model/GameInput/GamepadKeyAssignUtils.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+
+namespace Baku.VMagicMirrorConfig
+{
+    internal static class GamepadKeyAssignUtils
+    {
+        /// <summary>
+        /// 指定したカスタムアクション一覧に含まれないような割当のボタンがあると、trueを戻しつつ、対象ボタンの割当を「なし」にリセットします。
+        /// この関数を呼んでもボタンの割当がまったく変化しなかった場合、falseを返します。
+        /// </summary>
+        /// <param name="target"></param>
+        /// <param name="actionKeys"></param>
+        /// <returns></returns>
+        public static bool TryResetMissingCustomAction(this GameInputGamepadKeyAssign target, GameInputActionKey[] actionKeys)
+        {
+            var result = false;
+
+            if (!actionKeys.Contains(target.ButtonAKey))
+            {
+                result = true;
+                target.ButtonA = GameInputButtonAction.None;
+                target.CustomButtonA.CustomKey = "";
+            }
+            if (!actionKeys.Contains(target.ButtonBKey))
+            {
+                result = true;
+                target.ButtonB = GameInputButtonAction.None;
+                target.CustomButtonB.CustomKey = "";
+            }
+            if (!actionKeys.Contains(target.ButtonXKey))
+            {
+                result = true;
+                target.ButtonX = GameInputButtonAction.None;
+                target.CustomButtonX.CustomKey = "";
+            }
+            if (!actionKeys.Contains(target.ButtonYKey))
+            {
+                result = true;
+                target.ButtonY = GameInputButtonAction.None;
+                target.CustomButtonY.CustomKey = "";
+            }
+
+            if (!actionKeys.Contains(target.ButtonLButtonKey))
+            {
+                result = true;
+                target.ButtonLButton = GameInputButtonAction.None;
+                target.CustomButtonLButton.CustomKey = "";
+            }
+            if (!actionKeys.Contains(target.ButtonYKey))
+            {
+                result = true;
+                target.ButtonY = GameInputButtonAction.None;
+                target.CustomButtonY.CustomKey = "";
+            }
+            if (!actionKeys.Contains(target.ButtonRButtonKey))
+            {
+                result = true;
+                target.ButtonRButton = GameInputButtonAction.None;
+                target.CustomButtonRButton.CustomKey = "";
+            }
+            if (!actionKeys.Contains(target.ButtonRTriggerKey))
+            {
+                result = true;
+                target.ButtonRTrigger = GameInputButtonAction.None;
+                target.CustomButtonRTrigger.CustomKey = "";
+            }
+
+            if (!actionKeys.Contains(target.ButtonMenuKey))
+            {
+                result = true;
+                target.ButtonMenu = GameInputButtonAction.None;
+                target.CustomButtonMenu.CustomKey = "";
+            }
+            if (!actionKeys.Contains(target.ButtonViewKey))
+            {
+                result = true;
+                target.ButtonView = GameInputButtonAction.None;
+                target.CustomButtonView.CustomKey = "";
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

- fixed #1013 
    - Unity側でCustomActionを見てない + WPF側の送信時シリアライズにも問題があったので双方を修正
- fixed #1014
    - WPF側でキーの欠損時にボタン/クリックの割当を修正してなかったので、明示的に比較して修正できるようにした

## How to confirm

WPF Build + Editorで

- [x] : マウスクリックにVRM Animationを割り当てたとき、実際にマウスクリックでそのモーションを実行できること
- [x] : ボタンにVRM Animationを割り当てたあと、そのファイルを削除して再度実行したとき、
    - ゲーム入力の設定を開かずに起動+終了したとき、該当ボタンのアクションがNoneに巻き戻ること
    - ゲーム入力の設定を開いた場合も、該当ボタンのアクションがNoneになっているのが確認できること
