### PR TITLE
Add outline effect 

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer_Profiles/PostProcessing Profile.asset
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer_Profiles/PostProcessing Profile.asset
@@ -25,6 +25,37 @@ MonoBehaviour:
   scanline:
     overrideState: 1
     value: 0.117
+--- !u!114 &-4968429724501136736
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1c7e0b21f9fde1c429ce58be087a0258, type: 3}
+  m_Name: VmmAlphaEdge
+  m_EditorClassIdentifier: 
+  active: 0
+  enabled:
+    overrideState: 1
+    value: 1
+  thickness:
+    overrideState: 1
+    value: 15
+  threshold:
+    overrideState: 0
+    value: 0.5
+  edgeColor:
+    overrideState: 1
+    value: {r: 1, g: 1, b: 1, a: 1}
+  outlineOverwriteAlpha:
+    overrideState: 0
+    value: 0.02
+  highQualityMode:
+    overrideState: 1
+    value: 0
 --- !u!114 &-4431195256121071682
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -112,6 +143,7 @@ MonoBehaviour:
   - {fileID: 114612591270388130}
   - {fileID: -679367385162691271}
   - {fileID: 1713800730463470002}
+  - {fileID: -4968429724501136736}
 --- !u!114 &114612591270388130
 MonoBehaviour:
   m_ObjectHideFlags: 3

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer_Profiles/PostProcessing Profile.asset
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer_Profiles/PostProcessing Profile.asset
@@ -45,14 +45,14 @@ MonoBehaviour:
     overrideState: 1
     value: 15
   threshold:
-    overrideState: 0
+    overrideState: 1
     value: 0.5
   edgeColor:
     overrideState: 1
     value: {r: 1, g: 1, b: 1, a: 1}
   outlineOverwriteAlpha:
-    overrideState: 0
-    value: 0.02
+    overrideState: 1
+    value: 0.8
   highQualityMode:
     overrideState: 1
     value: 0
@@ -156,7 +156,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 48a79b01ea5641d4aa6daa2e23605641, type: 3}
   m_Name: Bloom
   m_EditorClassIdentifier: 
-  active: 1
+  active: 0
   enabled:
     overrideState: 1
     value: 1

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Editor/BuildHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Editor/BuildHelper.cs
@@ -27,8 +27,8 @@ namespace Baku.VMagicMirror
         [MenuItem("VMagicMirror/Symbols: Dev Standard", false, 11)]
         public static void PrepareDevStandardSymbols() 
             => PrepareScriptDefineSymbol(false, false);
-        [MenuItem("VMagicMirror/Symbols: Prod Full", false, 12)]
-        public static void PrepareDeFullSymbols() 
+        [MenuItem("VMagicMirror/Symbols: Dev Full", false, 12)]
+        public static void PrepareDevFullSymbols() 
             => PrepareScriptDefineSymbol(true, false);
         
         [MenuItem("VMagicMirror/Symbols: Prod Standard", false, 21)]

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -22,6 +22,7 @@ namespace Baku.VMagicMirror
 
         private Color _color = Color.white;
         private Bloom _bloom;
+        private VmmAlphaEdge _vmmAlphaEdge;
         private VmmVhs _vmmVhs;
         private VmmMonochrome _vmmMonochrome;
         private bool _handTrackingEnabled = false;
@@ -89,7 +90,28 @@ namespace Baku.VMagicMirror
                     float[] bloomRgb = message.ToColorFloats();
                     SetBloomColor(bloomRgb[0], bloomRgb[1], bloomRgb[2]);
                 });
-            
+
+            receiver.AssignCommandHandler(
+                VmmCommands.OutlineEffectEnable,
+                message => SetOutlineEffectActive(message.ToBoolean())
+            );
+            receiver.AssignCommandHandler(
+                VmmCommands.OutlineEffectThickness,
+                message => SetOutlineEffectThickness(message.ToInt())
+            );
+            receiver.AssignCommandHandler(
+                VmmCommands.OutlineEffectColor,
+                message =>
+                {
+                    var rgb = message.ToColorFloats();
+                    var color = new Color(rgb[0], rgb[1], rgb[2]);
+                    SetOutlineEffectEdgeColor(color);
+                });
+            receiver.AssignCommandHandler(
+                VmmCommands.OutlineEffectHighQualityMode,
+                message => SetOutlineEffectHighQualityMode(message.ToBoolean())
+            );
+
             receiver.AssignCommandHandler(
                 VmmCommands.EnableImageBasedHandTracking,
                 message =>
@@ -110,6 +132,7 @@ namespace Baku.VMagicMirror
         private void Start()
         {
             _bloom = postProcess.profile.GetSetting<Bloom>();
+            _vmmAlphaEdge = postProcess.profile.GetSetting<VmmAlphaEdge>();
             _vmmMonochrome = postProcess.profile.GetSetting<VmmMonochrome>();
             _vmmVhs = postProcess.profile.GetSetting<VmmVhs>();
         }
@@ -209,6 +232,19 @@ namespace Baku.VMagicMirror
         private void SetBloomThreshold(float threshold)
             => _bloom.threshold.value = threshold;
 
+        private void SetOutlineEffectActive(bool active)
+            => _vmmAlphaEdge.active = active;
+
+        //NOTE: GUIからは整数指定するが設定上はfloat
+        private void SetOutlineEffectThickness(int thickness)
+            => _vmmAlphaEdge.thickness.Override(thickness);
+
+        private void SetOutlineEffectEdgeColor(Color color)
+            => _vmmAlphaEdge.edgeColor.Override(color);
+
+        private void SetOutlineEffectHighQualityMode(bool useHighQualityMode)
+            => _vmmAlphaEdge.highQualityMode.Override(useHighQualityMode);
+        
         private void UpdateRetroEffectStatus()
         {
             bool enableEffect =_handTrackingEnabled &&

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -30,6 +30,9 @@ namespace Baku.VMagicMirror
         //制限版でGUI側にtrue相当の値が表示されるが、これはGUI側が別途決め打ちしてくれてる
         private bool _showEffectDuringTracking = false;
 
+        private bool _windowFrameVisible = true;
+        private bool _enableOutlineEffect = false;
+        
         [Inject]
         public void Initialize(IMessageReceiver receiver)
         {
@@ -92,9 +95,19 @@ namespace Baku.VMagicMirror
                 });
 
             receiver.AssignCommandHandler(
+                VmmCommands.WindowFrameVisibility,
+                message =>
+                {
+                    _windowFrameVisible = message.ToBoolean();
+                    SetOutlineEffectActive(_windowFrameVisible, _enableOutlineEffect);
+                });
+            receiver.AssignCommandHandler(
                 VmmCommands.OutlineEffectEnable,
-                message => SetOutlineEffectActive(message.ToBoolean())
-            );
+                message =>
+                {
+                    _enableOutlineEffect = message.ToBoolean();
+                    SetOutlineEffectActive(_windowFrameVisible, _enableOutlineEffect);
+                });
             receiver.AssignCommandHandler(
                 VmmCommands.OutlineEffectThickness,
                 message => SetOutlineEffectThickness(message.ToInt())
@@ -232,8 +245,8 @@ namespace Baku.VMagicMirror
         private void SetBloomThreshold(float threshold)
             => _bloom.threshold.value = threshold;
 
-        private void SetOutlineEffectActive(bool active)
-            => _vmmAlphaEdge.active = active;
+        private void SetOutlineEffectActive(bool windowFrameVisible, bool enableOutlineEffect) 
+            => _vmmAlphaEdge.active = !windowFrameVisible && enableOutlineEffect;
 
         //NOTE: GUIからは整数指定するが設定上はfloat
         private void SetOutlineEffectThickness(int thickness)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmAlphaEdge.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmAlphaEdge.cs
@@ -1,0 +1,39 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering.PostProcessing;
+
+namespace Baku.VMagicMirror
+{
+    
+    [Serializable]
+    [PostProcess(typeof(VmmAlphaEdgeRenderer), PostProcessEvent.AfterStack, "Vmm/AlphaEdge", allowInSceneView: false)]
+    public sealed class VmmAlphaEdge : PostProcessEffectSettings
+    {
+        public FloatParameter thickness = new() { value = 20f };
+        public FloatParameter threshold = new() { value = 1f };
+        public ColorParameter edgeColor = new() { value = Color.white };
+        public FloatParameter outlineOverwriteAlpha = new() { value = 0.02f };
+        public BoolParameter highQualityMode = new() { value = false };
+    }
+
+    public sealed class VmmAlphaEdgeRenderer : PostProcessEffectRenderer<VmmAlphaEdge>
+    {
+        private static readonly int Thickness = Shader.PropertyToID("_Thickness");
+        private static readonly int Threshold = Shader.PropertyToID("_Threshold");
+        private static readonly int EdgeColor = Shader.PropertyToID("_EdgeColor");
+        private static readonly int OutlineOverwriteAlpha = Shader.PropertyToID("_OutlineOverwriteAlpha");
+        private static readonly int HighQualityMode = Shader.PropertyToID("_HighQualityMode");
+
+        public override void Render(PostProcessRenderContext context)
+        {
+            var sheet = context.propertySheets.Get(Shader.Find("Hidden/Vmm/AlphaEdge"));
+            sheet.properties.SetFloat(Thickness, settings.thickness);
+            sheet.properties.SetFloat(Threshold, settings.threshold);
+            sheet.properties.SetColor(EdgeColor, settings.edgeColor);
+            sheet.properties.SetFloat(OutlineOverwriteAlpha, settings.outlineOverwriteAlpha);
+            sheet.properties.SetFloat(HighQualityMode, settings.highQualityMode ? 1f : 0f);
+
+            context.command.BlitFullscreenTriangle(context.source, context.destination, sheet, 0);
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmAlphaEdge.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmAlphaEdge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c7e0b21f9fde1c429ce58be087a0258
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/Model/VmmCommands.cs
@@ -173,6 +173,11 @@
         public const string BloomThreshold = nameof(BloomThreshold);
         public const string BloomColor = nameof(BloomColor);
 
+        public const string OutlineEffectEnable = nameof(OutlineEffectEnable);
+        public const string OutlineEffectThickness = nameof(OutlineEffectThickness);
+        public const string OutlineEffectColor = nameof(OutlineEffectColor);
+        public const string OutlineEffectHighQualityMode = nameof(OutlineEffectHighQualityMode);
+        
         public const string ShowEffectDuringHandTracking = nameof(ShowEffectDuringHandTracking);
 
         public const string WindEnable = nameof(WindEnable);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10InstanceUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10InstanceUpdater.cs
@@ -1,4 +1,5 @@
 using System;
+using UniRx;
 using UnityEngine;
 using UniVRM10;
 using Zenject;
@@ -13,6 +14,11 @@ namespace Baku.VMagicMirror
     {
         private bool _hasModel;
         private Vrm10Instance _instance;
+
+        private readonly Subject<Unit> _preRuntimeProcessed = new();
+        private readonly Subject<Unit> _postRuntimeProcessed = new();
+        public IObservable<Unit> PostRuntimeProcess => _postRuntimeProcessed;
+        public IObservable<Unit> PreRuntimeProcess => _preRuntimeProcessed;
         
         [Inject]
         public void Initialize(IVRMLoadable vrmLoadable)
@@ -34,7 +40,9 @@ namespace Baku.VMagicMirror
         {
             if (_hasModel)
             {
+                _preRuntimeProcessed.OnNext(Unit.Default);
                 _instance.Runtime.Process();
+                _postRuntimeProcessed.OnNext(Unit.Default);
             }
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAlphaEdge.shader
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAlphaEdge.shader
@@ -1,0 +1,83 @@
+Shader "Hidden/Vmm/AlphaEdge"
+{
+    HLSLINCLUDE
+
+        #include "Packages/com.unity.postprocessing/PostProcessing/Shaders/StdLib.hlsl"
+
+        TEXTURE2D_SAMPLER2D(_MainTex, sampler_MainTex);
+        float4 _MainTex_TexelSize;
+
+        float4 _EdgeColor;
+        float _Thickness;
+        float _Threshold;
+        float _OutlineOverwriteAlpha;
+        float _HighQualityMode;
+
+        float4 Frag(VaryingsDefault i) : SV_Target
+        {
+            float4 original = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord);
+            float4 result = original;
+
+            float4 offsets = (_Thickness / 1.41421) * _MainTex_TexelSize.xyxy * float4(-0.5, -0.5, 0.5, 0.5);
+            const float lu = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.xw).a;
+            const float rd = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.zy).a;
+            const float ru = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.zw).a;
+            const float ld = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.xy).a;
+
+            float d = length(float2(lu - rd, ld - ru));
+
+            // 8方位に増やす: ちょっと見栄えがよくなる
+            if (_HighQualityMode > 0.5)
+            {
+                float3 offsets2 = _Thickness * _MainTex_TexelSize.xyx * float3(0.5, 0.5, 0.0);
+                const float up = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets2.zy).a;
+                const float down = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord - offsets2.zy).a;
+                const float left = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets2.xz).a;
+                const float right = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord - offsets2.xz).a;
+                d = length(float4(
+                    lu - rd,
+                    ld - ru,
+                    left - right,
+                    up - down
+                    ));
+            }
+
+            // さらに頑張るパターン (ボツ) : 重たい + この方向で高解像度にしてもVRM自体のoutlineがギザギザだと見栄えが改善しないため
+            // float count = 8.0 - 0.001;
+            // float i2rad = 3.14159265 / count;
+            // float d = 0.0;
+            // for (float k = 0; k < count; k += 1.0)
+            // {
+            //     float angle = k * i2rad;
+            //     float2 diff = (_Thickness * 0.5) * _MainTex_TexelSize.xy * float2(cos(angle), sin(angle));
+            //     float a1 = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + diff).a;
+            //     float a2 = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord - diff).a;
+            //     d = max(d, abs(a1 - a2));
+            // }
+            
+            // NOTE: もともと半透明/不透明な場所はアウトライン上書きをしないことに注意
+            const float outline = step(_Threshold, d) * step(original.a, _OutlineOverwriteAlpha);
+            
+            result.a = lerp(original.a, 1.0, outline);
+            result.rgb = lerp(original.rgb, _EdgeColor.rgb, outline);
+            
+            return result;
+        }
+        
+    ENDHLSL
+
+    SubShader
+    {
+        Cull Off ZWrite Off ZTest Always
+
+        Pass
+        {
+            HLSLPROGRAM
+
+                #pragma vertex VertDefault
+                #pragma fragment Frag
+
+            ENDHLSL
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAlphaEdge.shader
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAlphaEdge.shader
@@ -5,6 +5,7 @@ Shader "Hidden/Vmm/AlphaEdge"
         #include "Packages/com.unity.postprocessing/PostProcessing/Shaders/StdLib.hlsl"
 
         TEXTURE2D_SAMPLER2D(_MainTex, sampler_MainTex);
+        TEXTURE2D_SAMPLER2D(_CameraDepthTexture, sampler_CameraDepthTexture);
         float4 _MainTex_TexelSize;
 
         float4 _EdgeColor;
@@ -13,36 +14,51 @@ Shader "Hidden/Vmm/AlphaEdge"
         float _OutlineOverwriteAlpha;
         float _HighQualityMode;
 
-        float4 Frag(VaryingsDefault i) : SV_Target
+        float SampleAlpha(float2 uv)
         {
-            float4 original = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord);
-            float4 result = original;
-
+            return SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv).a;
+        }
+        
+        float GetAlphaBasedD(VaryingsDefault i)
+        {
             float4 offsets = (_Thickness / 1.41421) * _MainTex_TexelSize.xyxy * float4(-0.5, -0.5, 0.5, 0.5);
-            const float lu = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.xw).a;
-            const float rd = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.zy).a;
-            const float ru = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.zw).a;
-            const float ld = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets.xy).a;
+            const float lu = SampleAlpha(i.texcoord + offsets.xw);
+            const float rd = SampleAlpha(i.texcoord + offsets.zy);
+            const float ru = SampleAlpha(i.texcoord + offsets.zw);
+            const float ld = SampleAlpha(i.texcoord + offsets.xy);
 
-            float d = length(float2(lu - rd, ld - ru));
+            float d;
 
-            // 8方位に増やす: ちょっと見栄えがよくなる
+            // optionalに8方位に増やす: ちょっと見栄えがよくなる
             float3 offsets2 = _Thickness * _MainTex_TexelSize.xyx * float3(0.5, 0.5, 0.0);
             if (_HighQualityMode > 0.5)
             {
-                const float up = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets2.zy).a;
-                const float down = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord - offsets2.zy).a;
-                const float left = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + offsets2.xz).a;
-                const float right = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord - offsets2.xz).a;
-                d = length(float4(
-                    lu - rd,
-                    ld - ru,
-                    left - right,
-                    up - down
-                    ));
+                const float up = SampleAlpha(i.texcoord + offsets2.zy);
+                const float down = SampleAlpha(i.texcoord - offsets2.zy);
+                const float left = SampleAlpha(i.texcoord + offsets2.xz);
+                const float right = SampleAlpha(i.texcoord - offsets2.xz);
+                d = max(max(max(
+                    abs(lu - rd),
+                    abs(ld - ru)),
+                    abs(left - right)),
+                    abs(up - down)
+                    );
+                // d = length(float4(
+                //     lu - rd,
+                //     ld - ru,
+                //     left - right,
+                //     up - down
+                //     ));
+            }
+            else
+            {
+                d = max(abs(lu - rd), abs(ld - ru));
+                // d = length(float2(lu - rd, ld - ru));
             }
 
-            // さらに頑張るパターン (ボツ) : 重たい + この方向で高解像度にしてもVRM自体のoutlineがギザギザだと見栄えが改善しないため
+            return d;
+
+            // (ボツ) さらに頑張るパターン : 重たいし、この方向で高解像度にしてもVRM自体のoutlineがギザギザだと見栄えが改善しない
             // float count = 8.0 - 0.001;
             // float i2rad = 3.14159265 / count;
             // float d = 0.0;
@@ -50,25 +66,78 @@ Shader "Hidden/Vmm/AlphaEdge"
             // {
             //     float angle = k * i2rad;
             //     float2 diff = (_Thickness * 0.5) * _MainTex_TexelSize.xy * float2(cos(angle), sin(angle));
-            //     float a1 = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord + diff).a;
-            //     float a2 = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord - diff).a;
+            //     float a1 = SampleAlpha(i.texcoord + diff);
+            //     float a2 = SampleAlpha(_MainTex, sampler_MainTex, i.texcoord - diff).a;
             //     d = max(d, abs(a1 - a2));
             // }
-            
-            // NOTE: もともと半透明/不透明な場所はアウトライン上書きをしないことに注意
+        }
+
+        // NOTE: Depthでエッジ検出する方法も試したが、とくにShadowBoardの実装と相性が悪いのを重く見て不採用にしている
+        float SampleDepth01(float2 uv)
+        {
+            return Linear01Depth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, sampler_CameraDepthTexture, uv));
+        }
+
+        float GetDepthBasedD(VaryingsDefault i)
+        {
+            //NOTE: 最終的にDepthTextureのtexelSizeにしたほうがいいかも
+            float4 offsets = (_Thickness / 1.41421) * _MainTex_TexelSize.xyxy * float4(-0.5, -0.5, 0.5, 0.5);
+            const float lu = SampleDepth01(i.texcoord + offsets.xw);
+            const float rd = SampleDepth01(i.texcoord + offsets.zy);
+            const float ru = SampleDepth01(i.texcoord + offsets.zw);
+            const float ld = SampleDepth01(i.texcoord + offsets.xy);
+
+            float d;
+
+            // optionalに8方位に増やす: ちょっと見栄えがよくなる
+            float3 offsets2 = _Thickness * _MainTex_TexelSize.xyx * float3(0.5, 0.5, 0.0);
+            if (_HighQualityMode > 0.5)
+            {
+                const float up = SampleDepth01(i.texcoord + offsets2.zy);
+                const float down = SampleDepth01(i.texcoord - offsets2.zy);
+                const float left = SampleDepth01(i.texcoord + offsets2.xz);
+                const float right = SampleDepth01(i.texcoord - offsets2.xz);
+                d = length(float4(
+                    lu - rd,
+                    ld - ru,
+                    left - right,
+                    up - down
+                    ));
+            }
+            else
+            {
+                d = length(float2(lu - rd, ld - ru));
+            }
+            return d;
+        }
+        
+        float4 Frag(VaryingsDefault i) : SV_Target
+        {
+            float4 original = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.texcoord);
+            float4 result = original;
+
+            //test: write depth
+            // result.rgb = Linear01Depth(SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, sampler_CameraDepthTexture, i.texcoord));
+            // return result;
+
+            float d = GetAlphaBasedD(i);
+            //float d = GetDepthBasedD(i);
+
+            // NOTE: もともと半透明/不透明な場所はアウトライン上書きをしない…というのが第2項
             const float outline = step(_Threshold, d) * step(original.a, _OutlineOverwriteAlpha);
             
             result.a = lerp(original.a, 1.0, outline);
             result.rgb = lerp(original.rgb, _EdgeColor.rgb, outline);
+            float2 xyOffsets = (_Thickness * 0.5) * _MainTex_TexelSize.xy;
 
             // NOTE: 画面端が不透明なとき、その領域にはOutlineの色が適用される
             // これにより、バストアップ構図で背景透過していると下端にoutlineが効くようになる
             const float edge_factor =
-                step(1.0 - offsets2.x, i.texcoord.x) +
-                step(i.texcoord.x, offsets2.x) +
-                step(1.0 - offsets2.y, i.texcoord.y) +
-                step(i.texcoord.y, offsets2.y);
-
+                step(1.0 - xyOffsets.x, i.texcoord.x) +
+                step(i.texcoord.x, xyOffsets.x) +
+                step(1.0 - xyOffsets.y, i.texcoord.y) +
+                step(i.texcoord.y, xyOffsets.y);
+            
             const float apply_edge_outline =
                 step(1.0, edge_factor) * step(_OutlineOverwriteAlpha, original.a);
             result.a = lerp(result.a, _EdgeColor.a, apply_edge_outline);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAlphaEdge.shader.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAlphaEdge.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 46ea3e410cd895144a0928a45dbe589d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/ProjectSettings/GraphicsSettings.asset
+++ b/VMagicMirror/ProjectSettings/GraphicsSettings.asset
@@ -3,7 +3,7 @@
 --- !u!30 &1
 GraphicsSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 13
+  serializedVersion: 15
   m_Deferred:
     m_Mode: 1
     m_Shader: {fileID: 69, guid: 0000000000000000f000000000000000, type: 0}
@@ -13,9 +13,6 @@ GraphicsSettings:
   m_ScreenSpaceShadows:
     m_Mode: 1
     m_Shader: {fileID: 64, guid: 0000000000000000f000000000000000, type: 0}
-  m_LegacyDeferred:
-    m_Mode: 1
-    m_Shader: {fileID: 63, guid: 0000000000000000f000000000000000, type: 0}
   m_DepthNormals:
     m_Mode: 1
     m_Shader: {fileID: 62, guid: 0000000000000000f000000000000000, type: 0}
@@ -44,7 +41,9 @@ GraphicsSettings:
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 4800000, guid: b296327b68990cc40bd6a2067223ab41, type: 3}
   - {fileID: 4800000, guid: 20913afc4b215a04b9fbe903fbb2d0fa, type: 3}
+  - {fileID: 4800000, guid: 46ea3e410cd895144a0928a45dbe589d, type: 3}
   m_PreloadedShaders: []
+  m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
   m_CustomRenderPipeline: {fileID: 0}
@@ -56,6 +55,7 @@ GraphicsSettings:
   m_LightmapStripping: 0
   m_FogStripping: 0
   m_InstancingStripping: 0
+  m_BrgStripping: 0
   m_LightmapKeepPlain: 1
   m_LightmapKeepDirCombined: 1
   m_LightmapKeepDynamicPlain: 1
@@ -70,3 +70,7 @@ GraphicsSettings:
   m_LightsUseColorTemperature: 0
   m_DefaultRenderingLayerMask: 1
   m_LogWhenShaderIsCompiled: 0
+  m_SRPDefaultSettings: {}
+  m_LightProbeOutsideHullStrategy: 0
+  m_CameraRelativeLightCulling: 0
+  m_CameraRelativeShadowCulling: 0

--- a/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
@@ -53,6 +53,17 @@
 
         #endregion
 
+        #region Outline Effect
+
+        public bool EnableOutlineEffect { get; set; } = false;
+        public int OutlineEffectThickness { get; set; } = 20;
+        public int OutlineEffectR { get; set; } = 255;
+        public int OutlineEffectG { get; set; } = 255;
+        public int OutlineEffectB { get; set; } = 255;
+        public bool OutlineEffectHighQualityMode { get; set; } = false;
+
+        #endregion
+
         #region Wind
 
         public bool EnableWind { get; set; } = true;

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -284,6 +284,11 @@ namespace Baku.VMagicMirrorConfig
         public Message BloomIntensity(int intensityPercent) => WithArg(intensityPercent);
         public Message BloomThreshold(int thresholdPercent) => WithArg(thresholdPercent);
 
+        public Message OutlineEffectEnable(bool active) => WithArg(active);
+        public Message OutlineEffectThickness(int thickness) => WithArg(thickness);
+        public Message OutlineEffectColor(int r, int g, int b) => WithArg($"{r},{g},{b}");
+        public Message OutlineEffectHighQualityMode(bool enable) => WithArg(enable);
+        
         public Message WindEnable(bool enableWind) => WithArg(enableWind);
         public Message WindStrength(int strength) => WithArg(strength);
         public Message WindInterval(int percentage) => WithArg(percentage);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 
 namespace Baku.VMagicMirrorConfig
 {
@@ -48,6 +47,18 @@ namespace Baku.VMagicMirrorConfig
             BloomG = new RProperty<int>(s.BloomG, _ => sendBloomColor());
             BloomB = new RProperty<int>(s.BloomB, _ => sendBloomColor());
 
+            EnableOutlineEffect = new RProperty<bool>(s.EnableOutlineEffect, v => SendMessage(factory.OutlineEffectEnable(v)));
+            OutlineEffectThickness = new RProperty<int>(s.OutlineEffectThickness, v => SendMessage(factory.OutlineEffectThickness(v)));
+            Action sendOutlineEffectColor = () =>
+                SendMessage(factory.OutlineEffectColor(OutlineEffectR?.Value ?? 255, OutlineEffectG?.Value ?? 255, OutlineEffectB?.Value ?? 255));
+            OutlineEffectR = new RProperty<int>(s.OutlineEffectR, _ => sendOutlineEffectColor());
+            OutlineEffectG = new RProperty<int>(s.OutlineEffectG, _ => sendOutlineEffectColor());
+            OutlineEffectB = new RProperty<int>(s.OutlineEffectB, _ => sendOutlineEffectColor());
+            OutlineEffectHighQualityMode = new RProperty<bool>(
+                s.OutlineEffectHighQualityMode,
+                v => SendMessage(factory.OutlineEffectHighQualityMode(v))
+                );
+
             EnableWind = new RProperty<bool>(s.EnableWind, b => SendMessage(factory.WindEnable(b)));
             WindStrength = new RProperty<int>(s.WindStrength, i => SendMessage(factory.WindStrength(i)));
             WindInterval = new RProperty<int>(s.WindInterval, i => SendMessage(factory.WindInterval(i)));
@@ -94,6 +105,18 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<int> BloomR { get; }
         public RProperty<int> BloomG { get; }
         public RProperty<int> BloomB { get; }
+
+        #endregion
+
+        #region OutlineEffect
+
+        public RProperty<bool> EnableOutlineEffect { get; }
+        public RProperty<int> OutlineEffectThickness { get; }
+        public RProperty<bool> OutlineEffectHighQualityMode { get; }
+
+        public RProperty<int> OutlineEffectR { get; }
+        public RProperty<int> OutlineEffectG { get; }
+        public RProperty<int> OutlineEffectB { get; }
 
         #endregion
 
@@ -149,6 +172,17 @@ namespace Baku.VMagicMirrorConfig
             BloomThreshold.Value = setting.BloomThreshold;
         }
 
+        public void ResetOutlineEffectSetting()
+        {
+            var setting = LightSetting.Default;
+            EnableOutlineEffect.Value = setting.EnableOutlineEffect;
+            OutlineEffectThickness.Value = setting.OutlineEffectThickness;
+            OutlineEffectR.Value = setting.OutlineEffectR;
+            OutlineEffectG.Value = setting.OutlineEffectG;
+            OutlineEffectB.Value = setting.OutlineEffectB;
+            OutlineEffectHighQualityMode.Value = setting.OutlineEffectHighQualityMode;
+        }
+
         public void ResetWindSetting()
         {
             var setting = LightSetting.Default;
@@ -163,6 +197,7 @@ namespace Baku.VMagicMirrorConfig
             ResetLightSetting();
             ResetShadowSetting();
             ResetBloomSetting();
+            ResetOutlineEffectSetting();
             ResetWindSetting();
             ResetImageQuality();
         }

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -73,6 +73,7 @@
     <sys:String x:Key="Streaming_Screenshot">Screenshot</sys:String>
     <sys:String x:Key="Streaming_Screenshot_OpenSaveFolder">Saved Folder...</sys:String>
     
+    <sys:String x:Key="Streaming_Visibility_OutlineWillNotWorkWarning">Outline is not applied because "Transparent Window" is off.</sys:String>
     <sys:String x:Key="Streaming_WordToMotion_GameInputActiveWarning">Game Input also uses gamepad!</sys:String>
 
     <!-- Ex.Tracker -->
@@ -459,6 +460,7 @@ Translate (2 way):
     
     <sys:String x:Key="OutlineEffect">Outline (require transparent background)</sys:String>
     <sys:String x:Key="OutlineEffect_Enable">Enable Outline Effect</sys:String>
+    <sys:String x:Key="OutlineEffect_Enable_Short">Outline if BG Transparent</sys:String>
     <sys:String x:Key="OutlineEffect_Thickness">Thickness</sys:String>
     <sys:String x:Key="OutlineEffect_HighQualityMode">High Quality Mode (*Require higher GPU resources)</sys:String>    
     

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -457,6 +457,11 @@ Translate (2 way):
     <sys:String x:Key="Bloom_Intensity">Intensity [%]</sys:String>
     <sys:String x:Key="Bloom_Threshold">Threshold [%]</sys:String>
     
+    <sys:String x:Key="OutlineEffect">Outline (require transparent background)</sys:String>
+    <sys:String x:Key="OutlineEffect_Enable">Enable Outline Effect</sys:String>
+    <sys:String x:Key="OutlineEffect_Thickness">Thickness</sys:String>
+    <sys:String x:Key="OutlineEffect_HighQualityMode">High Quality Mode (*Require higher GPU resources)</sys:String>    
+    
     <sys:String x:Key="Wind">Wind</sys:String>
     <sys:String x:Key="Wind_Enable">Enable Wind</sys:String>
     <sys:String x:Key="Wind_Enable_Streaming">Wind</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -73,6 +73,7 @@
     <sys:String x:Key="Streaming_Screenshot">スクリーンショット</sys:String>
     <sys:String x:Key="Streaming_Screenshot_OpenSaveFolder">保存フォルダ...</sys:String>
     
+    <sys:String x:Key="Streaming_Visibility_OutlineWillNotWorkWarning">「背景を透過」がオフのため縁取りは無効になっています。</sys:String>
     <sys:String x:Key="Streaming_WordToMotion_GameInputActiveWarning">ゲーム入力でもゲームパッドが使われています！</sys:String>
     
     <!-- Ex.Tracker -->
@@ -458,6 +459,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Bloom_Threshold">しきい値[%]</sys:String>
     
     <sys:String x:Key="OutlineEffect">縁取り (背景透過でのみ有効)</sys:String>
+    <sys:String x:Key="OutlineEffect_Enable_Short">縁取り (背景透過時のみ)</sys:String>
     <sys:String x:Key="OutlineEffect_Enable">縁取りエフェクトをオン</sys:String>
     <sys:String x:Key="OutlineEffect_Thickness">縁の分厚さ</sys:String>
     <sys:String x:Key="OutlineEffect_HighQualityMode">高品質モード (*GPU負荷が増えます)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -457,6 +457,11 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Bloom_Intensity">強さ[%]</sys:String>
     <sys:String x:Key="Bloom_Threshold">しきい値[%]</sys:String>
     
+    <sys:String x:Key="OutlineEffect">縁取り (背景透過でのみ有効)</sys:String>
+    <sys:String x:Key="OutlineEffect_Enable">縁取りエフェクトをオン</sys:String>
+    <sys:String x:Key="OutlineEffect_Thickness">縁の分厚さ</sys:String>
+    <sys:String x:Key="OutlineEffect_HighQualityMode">高品質モード (*GPU負荷が増えます)</sys:String>
+    
     <sys:String x:Key="Wind">風</sys:String>
     <sys:String x:Key="Wind_Enable">風を有効化</sys:String>
     <sys:String x:Key="Wind_Enable_Streaming">風</sys:String>

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
@@ -530,6 +530,25 @@
                                   Content="{DynamicResource OutlineEffect_Enable_Short}"
                                   IsChecked="{Binding UseOutlineEffect.Value}"
                                   />
+
+                        <Grid Margin="5"
+                              Visibility="{Binding ShowOutlineEffectWarning.Value,
+                                                   Converter={StaticResource BooleanToVisibilityConverter},
+                                                   FallbackValue=Collapsed}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <md:PackIcon Grid.Column="0"
+                                         VerticalAlignment="Center" 
+                                         Kind="WarningOutline" Foreground="{StaticResource MahApps.Brushes.Accent}" />
+                            <TextBlock Grid.Column="1"
+                                       FontWeight="Bold"
+                                       Text="{DynamicResource Streaming_Visibility_OutlineWillNotWorkWarning}" 
+                                       TextWrapping="Wrap"
+                                       />
+                        </Grid>
+
                         <CheckBox Style="{StaticResource SmallMarginCheckBox}"
                                   Content="{DynamicResource Wind_Enable_Streaming}"
                                   IsChecked="{Binding EnableWind.Value}"
@@ -571,23 +590,6 @@
                             </ComboBox>
                         </Grid>
 
-                        <Grid Margin="5,10"
-                              Visibility="{Binding ShowOutlineEffectWarning.Value,
-                                                   Converter={StaticResource BooleanToVisibilityConverter},
-                                                   FallbackValue=Collapsed}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="*"/>
-                            </Grid.ColumnDefinitions>
-                            <md:PackIcon Grid.Column="0"
-                                         VerticalAlignment="Center" 
-                                         Kind="WarningOutline" Foreground="{StaticResource MahApps.Brushes.Accent}" />
-                            <TextBlock Grid.Column="1"
-                                       FontWeight="Bold"
-                                       Text="{DynamicResource Streaming_Visibility_OutlineWillNotWorkWarning}" 
-                                       TextWrapping="Wrap"
-                                       />
-                        </Grid>
                     </StackPanel>
                 </Border>
 

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
@@ -527,12 +527,12 @@
                                   IsChecked="{Binding EnableShadow.Value}"
                                   />
                         <CheckBox Style="{StaticResource SmallMarginCheckBox}"
-                                  Content="{DynamicResource Wind_Enable_Streaming}"
-                                  IsChecked="{Binding EnableWind.Value}"
+                                  Content="{DynamicResource OutlineEffect_Enable_Short}"
+                                  IsChecked="{Binding UseOutlineEffect.Value}"
                                   />
                         <CheckBox Style="{StaticResource SmallMarginCheckBox}"
-                                  Content="{DynamicResource Light_BgAdjust}"
-                                  IsChecked="{Binding UseDesktopLightAdjust.Value}"
+                                  Content="{DynamicResource Wind_Enable_Streaming}"
+                                  IsChecked="{Binding EnableWind.Value}"
                                   />
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -571,6 +571,23 @@
                             </ComboBox>
                         </Grid>
 
+                        <Grid Margin="5,10"
+                              Visibility="{Binding ShowOutlineEffectWarning.Value,
+                                                   Converter={StaticResource BooleanToVisibilityConverter},
+                                                   FallbackValue=Collapsed}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <md:PackIcon Grid.Column="0"
+                                         VerticalAlignment="Center" 
+                                         Kind="WarningOutline" Foreground="{StaticResource MahApps.Brushes.Accent}" />
+                            <TextBlock Grid.Column="1"
+                                       FontWeight="Bold"
+                                       Text="{DynamicResource Streaming_Visibility_OutlineWillNotWorkWarning}" 
+                                       TextWrapping="Wrap"
+                                       />
+                        </Grid>
                     </StackPanel>
                 </Border>
 

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -626,7 +626,7 @@
                         <CheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
                                   Margin="10,10,10,15"
                                   Content="{DynamicResource OutlineEffect_HighQualityMode}"
-                                  IsChecked="{Binding EnableOutlineEffect.Value}"
+                                  IsChecked="{Binding OutlineEffectHighQualityMode.Value}"
                                   />
 
                     </Grid>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -7,7 +7,7 @@
              xmlns:view="clr-namespace:Baku.VMagicMirrorConfig.View"
              xmlns:vm="clr-namespace:Baku.VMagicMirrorConfig.ViewModel"
              mc:Ignorable="d"
-             d:DesignHeight="1350"
+             d:DesignHeight="2050"
              d:DesignWidth="350"
              >
     <UserControl.DataContext>
@@ -491,6 +491,144 @@
                         <TextBox Grid.Row="1" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderBloomThreshold}"
                                  />
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <Border Style="{StaticResource SideMarginSectionBorder}">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal">
+
+                        <md:PackIcon Kind="BabyFaceOutline"
+                                     Style="{StaticResource SettingHeaderPackIcon}"
+                                     />
+
+                        <TextBlock Text="{DynamicResource OutlineEffect}"
+                                   Margin="5"
+                                   Style="{StaticResource HeaderText}"
+                                   />
+
+                        <md:Card Style="{StaticResource ColorIndicatorCard}">
+                            <Rectangle>
+                                <Rectangle.Fill>
+                                    <SolidColorBrush Color="{Binding OutlineEffectColor}"/>
+                                </Rectangle.Fill>
+                            </Rectangle>
+                        </md:Card>
+
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetOutlineEffectSettingCommand}"
+                                />
+                    </StackPanel>
+
+                    <CheckBox Margin="10,5,10,5"
+                              Content="{DynamicResource OutlineEffect_Enable}"
+                              IsChecked="{Binding EnableOutlineEffect.Value}"
+                              />
+
+                    <md:Card md:ShadowAssist.ShadowDepth="Depth1" 
+                             Margin="5,10" 
+                             Padding="0">
+
+                        <Expander Margin="0">
+                            <Expander.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <md:PackIcon Kind="Edit" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{DynamicResource Setting_Color_Expander_Header}"/>
+                                </StackPanel>
+                            </Expander.Header>
+
+                            <Grid>
+                                <Grid.Resources>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                        <Setter Property="TextAlignment" Value="Center"/>
+                                    </Style>
+                                </Grid.Resources>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition />
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="30"/>
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Row="0" Grid.Column="0"
+                                           Text="R"/>
+                                <Slider Grid.Row="0" Grid.Column="1"
+                                        x:Name="sliderOutlineEffectR"
+                                        Value="{Binding OutlineEffectR.Value, Mode=TwoWay}"
+                                        />
+                                <TextBox Grid.Row="0" Grid.Column="2"
+                                         Text="{Binding Value, ElementName=sliderOutlineEffectR}"
+                                         />
+
+                                <TextBlock Grid.Row="1" Grid.Column="0"
+                                           Text="G"/>
+                                <Slider Grid.Row="1" Grid.Column="1"
+                                        x:Name="sliderOutlineEffectG"
+                                        Value="{Binding OutlineEffectG.Value, Mode=TwoWay}"
+                                        />
+                                <TextBox Grid.Row="1" Grid.Column="2"
+                                         Text="{Binding Value, ElementName=sliderOutlineEffectG}"
+                                         />
+
+                                <TextBlock Grid.Row="2" Grid.Column="0"
+                                           Text="B"/>
+                                <Slider Grid.Row="2" Grid.Column="1"
+                                        x:Name="sliderOutlineEffectB"
+                                        Value="{Binding OutlineEffectB.Value, Mode=TwoWay}"
+                                        />
+                                <TextBox Grid.Row="2" Grid.Column="2"
+                                         Text="{Binding Value, ElementName=sliderOutlineEffectB}"
+                                         />
+
+                                <md:ColorPicker Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="3" 
+                                                Height="200"
+                                                Margin="20"
+                                                Color="{Binding OutlineEffectColor, Mode=TwoWay}"
+                                                />
+                            </Grid>
+                        </Expander>
+                    </md:Card>
+
+                    <Grid Margin="5">
+                        <Grid.Resources>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                <Setter Property="TextAlignment" Value="Center"/>
+                            </Style>
+                        </Grid.Resources>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0"
+                                   Text="{DynamicResource OutlineEffect_Thickness}" />
+                        <Slider Grid.Row="0" Grid.Column="1"
+                                x:Name="sliderOutlineEffectThickness"
+                                Minimum="1"
+                                Maximum="150"
+                                Value="{Binding OutlineEffectThickness.Value, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="0" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderOutlineEffectThickness}"
+                                 />
+
+                        <CheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3"
+                                  Margin="10,10,10,15"
+                                  Content="{DynamicResource OutlineEffect_HighQualityMode}"
+                                  IsChecked="{Binding EnableOutlineEffect.Value}"
+                                  />
+
                     </Grid>
                 </StackPanel>
             </Border>

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/StreamingTabViewModels.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/StreamingTabViewModels.cs
@@ -1,5 +1,6 @@
 ﻿using Baku.VMagicMirrorConfig.View;
 using MaterialDesignThemes.Wpf;
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
@@ -271,6 +272,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel.StreamingTabViewModels
     {
         public VisibilityViewModel() : this(
             ModelResolver.Instance.Resolve<LoadedAvatarInfo>(),
+            ModelResolver.Instance.Resolve<WindowSettingModel>(),
             ModelResolver.Instance.Resolve<LayoutSettingModel>(),
             ModelResolver.Instance.Resolve<GamepadSettingModel>(),
             ModelResolver.Instance.Resolve<LightSettingModel>()
@@ -280,11 +282,13 @@ namespace Baku.VMagicMirrorConfig.ViewModel.StreamingTabViewModels
 
         internal VisibilityViewModel(
             LoadedAvatarInfo loadedAvatar,
+            WindowSettingModel window,
             LayoutSettingModel layout, 
             GamepadSettingModel gamepad, 
             LightSettingModel effects)
         {
             _loadedAvatar = loadedAvatar;
+            _window = window;
             _layout = layout;
             _gamepad = gamepad;
             _effects = effects;
@@ -301,10 +305,15 @@ namespace Baku.VMagicMirrorConfig.ViewModel.StreamingTabViewModels
                 _layout.SelectedTypingEffectId.AddWeakEventHandler(OnTypingEffectIdChanged);
                 _typingEffectItem = TypingEffectSelections
                     .FirstOrDefault(v => v.Id == _layout.SelectedTypingEffectId.Value);
+
+                _window.IsTransparent.AddWeakEventHandler(OnOutlineEffectWarningMaybeChanged);
+                _effects.EnableOutlineEffect.AddWeakEventHandler(OnOutlineEffectWarningMaybeChanged);
+                ShowOutlineEffectWarning.Value = !_window.IsTransparent.Value && _effects.EnableOutlineEffect.Value;
             }
         }
 
         private readonly LoadedAvatarInfo _loadedAvatar;
+        private readonly WindowSettingModel _window;
         private readonly LayoutSettingModel _layout;
         private readonly GamepadSettingModel _gamepad;
         private readonly LightSettingModel _effects;
@@ -315,9 +324,22 @@ namespace Baku.VMagicMirrorConfig.ViewModel.StreamingTabViewModels
         public RProperty<bool> GamepadVisibility => _gamepad.GamepadVisibility;
         public RProperty<bool> EnableShadow => _effects.EnableShadow;
         public RProperty<bool> EnableWind => _effects.EnableWind;
-        public RProperty<bool> UseDesktopLightAdjust => _effects.UseDesktopLightAdjust;
+
+        //public RProperty<bool> UseDesktopLightAdjust => _effects.UseDesktopLightAdjust;
+        public RProperty<bool> UseOutlineEffect => _effects.EnableOutlineEffect;
+
+        /// <summary>
+        /// 背景不透明なのに縁取りエフェクトをオンにしているあいだtrueになる
+        /// </summary>
+        public RProperty<bool> ShowOutlineEffectWarning { get; } = new(false);
 
         public ActionCommand ShowPenUnavaiableWarningCommand { get; }
+
+
+        private void OnOutlineEffectWarningMaybeChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            ShowOutlineEffectWarning.Value = !_window.IsTransparent.Value && _effects.EnableOutlineEffect.Value;
+        }
 
 
         #region タイピングエフェクト

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -38,6 +38,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             ResetBloomSettingCommand = new ActionCommand(
                 () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetBloomSetting)
                 );
+            ResetOutlineEffectSettingCommand = new ActionCommand(
+                () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetOutlineEffectSetting)
+                );
             ResetWindSettingCommand = new ActionCommand(
                 () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetWindSetting)
                 );
@@ -55,6 +58,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 model.BloomR.AddWeakEventHandler(UpdateBloomColor);
                 model.BloomG.AddWeakEventHandler(UpdateBloomColor);
                 model.BloomB.AddWeakEventHandler(UpdateBloomColor);
+               
+                model.OutlineEffectR.AddWeakEventHandler(UpdateOutlineEffectColor);
+                model.OutlineEffectG.AddWeakEventHandler(UpdateOutlineEffectColor);
+                model.OutlineEffectB.AddWeakEventHandler(UpdateOutlineEffectColor);
             }
         }
 
@@ -78,6 +85,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         void UpdateLightColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(LightColor));
         void UpdateBloomColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(BloomColor));
+        void UpdateOutlineEffectColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(OutlineEffectColor));
 
         void ApplyAntiAliasStyle(object? sender, PropertyChangedEventArgs e) 
             => AntiAliasStyle.Value = GetAntiAliasStyle(_model.AntiAliasStyle.Value);
@@ -158,6 +166,28 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         #endregion
 
+        #region OutlineEffect
+
+        public RProperty<bool> EnableOutlineEffect => _model.EnableOutlineEffect;
+        public RProperty<int> OutlineEffectThickness => _model.OutlineEffectThickness;
+        public RProperty<int> OutlineEffectR => _model.OutlineEffectR;
+        public RProperty<int> OutlineEffectG => _model.OutlineEffectG;
+        public RProperty<int> OutlineEffectB => _model.OutlineEffectB;
+        public RProperty<bool> OutlineEffectHighQualityMode => _model.OutlineEffectHighQualityMode;
+
+        public Color OutlineEffectColor
+        {
+            get => Color.FromRgb((byte)OutlineEffectR.Value, (byte)OutlineEffectG.Value, (byte)OutlineEffectB.Value);
+            set
+            {
+                OutlineEffectR.Value = value.R;
+                OutlineEffectG.Value = value.G;
+                OutlineEffectB.Value = value.B;
+            }
+        }
+
+        #endregion
+
         #region Wind
 
         public RProperty<bool> EnableWind => _model.EnableWind;
@@ -172,6 +202,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand ResetLightSettingCommand { get; }
         public ActionCommand ResetShadowSettingCommand { get; }
         public ActionCommand ResetBloomSettingCommand { get; }
+        public ActionCommand ResetOutlineEffectSettingCommand { get; }
         public ActionCommand ResetWindSettingCommand { get; }
 
         private async void ResetImageQuality()


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature

## What the PR does

fixed #1021 

根本的な実装

- PPsで実装されている
- PPsへの入力に対してalphaベースでエッジを検出することでoutlineをつけている

妥協点

- 影をめっちゃ濃くすると影に対してアウトラインが出てしまうが、マイナーケースという事にして妥協している

ついででやってる

- このオプションを配信タブに導入するため、「デスクトップ色調でライト補正」を配信タブから削除
- 「ボーンの低FPS」オプションがVRM1.0対応の影響で動かなくなってたので、最低限動くようにメンテ

## How to confirm

- [x] 配信タブ、または詳細設定ウィンドウのエフェクトタブから縁取りが表示できる
- [x] 詳細設定ウィンドウで色、厚さ、品質が設定できる
- [x] 背景透過がオフの場合、「縁取り」がオンであっても実際にはoutlineは適用されず、かつ配信タブに専用の警告表示が出る
- [x] outlineと影が両方オンのとき、影よりは手前にアウトラインが表示でき、かつ影に対してoutlineが出てしまわない

