### PR TITLE
パーフェクトシンク無しのiFacialMocap連携時に片目だけが半目になる問題を対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/FaceController.prefab
@@ -31,14 +31,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3748028266611161173}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3748028267383499194}
   - {fileID: 3752062569261173665}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5395904245375780253
 MonoBehaviour:
@@ -187,12 +188,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3748028267383499195}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3748028266611161172}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3748028267383499190
 MonoBehaviour:
@@ -280,7 +282,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   eyeMapMin: 0.25
   eyeMapMax: 0.7
-  blinkValueOnSquint: 0.5
+  blinkValueOnSquint: 0.3
   blinkOpenSpeedMax: 0.1
 --- !u!114 &1428360342779558990
 MonoBehaviour:
@@ -350,12 +352,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3748904030990320353}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3748028266611161172}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!82 &3828096490885343573
 AudioSource:
@@ -546,3 +549,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   audioSource: {fileID: 0}
   provider: 0
+  enableAcceleration: 1

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerBlink.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerBlink.cs
@@ -49,7 +49,7 @@ namespace Baku.VMagicMirror
             float right = MapClamp(rawRightBlink);
             if (right < 0.9f)
             {
-                Mathf.Lerp(right, blinkValueOnSquint, rawRightSquint);
+                right = Mathf.Lerp(right, blinkValueOnSquint, rawRightSquint);
             }
             right = Mathf.Clamp(right, _blinkSource.Right - subLimit, 1.0f);
             _blinkSource.Right = Mathf.Clamp01(right);


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #1051 

- iFacialMocapから送信されるブレンドシェイプのうち `eyeSquint` を右目にだけ反映出来てなかったのを修正
    - これによって左右の目の挙動差を修正
- 元のフィードバックで言われている事象について、Squintのブレンドシェイプが大きいときのBlinkがあまり大きくならないように調整
    - つまり、Squintのブレンドシェイプが効いててもあまり半目にならないようにした

## How to confirm

Editor上でVRoid Sample Aを使って大まかに確認済

## Note 

Authorはそもそも半目になる事象をあまり起こせてないので、そういう意味では検証は不徹底かも
