### PR TITLE
VRM1.0モデル向けの目の回転処理が不適切だったのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
@@ -114,7 +114,7 @@ namespace Baku.VMagicMirror
                 //NOTE: UniVRMの適用タイミングに依存したくないので、自前で勝手に仮想ボーンを入れておく
                 _leftEye = leftEyeBone.ControlTarget;
                 _leftEyeInitialLocalRot = _leftEye.localRotation;
-                _leftEyeInitialLocalRot = _leftEye.rotation;
+                _leftEyeInitialGlobalRot = _leftEye.rotation;
             }
             _hasRightEyeBone = controlRigBones.TryGetValue(HumanBodyBones.RightEye, out var rightEyeBone);
             if (_hasRightEyeBone && rightEyeBone != null)


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixed #1081 

- コード差分に示す通り、仮想ボーンの初期化で参照してるボーンが間違っていたのが原因で、パーフェクトシンクとは無関係
- VRM0の場合、どのボーンもワールドXYZ軸に沿っているので、このミスによる実害はなかった

## How to confirm

- #1081 のユーザー報告で共有されたモデルについて、目が正面方向付近を向いた状態になり、かつ視線の動きも反映されること

