### PR TITLE
MediaPipe用のモデルファイルがビルド時に削除対象になっていたのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Editor/BuildHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Editor/BuildHelper.cs
@@ -152,16 +152,17 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            //VRMLoaderUI以外のディレクトリは削除
+            // フォルダ: VRMLoaderUI, MediaPipeTrackerだけがruntimeで必要
             foreach (var dir in Directory.GetDirectories(streamingAssetDir))
             {
-                if (Path.GetFileName(dir) != StreamingAssetFileNames.LoaderUiFolder)
+                if (Path.GetFileName(dir) != StreamingAssetFileNames.LoaderUiFolder &&
+                    Path.GetFileName(dir) != StreamingAssetFileNames.MediaPipeTrackerFolder)
                 {
                     Directory.Delete(dir, true);
                 }
             }
             
-            //顔トラッキングのモデルファイル以外のファイルも削除
+            //　ファイル: Dlibの顔トラッキングのファイルだけStreamingAssets直下に置く想定
             foreach (var file in Directory.GetFiles(streamingAssetDir))
             {
                 var fileName = Path.GetFileName(file);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Utils/FilePathUtil.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Utils/FilePathUtil.cs
@@ -9,7 +9,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         {
             return Path.Combine(
                 Application.streamingAssetsPath,
-                "MediaPipeTracker",
+                StreamingAssetFileNames.MediaPipeTrackerFolder,
                 fileName
             );
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Utils/FilePathUtil.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Utils/FilePathUtil.cs
@@ -9,7 +9,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         {
             return Path.Combine(
                 Application.streamingAssetsPath,
-                "MediapipeTracker",
+                "MediaPipeTracker",
                 fileName
             );
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/StreamingAssetFileNames.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/StreamingAssetFileNames.cs
@@ -9,5 +9,7 @@ namespace Baku.VMagicMirror
         /// </summary>
         public const string LoaderUiFolder = "VRMLoaderUI";
 
+        public const string MediaPipeTrackerFolder = "MediaPipeTracker";
+
     }
 }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

タイトルと差分の通りで、このPR時点でのReadmeを正とするための修正。

## How to confirm

ビルド版でwebカメラ(高負荷)の顔トラッキングが動作すること

## Note

今回のバグと無関係だが参考情報として:

MediaPipeUnityPluginで発生しうる典型的な初期化エラーとして「CPU/GPUのモード選択を正しく行えてない」というケースがありうるが、今回はもともとCPUを選択済みだったので、これは原因ではない。

GPUを選択した場合は下記等を原因として失敗するのが現行の想定挙動であり、このPRの時点で仮に試すと実際に失敗する。

https://github.com/homuler/MediaPipeUnityPlugin/blob/master/docs/Build.md#supported-platforms
