### PR TITLE
VMCProtocolでパーフェクトシンクっぽい値が受信できている場合はFace Switchの入力につなぐ

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
@@ -168,19 +168,20 @@ namespace Baku.VMagicMirror
             // NOTE:
             // 誰もUpdateを呼んでない場合、トラッキングロストしている or Webカメラ等が完全に止まってるはずなので、
             // その場合も何も適用しない
-            if (!_faceSwitch.UpdateCalled || _faceSwitchItem.IsEmpty)
+            if (_faceSwitch.UpdateCalled && !_faceSwitchItem.IsEmpty)
+            {
+                _currentValue.Value = FaceSwitchKeyApplyContent.Create(
+                    ExpressionKeyUtils.CreateKeyByName(_faceSwitchItem.ClipName),
+                    _faceSwitchItem.KeepLipSync,
+                    _faceSwitchItem.AccessoryName
+                );
+            }
+            else
             {
                 _currentValue.Value = FaceSwitchKeyApplyContent.Empty();
-                _config.FaceSwitchActive = false;
-                return;
             }
 
             _faceSwitch.ResetUpdateCalledFlag();
-            _currentValue.Value = FaceSwitchKeyApplyContent.Create(
-                ExpressionKeyUtils.CreateKeyByName(_faceSwitchItem.ClipName),
-                _faceSwitchItem.KeepLipSync,
-                _faceSwitchItem.AccessoryName
-            );
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBlendShape.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBlendShape.cs
@@ -11,9 +11,11 @@ namespace Baku.VMagicMirror.VMCP
     /// </summary>
     public class VMCPBlendShape : PresenterBase, ITickable
     {
+        // Perfect Syncっぽいキーをこの数の種類だけ受信した場合、送信元が送っているのがパーフェクトシンク用のキー情報であると見なす
+        private const int CountToTreatPerfectSyncValid = 26;
         private const float DisconnectCount = VMCPReceiver.DisconnectCount;
 
-        private static readonly HashSet<ExpressionKey> LipSyncKeys = new HashSet<ExpressionKey>()
+        private static readonly HashSet<ExpressionKey> LipSyncKeys = new()
         {
             ExpressionKey.Aa,
             ExpressionKey.Ee,
@@ -22,15 +24,24 @@ namespace Baku.VMagicMirror.VMCP
             ExpressionKey.Ou,
         };
 
-        private readonly List<ExpressionKey> _keys = new List<ExpressionKey>();
-        private readonly Dictionary<ExpressionKey, float> _internalValues = new Dictionary<ExpressionKey, float>();
-        private readonly Dictionary<ExpressionKey, float> _values = new Dictionary<ExpressionKey, float>();
+        private readonly List<ExpressionKey> _keys = new();
+        private readonly Dictionary<ExpressionKey, float> _internalValues = new();
+        private readonly Dictionary<ExpressionKey, float> _values = new();
         //送信側がVRM0.xのケースと1.0のケースで都合が変わるんですよ信じられますか
-        private readonly Dictionary<string, ExpressionKey> _stringToKeyCache = new Dictionary<string, ExpressionKey>();
+        private readonly Dictionary<string, ExpressionKey> _stringToKeyCache = new();
 
-        private readonly ReactiveProperty<bool> _isActive = new ReactiveProperty<bool>(false);
+        private readonly ReactiveProperty<bool> _isActive = new(false);
         public IReadOnlyReactiveProperty<bool> IsActive => _isActive;
 
+        private readonly RecordFaceTrackBlendShapes _faceSwitchBlendShapes = new();
+        // NOTE: この値は「受信値がPerfect SyncっぽければFace Switchの入力値にしていい値」として公開する。
+        // ただし、VMCPで常にPerfect Syncを受信するわけではないので、その判定も別途やっている…というのがすぐ下のRP<bool>
+        public IFaceTrackBlendShapes FaceTrackBlendShapes => _faceSwitchBlendShapes;
+
+        private readonly ReactiveProperty<bool> _seemsToHavePerfectSyncData = new();
+        public IReadOnlyReactiveProperty<bool> SeemsToHavePerfectSyncData => _seemsToHavePerfectSyncData;
+        private readonly HashSet<string> _receivedPerfectSyncKeys = new();
+        
         private bool _hasModel;
         private readonly IVRMLoadable _vrmLoadable;
 
@@ -89,6 +100,14 @@ namespace Baku.VMagicMirror.VMCP
             _internalValues[key] = Mathf.Clamp01(value);
             _isConnected = true;
             _disconnectCountDown = DisconnectCount;
+
+            var isPerfectSyncKey = VMCPBlendShapePerfectSyncKeys.TrySet(
+                rawKey, value, _faceSwitchBlendShapes, out var camelCaseKey);
+            if (isPerfectSyncKey && !_seemsToHavePerfectSyncData.Value)
+            {
+                _receivedPerfectSyncKeys.Add(camelCaseKey);
+                _seemsToHavePerfectSyncData.Value = _receivedPerfectSyncKeys.Count >= CountToTreatPerfectSyncValid;
+            }
         }
 
         private void ResetValues()
@@ -98,6 +117,9 @@ namespace Baku.VMagicMirror.VMCP
                 _internalValues[key] = 0f;
                 _values[key] = 0f;
             }
+            
+            _receivedPerfectSyncKeys.Clear();
+            _seemsToHavePerfectSyncData.Value = false;
         }
         
         public void Apply()
@@ -151,7 +173,7 @@ namespace Baku.VMagicMirror.VMCP
             }
 
             // ここでVRM0用のキーも入れておくことで、VRM0.xのSender Appから「A」が来たとき「Aa」に紐付ける…みたいな措置が取れる。
-            // * Senderが VRM1.0未対応なケースをケアしないで良くなったら消したいが、2023-24年くらいでは絶対そうならないと思う
+            // * Senderが VRM1.0未対応なケースをケアしないで良くなったら消したいが、2025年内とかでは絶対そうならないと思う
             var vrm0KeyMap = Vrm0BlendShapeKeyUtils.CreateVrm0StringKeyToVrm1KeyMap();
             foreach (var pair in vrm0KeyMap)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBlendShapeKeys.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBlendShapeKeys.cs
@@ -1,0 +1,173 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Baku.VMagicMirror.VMCP
+{
+    public static class VMCPBlendShapePerfectSyncKeys
+    {
+        public static bool TrySet(string rawKey, float value, RecordFaceTrackBlendShapes dest, out string camelCaseKey)
+        {
+            if (string.IsNullOrEmpty(rawKey) || rawKey.Length < 7)
+            {
+                camelCaseKey = "";
+                return false;
+            }
+
+            // NOTE: PascalCaseも含めてswitchさせたらこれを省けるが、それはそれでめんどいので無し
+            var key = char.ToLower(rawKey[0]) + rawKey[1..];
+
+            switch (key)
+            {
+                // 目
+                case CamelCaseKeys.eyeBlinkLeft: dest.Eye.LeftBlink = value; break;
+                case CamelCaseKeys.eyeLookUpLeft: dest.Eye.LeftLookUp = value; break;
+                case CamelCaseKeys.eyeLookDownLeft: dest.Eye.LeftLookDown = value; break;
+                case CamelCaseKeys.eyeLookInLeft: dest.Eye.LeftLookIn = value; break;
+                case CamelCaseKeys.eyeLookOutLeft: dest.Eye.LeftLookOut = value; break;
+                case CamelCaseKeys.eyeWideLeft: dest.Eye.LeftWide = value; break;
+                case CamelCaseKeys.eyeSquintLeft: dest.Eye.LeftSquint = value; break;
+
+                case CamelCaseKeys.eyeBlinkRight: dest.Eye.RightBlink = value; break;
+                case CamelCaseKeys.eyeLookUpRight: dest.Eye.RightLookUp = value; break;
+                case CamelCaseKeys.eyeLookDownRight: dest.Eye.RightLookDown = value; break;
+                case CamelCaseKeys.eyeLookInRight: dest.Eye.RightLookIn = value; break;
+                case CamelCaseKeys.eyeLookOutRight: dest.Eye.RightLookOut = value; break;
+                case CamelCaseKeys.eyeWideRight: dest.Eye.RightWide = value; break;
+                case CamelCaseKeys.eyeSquintRight: dest.Eye.RightSquint = value; break;
+
+                //口(多い)
+                case CamelCaseKeys.mouthLeft: dest.Mouth.Left = value; break;
+                case CamelCaseKeys.mouthSmileLeft: dest.Mouth.LeftSmile = value; break;
+                case CamelCaseKeys.mouthFrownLeft: dest.Mouth.LeftFrown = value; break;
+                case CamelCaseKeys.mouthPressLeft: dest.Mouth.LeftPress = value; break;
+                case CamelCaseKeys.mouthUpperUpLeft: dest.Mouth.LeftUpperUp = value; break;
+                case CamelCaseKeys.mouthLowerDownLeft: dest.Mouth.LeftLowerDown = value; break;
+                case CamelCaseKeys.mouthStretchLeft: dest.Mouth.LeftStretch = value; break;
+                case CamelCaseKeys.mouthDimpleLeft: dest.Mouth.LeftDimple = value; break;
+
+                case CamelCaseKeys.mouthRight: dest.Mouth.Right = value; break;
+                case CamelCaseKeys.mouthSmileRight: dest.Mouth.RightSmile = value; break;
+                case CamelCaseKeys.mouthFrownRight: dest.Mouth.RightFrown = value; break;
+                case CamelCaseKeys.mouthPressRight: dest.Mouth.RightPress = value; break;
+                case CamelCaseKeys.mouthUpperUpRight: dest.Mouth.RightUpperUp = value; break;
+                case CamelCaseKeys.mouthLowerDownRight: dest.Mouth.RightLowerDown = value; break;
+                case CamelCaseKeys.mouthStretchRight: dest.Mouth.RightStretch = value; break;
+                case CamelCaseKeys.mouthDimpleRight: dest.Mouth.RightDimple = value; break;
+
+                case CamelCaseKeys.mouthClose: dest.Mouth.Close = value; break;
+                case CamelCaseKeys.mouthFunnel: dest.Mouth.Funnel = value; break;
+                case CamelCaseKeys.mouthPucker: dest.Mouth.Pucker = value; break;
+                case CamelCaseKeys.mouthShrugUpper: dest.Mouth.ShrugUpper = value; break;
+                case CamelCaseKeys.mouthShrugLower: dest.Mouth.ShrugLower = value; break;
+                case CamelCaseKeys.mouthRollUpper: dest.Mouth.RollUpper = value; break;
+                case CamelCaseKeys.mouthRollLower: dest.Mouth.RollLower = value; break;
+
+                //あご
+                case CamelCaseKeys.jawOpen: dest.Jaw.Open = value; break;
+                case CamelCaseKeys.jawForward: dest.Jaw.Forward = value; break;
+                case CamelCaseKeys.jawLeft: dest.Jaw.Left = value; break;
+                case CamelCaseKeys.jawRight: dest.Jaw.Right = value; break;
+
+                //鼻
+                case CamelCaseKeys.noseSneerLeft: dest.Nose.LeftSneer = value; break;
+                case CamelCaseKeys.noseSneerRight: dest.Nose.RightSneer = value; break;
+
+                //ほお
+                case CamelCaseKeys.cheekPuff: dest.Cheek.Puff = value; break;
+                case CamelCaseKeys.cheekSquintLeft: dest.Cheek.LeftSquint = value; break;
+                case CamelCaseKeys.cheekSquintRight: dest.Cheek.RightSquint = value; break;
+
+                // 舌
+                case CamelCaseKeys.tongueOut: dest.Tongue.TongueOut = value; break;
+
+                //まゆげ
+                case CamelCaseKeys.browDownLeft: dest.Brow.LeftDown = value; break;
+                case CamelCaseKeys.browOuterUpLeft: dest.Brow.LeftOuterUp = value; break;
+                case CamelCaseKeys.browDownRight: dest.Brow.RightDown = value; break;
+                case CamelCaseKeys.browOuterUpRight: dest.Brow.RightOuterUp = value; break;
+                case CamelCaseKeys.browInnerUp: dest.Brow.InnerUp = value; break;
+
+                
+                default:
+                    camelCaseKey = "";
+                    return false;
+            }
+
+            // ここに到達 = defaultのとこを通ってないので有効なキー
+            camelCaseKey = key;
+            return true;
+        }
+
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
+        private static class CamelCaseKeys
+        {
+            //目
+            public const string eyeBlinkLeft = nameof(eyeBlinkLeft);
+            public const string eyeLookUpLeft = nameof(eyeLookUpLeft);
+            public const string eyeLookDownLeft = nameof(eyeLookDownLeft);
+            public const string eyeLookInLeft = nameof(eyeLookInLeft);
+            public const string eyeLookOutLeft = nameof(eyeLookOutLeft);
+            public const string eyeWideLeft = nameof(eyeWideLeft);
+            public const string eyeSquintLeft = nameof(eyeSquintLeft);
+
+            public const string eyeBlinkRight = nameof(eyeBlinkRight);
+            public const string eyeLookUpRight = nameof(eyeLookUpRight);
+            public const string eyeLookDownRight = nameof(eyeLookDownRight);
+            public const string eyeLookInRight = nameof(eyeLookInRight);
+            public const string eyeLookOutRight = nameof(eyeLookOutRight);
+            public const string eyeWideRight = nameof(eyeWideRight);
+            public const string eyeSquintRight = nameof(eyeSquintRight);
+
+            //口(多い)
+            public const string mouthLeft = nameof(mouthLeft);
+            public const string mouthSmileLeft = nameof(mouthSmileLeft);
+            public const string mouthFrownLeft = nameof(mouthFrownLeft);
+            public const string mouthPressLeft = nameof(mouthPressLeft);
+            public const string mouthUpperUpLeft = nameof(mouthUpperUpLeft);
+            public const string mouthLowerDownLeft = nameof(mouthLowerDownLeft);
+            public const string mouthStretchLeft = nameof(mouthStretchLeft);
+            public const string mouthDimpleLeft = nameof(mouthDimpleLeft);
+
+            public const string mouthRight = nameof(mouthRight);
+            public const string mouthSmileRight = nameof(mouthSmileRight);
+            public const string mouthFrownRight = nameof(mouthFrownRight);
+            public const string mouthPressRight = nameof(mouthPressRight);
+            public const string mouthUpperUpRight = nameof(mouthUpperUpRight);
+            public const string mouthLowerDownRight = nameof(mouthLowerDownRight);
+            public const string mouthStretchRight = nameof(mouthStretchRight);
+            public const string mouthDimpleRight = nameof(mouthDimpleRight);
+
+            public const string mouthClose = nameof(mouthClose);
+            public const string mouthFunnel = nameof(mouthFunnel);
+            public const string mouthPucker = nameof(mouthPucker);
+            public const string mouthShrugUpper = nameof(mouthShrugUpper);
+            public const string mouthShrugLower = nameof(mouthShrugLower);
+            public const string mouthRollUpper = nameof(mouthRollUpper);
+            public const string mouthRollLower = nameof(mouthRollLower);
+
+            //あご
+            public const string jawOpen = nameof(jawOpen);
+            public const string jawForward = nameof(jawForward);
+            public const string jawLeft = nameof(jawLeft);
+            public const string jawRight = nameof(jawRight);
+
+            //鼻
+            public const string noseSneerLeft = nameof(noseSneerLeft);
+            public const string noseSneerRight = nameof(noseSneerRight);
+
+            //ほお
+            public const string cheekPuff = nameof(cheekPuff);
+            public const string cheekSquintLeft = nameof(cheekSquintLeft);
+            public const string cheekSquintRight = nameof(cheekSquintRight);
+
+            //舌
+            public const string tongueOut = nameof(tongueOut);
+
+            //まゆげ
+            public const string browDownLeft = nameof(browDownLeft);
+            public const string browOuterUpLeft = nameof(browOuterUpLeft);
+            public const string browDownRight = nameof(browDownRight);
+            public const string browOuterUpRight = nameof(browOuterUpRight);
+            public const string browInnerUp = nameof(browInnerUp);
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBlendShapeKeys.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBlendShapeKeys.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d2df6c0b5825c14f8468ce8e009e49c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPFaceSwitchSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPFaceSwitchSetter.cs
@@ -1,0 +1,27 @@
+using Zenject;
+
+namespace Baku.VMagicMirror.VMCP
+{
+    public class VMCPFaceSwitchSetter : ITickable
+    {
+        private readonly VMCPBlendShape _blendShape;
+        private readonly FaceSwitchExtractor _faceSwitch;
+
+        [Inject]
+        public VMCPFaceSwitchSetter(VMCPBlendShape blendShape, FaceSwitchExtractor faceSwitch)
+        {
+            _blendShape = blendShape;
+            _faceSwitch = faceSwitch;
+        }
+
+        void ITickable.Tick()
+        {
+            // NOTE: 単にブレンドシェイプを受信していることだけでなく、
+            // 「パーフェクトシンクっぽいデータを受け取っている」という条件もつけていることに注意
+            if (_blendShape.IsActive.Value && _blendShape.SeemsToHavePerfectSyncData.Value)
+            {
+                _faceSwitch.Update(_blendShape.FaceTrackBlendShapes);
+            }
+        }
+    }    
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPFaceSwitchSetter.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPFaceSwitchSetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c8b9893673600a4393abf3e12ffe032
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/VMCPInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/VMCPInstaller.cs
@@ -32,8 +32,9 @@ namespace Baku.VMagicMirror
             Container.BindIFactory<uOscClient>()
                 .FromComponentInNewPrefab(oscClientPrefab)
                 .AsSingle();
-            Container.BindInterfacesTo<VMCPSender>()
-                .AsSingle();
+            Container.BindInterfacesTo<VMCPSender>().AsSingle();
+
+            Container.BindInterfacesTo<VMCPFaceSwitchSetter>().AsSingle();
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFaceSwitchSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFaceSwitchSetter.cs
@@ -1,4 +1,3 @@
-using Baku.VMagicMirror.ExternalTracker;
 using Zenject;
 
 namespace Baku.VMagicMirror.MediaPipeTracker


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixed #984 

- パーフェクトシンク用キーの半数にあたる26個以上を受信できているとき、そのデータもFace Switchの入力に使われる。

妥協してるポイント

- iFacialMocapやwebカメラが同時に繋がっており、かつこれらの入力からも有効なFace Switchが検出できてしまう場合、Face Switchの出力が安定しないかも
- 説明はあんまり親切ではない: 現状だと裏技に近い

## How to confirm

- わざと別アプリ経由でiFacialMocapの表情をVMCPとして受信したとき、その表情に基づいて「頬をふくらませると」等のFace Switchが動作すること
