### PR TITLE
Spout出力にMangaエフェクトの文字が映らないのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Particle/MangaParticleView.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Particle/MangaParticleView.prefab
@@ -58,9 +58,9 @@ Canvas:
   m_GameObject: {fileID: 277784890188760130}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
+  m_RenderMode: 1
   m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
+  m_PlaneDistance: 0.09
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
   m_OverrideSorting: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer.unity
@@ -1199,6 +1199,11 @@ PrefabInstance:
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4532191653127153807, guid: 24289ce6f3f366c4088007663df50e59,
+        type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 1629460661}
     - target: {fileID: 5933559195360744184, guid: 24289ce6f3f366c4088007663df50e59,
         type: 3}
       propertyPath: m_RootOrder


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #1072

修正としてはissue側に記載の通り、近距離のScreenSpace UI扱いにすることで回避している。

## How to confirm

- Editor + WPF Buildで確認

## Note

- 最前面表示モードのアクセサリーのほうがMangaエフェクトより前面にでてしまうのを確認済み
- これはアクセサリー用マテリアルのRender Queueが大きいのが原因であり、直しづらいので今回は放置で…
