### PR TITLE
Spout出力に縦長解像度のオプションを追加

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/TextureSharing/SpoutSenderWrapperView.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/TextureSharing/SpoutSenderWrapperView.cs
@@ -6,6 +6,14 @@ namespace Baku.VMagicMirror
 {
     public class SpoutSenderWrapperView : MonoBehaviour
     {
+        public enum AspectRatioStyle
+        {
+            /// <summary> 横長 16:9 </summary>
+            Landscape,
+            /// <summary> 縦長 9:16 </summary>
+            Portrait,
+        }
+        
         [SerializeField] private SpoutSender spoutSender;
         [SerializeField] private Camera windowOverwriteCamera;
         [SerializeField] private Canvas overwriteCanvas;
@@ -41,6 +49,23 @@ namespace Baku.VMagicMirror
             {
                 overwriteImage.transform.localScale = Vector3.one;
                 overwriteImage.rectTransform.sizeDelta = Vector2.zero;
+            }
+        }
+
+        public void SetAspectRatioStyle(AspectRatioStyle style)
+        {
+            // NOTE: 縦長についてはFitInParentしないと見えが大幅に変わる(めっちゃ拡大されたように見える)ため、
+            // 諦めてウィンドウの左右に黒帯が出るようにする
+            switch (style)
+            {
+                case AspectRatioStyle.Landscape:
+                    overwriteImageAspectRatioFitter.aspectRatio = 16f / 9f;
+                    overwriteImageAspectRatioFitter.aspectMode = AspectRatioFitter.AspectMode.EnvelopeParent;
+                    return;
+                case AspectRatioStyle.Portrait:
+                    overwriteImageAspectRatioFitter.aspectRatio = 9f / 16f;
+                    overwriteImageAspectRatioFitter.aspectMode = AspectRatioFitter.AspectMode.FitInParent;
+                    return;
             }
         }
     }

--- a/WPF/VMagicMirrorConfig/Model/Avatar/FaceBlendshapeNameStore.cs
+++ b/WPF/VMagicMirrorConfig/Model/Avatar/FaceBlendshapeNameStore.cs
@@ -26,7 +26,7 @@ namespace Baku.VMagicMirrorConfig
         /// <summary> UIに表示するのが妥当と考えられるブレンドシェイプクリップ名の一覧です。 </summary>
         public ReadOnlyObservableCollection<string> BlendShapeNames { get; }
 
-        //Unityで読み込まれたキャラクターのブレンドシェイプ名の一覧です。
+        //Unityで読み込まれたアバターのブレンドシェイプ名の一覧です。
         //NOTE: この値は標準ブレンドシェイプ名を含んでいてもいなくてもOK。ただし現行動作では標準ブレンドシェイプ名は含まない。
         private string[] _avatarClipNames = Array.Empty<string>();
 

--- a/WPF/VMagicMirrorConfig/Model/Entity/WindowSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/WindowSetting.cs
@@ -33,5 +33,11 @@
         Fixed1920 = 2,
         Fixed2560 = 3,
         Fixed3840 = 4,
+        // NOTE: ここから下は縦長解像度で、v3.9.1まででは存在しなかったオプション。
+        // `1280` 等の数値は縦幅であって横幅ではないので注意
+        Fixed1280Vertical = 5,
+        Fixed1920Vertical = 6,
+        Fixed2560Vertical = 7,
+        Fixed3840Vertical = 8,
     }
 }

--- a/WPF/VMagicMirrorConfig/Model/Entity/WordToMotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/WordToMotionSetting.cs
@@ -21,7 +21,7 @@ namespace Baku.VMagicMirrorConfig
 
         public int SelectedDeviceType { get; set; } = DeviceTypes.KeyboardWord;
 
-        //NOTE: 「UIに出さないけど保存はしたい」系のデータで、キャラロード時にUnityから勝手に送られてくる
+        //NOTE: 「UIに出さないけど保存はしたい」系のデータで、アバターロード時にUnityから勝手に送られてくる
         public List<string> ExtraBlendShapeClipNames { get; set; } = new List<string>();
 
         /// <summary>

--- a/WPF/VMagicMirrorConfig/Model/ExternalTracker/ExternalTrackerRuntimeConfig.cs
+++ b/WPF/VMagicMirrorConfig/Model/ExternalTracker/ExternalTrackerRuntimeConfig.cs
@@ -100,7 +100,7 @@ namespace Baku.VMagicMirrorConfig
         /// <summary> UIに表示するのが妥当と考えられるブレンドシェイプクリップ名の一覧です。 </summary>
         public ReadOnlyObservableCollection<string> BlendShapeNames { get; }
 
-        //Unityで読み込まれたキャラクターのブレンドシェイプ名の一覧です。
+        //Unityで読み込まれたアバターのブレンドシェイプ名の一覧です。
         //NOTE: この値は標準ブレンドシェイプ名を含んでいてもいなくてもOK。ただし現行動作では標準ブレンドシェイプ名は含まない。
         private string[] _avatarClipNames = Array.Empty<string>();
 

--- a/WPF/VMagicMirrorConfig/Model/SettingFileManagement/SaveFileManager.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingFileManagement/SaveFileManager.cs
@@ -31,9 +31,9 @@ namespace Baku.VMagicMirrorConfig
 
         /// <summary> 
         /// ユーザーがフォーカスしていると考えられるファイルのインデックスを取得します。
-        /// ソフト起動以降でファイルをセーブするか、あるいはキャラ情報以外をロードしたときに、
+        /// ソフト起動以降でファイルをセーブするか、あるいはアバター情報以外をロードしたときに、
         /// そのファイルのインデックスになります。
-        /// キャラのみをロードした場合、インデックスは変更されません。
+        /// アバターのみをロードした場合、インデックスは変更されません。
         /// </summary>
         public int FocusedFileIndex { get; private set; } = 0;
 
@@ -53,8 +53,8 @@ namespace Baku.VMagicMirrorConfig
         }
 
         /// <summary>
-        /// インデックスと、各情報(キャラとそれ以外)をロードするかどうかを指定してファイルをロードします。
-        /// キャラをロードする場合、必要なら実際のロードメッセージまで実行します。
+        /// インデックスと、各情報(アバターとそれ以外)をロードするかどうかを指定してファイルをロードします。
+        /// アバターをロードする場合、必要なら実際のロードメッセージまで実行します。
         /// </summary>
         /// <param name="index"></param>
         /// <param name="loadCharacter"></param>
@@ -86,7 +86,7 @@ namespace Baku.VMagicMirrorConfig
             var loadedVrmPath = _setting.LastVrmLoadFilePath;
             var loadedVRoidModelId = _setting.LastLoadedVRoidModelId;
 
-            //NOTE: この時点ではキャラを切り替えたわけではないので、実態に合わすため元に戻してから続ける。
+            //NOTE: この時点ではアバターを切り替えたわけではないので、実態に合わすため元に戻してから続ける。
             _setting.LastVrmLoadFilePath = prevVrmPath;
             _setting.LastLoadedVRoidModelId = prevVRoidModelId;
 
@@ -109,7 +109,7 @@ namespace Baku.VMagicMirrorConfig
                 VRoidModelLoadRequested?.Invoke(loadedVRoidModelId);
             }
 
-            //NOTE: キャラだけ切り替えるのはファイルロード扱いせず、前のファイルがロードされているように見なす。
+            //NOTE: アバターだけ切り替えるのはファイルロード扱いせず、前のファイルがロードされているように見なす。
             if (loadNonCharacter)
             {
                 FocusedFileIndex = index;

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/SettingFileIo.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/SettingFileIo.cs
@@ -268,7 +268,7 @@ namespace Baku.VMagicMirrorConfig
         None,
         /// <summary>ローカルVRMの情報だけ読み込む</summary>
         Character,
-        /// <summary>キャラ以外の情報だけ読み込む</summary>
+        /// <summary>アバター以外の情報だけ読み込む</summary>
         NonCharacter,
         /// <summary>全て読み込む: 普通はこれ</summary>
         All,

--- a/WPF/VMagicMirrorConfig/Model/WordToMotion/WordToMotionRuntimeConfig.cs
+++ b/WPF/VMagicMirrorConfig/Model/WordToMotion/WordToMotionRuntimeConfig.cs
@@ -40,7 +40,7 @@ namespace Baku.VMagicMirrorConfig
         public void LoadDefaultItems()
         {
             ExtraBlendShapeClipNames.Clear();
-            //NOTE: 現在ロードされてるキャラがいたら、そのキャラのブレンドシェイプをただちに当て直す
+            //NOTE: 現在ロードされてるアバターがいたら、そのアバターのブレンドシェイプをただちに当て直す
             ExtraBlendShapeClipNames.AddRange(_latestAvaterExtraClipNames);
             
             _setting.LoadDefaultMotionRequests(ExtraBlendShapeClipNames);

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -264,9 +264,9 @@ Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Window_Basics">Basic Settings</sys:String>
     <sys:String x:Key="Window_BackgroundColor">Background</sys:String>
     <sys:String x:Key="Window_Transparent">Transparent Window</sys:String>
-    <sys:String x:Key="Window_Draggable">(When Transparent) Drag character</sys:String>
+    <sys:String x:Key="Window_Draggable">(When Transparent) Drag avatar</sys:String>
     <sys:String x:Key="Window_TopMost">(When Transparent) Always Foreground</sys:String>
-    <sys:String x:Key="Window_ResetPosition">Reset Character Position</sys:String>
+    <sys:String x:Key="Window_ResetPosition">Reset Avatar Position</sys:String>
     
     <sys:String x:Key="Window_BackgroundImage">BG Image:</sys:String>
     <sys:String x:Key="Window_BackgroundImage_Load">Load...</sys:String>
@@ -289,14 +289,14 @@ Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed2560Vertical">1440 x 2560 (Fixed)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed3840Vertical">2160 x 3840 (Fixed)</sys:String>
     
-    <sys:String x:Key="Window_TransparencySupport">Character Transparency Support</sys:String>
+    <sys:String x:Key="Window_TransparencySupport">Avatar Transparency Support</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Level">Transparency Level</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Alpha">Alpha when Transparent(32-255)</sys:String>
 
     <sys:String x:Key="Window_TransparencySupport_Level_0">Level 0: Always NOT transparent.</sys:String>
-    <sys:String x:Key="Window_TransparencySupport_Level_1">Level 1: Transparent if "Drag character" is off, and mouse pointer is close to the character.</sys:String>
-    <sys:String x:Key="Window_TransparencySupport_Level_2">Level 2: Transparent if mouse pointer is close to the character.</sys:String>
-    <sys:String x:Key="Window_TransparencySupport_Level_3">Level 3: Transparent if "Drag character" is off.</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_1">Level 1: Transparent if "Drag avatar" is off, and mouse pointer is close to the avatar.</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_2">Level 2: Transparent if mouse pointer is close to the avatar.</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_3">Level 3: Transparent if "Drag avatar" is off.</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Level_4">Level 4: Always transparent.</sys:String>
    
     <!-- Motion -->
@@ -553,7 +553,7 @@ Translate (2 way):
     <sys:String x:Key="WordToMotion_Enable">Enable Word to Motion</sys:String>
     <sys:String x:Key="WordToMotion_UseGamepadForInput">Use gamepad as launcher</sys:String>
     <sys:String x:Key="WordToMotion_Instruction" xml:space="preserve">This tab is `Word to Motion` tab.
-`Word to Motion` feature supports character motion by your word input.
+`Word to Motion` feature supports avatar motion by your word input.
 Please test by typing "joy".</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice">Assign device for this function</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice_None">None</sys:String>
@@ -656,8 +656,8 @@ Input favorite key combination in text area.
     <sys:String x:Key="SettingFile_Load">Load</sys:String>
     <sys:String x:Key="SettingFile_Save_Instruction">Select target to save.</sys:String>
     <sys:String x:Key="SettingFile_Load_Instruction">Select data to load.</sys:String>
-    <sys:String x:Key="SettingFile_LoadCharacter">Load Character</sys:String>
-    <sys:String x:Key="SettingFile_LoadNonCharacter">Load Non-Character Settings</sys:String>
+    <sys:String x:Key="SettingFile_LoadCharacter">Load Avatar</sys:String>
+    <sys:String x:Key="SettingFile_LoadNonCharacter">Load Non-Avatar Settings</sys:String>
     <sys:String x:Key="SettingFile_Export">Export</sys:String>
     <sys:String x:Key="SettingFile_Import">Import</sys:String>
 
@@ -737,7 +737,7 @@ VRoid Hub model is not supported in this feature.</sys:String>
     
     <!-- Dialog Messages -->
     <sys:String x:Key="DialogTitle_LoadLocalVrm">Load VRM</sys:String>
-    <sys:String x:Key="DialogMessage_LoadLocalVrm">Please confirm the license in viewer window. Do you load the character?</sys:String>
+    <sys:String x:Key="DialogMessage_LoadLocalVrm">Please confirm the license in viewer window. Do you load the avatar?</sys:String>
     <sys:String x:Key="DialogTitle_ResetAllSetting">Reset Setting</sys:String>
     <sys:String x:Key="DialogMessage_ResetAllSetting" xml:space="preserve">Reset process will delete current setting, and VMagicMirror will restart.
 
@@ -782,7 +782,7 @@ Choose 'OK' to enable webcam based tracking.
     <sys:String x:Key="DialogTitle_ConfirmSettingFileLoad">Setting File Load</sys:String>
     <sys:String x:Key="DialogMessage_ConfirmSettingFileLoad" xml:space="preserve">Are you sure to load setting No.{0}?
 
-If you load with non-character option, most of the settings will be overwritten.</sys:String>    
+If you load with non-avatar option, most of the settings will be overwritten.</sys:String>    
 
     <sys:String x:Key="DialogTitle_GuardSettingWindowDuringSaveLoad">Save / Load Process Running</sys:String>
     <sys:String x:Key="DialogMessage_GuardSettingWindowDuringSaveLoad">Setting window is locked during save and load process.</sys:String>
@@ -790,7 +790,7 @@ If you load with non-character option, most of the settings will be overwritten.
     <sys:String x:Key="DialogTitle_EnableAutomation">Enable Automation</sys:String>
     <sys:String x:Key="DialogMessage_EnableAutomation" xml:space="preserve">Are you sure to enable automation feature?
 
-This feature enable switch setting and change character without GUI operation.
+This feature enable switch setting and change avatar without GUI operation.
 Use this only after checking the licenses of VRM you will use.
 </sys:String>    
     <sys:String x:Key="DialogTitle_DisableAutomation">Disable Automation</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -274,7 +274,9 @@ Disable foreground mode, or attach item to another one.</sys:String>
 
     <sys:String x:Key="Window_SpoutOutput">Spout</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Instruction" xml:space="preserve">Spout feature support fixed resolution output.
-Output channel name is fixed to "VMagicMirrorSpout".</sys:String>
+
+- Output channel name is fixed to "VMagicMirrorSpout".
+- When portrait resolution is selected, left and right side of the character window will become black.</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Enable">Enable Spout Output</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution">Resolution:</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_SameAsScreen">Same as Window</sys:String>
@@ -282,6 +284,10 @@ Output channel name is fixed to "VMagicMirrorSpout".</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1920">1920 x 1080 (Fixed)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed2560">2560 x 1440 (Fixed)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed3840">3840 x 2160 (Fixed)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1280Vertical">720 x 1280 (Fixed)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1920Vertical">1080 x 1920 (Fixed)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed2560Vertical">1440 x 2560 (Fixed)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed3840Vertical">2160 x 3840 (Fixed)</sys:String>
     
     <sys:String x:Key="Window_TransparencySupport">Character Transparency Support</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Level">Transparency Level</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -276,9 +276,9 @@ Disable foreground mode, or attach item to another one.</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Instruction" xml:space="preserve">Spout feature support fixed resolution output.
 
 - Output channel name is fixed to "VMagicMirrorSpout".
-- When portrait resolution is selected, left and right side of the character window will become black.</sys:String>
+- When using a portrait (vertical) resolution, black bars may appear on the sides of the avatar window.</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Enable">Enable Spout Output</sys:String>
-    <sys:String x:Key="Window_SpoutOutput_Resolution">Resolution:</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution">Resolution (Width x Height):</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_SameAsScreen">Same as Window</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1280">1280 x 720 (Fixed)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1920">1920 x 1080 (Fixed)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -289,9 +289,9 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Instruction" xml:space="preserve">Spoutを用いて固定解像度で映像を出力できます。
 
 - 出力チャンネル名は"VMagicMirrorSpout"で固定です。
-- 縦長の解像度を選ぶとキャラクターウィンドウの左右が黒く表示されることがありますが、これは正常な動作です。</sys:String>
+- 縦長の解像度を選ぶとアバターウィンドウの左右が黒く表示されることがありますが、これは正常な動作です。</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Enable">Spoutを有効化</sys:String>
-    <sys:String x:Key="Window_SpoutOutput_Resolution">解像度:</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution">解像度 (幅 x 高さ):</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_SameAsScreen">ウィンドウと同じ</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1280">1280 x 720 (固定)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1920">1920 x 1080 (固定)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -278,8 +278,8 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Window_BackgroundColor">背景色</sys:String>
     <sys:String x:Key="Window_Transparent">背景を透過</sys:String>
     <sys:String x:Key="Window_Draggable">(透過中)キャラ付近を掴んでドラッグ</sys:String>
-    <sys:String x:Key="Window_TopMost">(透過中)キャラクターをつねに最前面で表示</sys:String>
-    <sys:String x:Key="Window_ResetPosition">キャラクター位置のリセット</sys:String>
+    <sys:String x:Key="Window_TopMost">(透過中)アバターをつねに最前面で表示</sys:String>
+    <sys:String x:Key="Window_ResetPosition">アバター位置のリセット</sys:String>
     
     <sys:String x:Key="Window_BackgroundImage">背景画像:</sys:String>
     <sys:String x:Key="Window_BackgroundImage_Load">ロード...</sys:String>
@@ -566,7 +566,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="WordToMotion_Enable">Word to Motionを有効化</sys:String>
     <sys:String x:Key="WordToMotion_UseGamepadForInput">ゲームパッドのボタンで表情/モーションを実行</sys:String>
     <sys:String x:Key="WordToMotion_Instruction" xml:space="preserve">このタブは `Word to Motion` タブです。
-`Word to Motion`は、単語をタイピングするとキャラクターを動かせる機能です。
+`Word to Motion`は、単語をタイピングするとアバターを動かせる機能です。
 ためしに "joy" とタイピングしてみてください。</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice">この機能専用にデバイスを割り当て</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice_None">なし</sys:String>
@@ -606,9 +606,9 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="WordToMotion_Face_PreferLipSync">リップシンクを続行</sys:String>
     
     <sys:String x:Key="WordToMotion_Face_CommonClip_Header">基本の表情</sys:String>
-    <sys:String x:Key="WordToMotion_Face_ExtraClip_Header">キャラ固有の表情</sys:String>
+    <sys:String x:Key="WordToMotion_Face_ExtraClip_Header">モデル固有の表情</sys:String>
     
-    <sys:String x:Key="WordToMotion_EnablePreview">現在のキャラクターでプレビュー</sys:String>    
+    <sys:String x:Key="WordToMotion_EnablePreview">現在のアバターでプレビュー</sys:String>    
         
     <sys:String x:Key="WordToMotion_MidiAssign">MIDIのノート割り当て</sys:String>
     <sys:String x:Key="WordToMotion_MidiAssign_MidiNotActive_Title">MIDI入力を有効化します</sys:String>
@@ -677,7 +677,7 @@ VMCPを使わない場合、「設定タブをメインウィンドウから非�
     
     <sys:String x:Key="SettingFile_Automation">オートメーション</sys:String>
     <sys:String x:Key="SettingFile_Instruction" xml:space="preserve">注意:
-この機能を使うとGUIを操作せずにキャラクターを切り替えられます。
+この機能を使うとGUIを操作せずにアバターを切り替えられます。
 ライセンスを十分確認したモデルでのみ、この機能を使用して下さい。
 
 また、本機能ではVRoid Hubモデルへの自動切り替えはできません。</sys:String>
@@ -771,7 +771,7 @@ VMCPを使わない場合、「設定タブをメインウィンドウから非�
     <sys:String x:Key="DialogTitle_InvalidIpAddress">無効なIPアドレス</sys:String>
     <sys:String x:Key="DialogMessage_InvalidIpAddress">無効なIPアドレスが指定されています。入力を確認して下さい。</sys:String>
     <sys:String x:Key="DialogTitle_ShowVRoidSdkUi">VRoid Hubに接続中</sys:String>
-    <sys:String x:Key="DialogMessage_ShowVRoidSdkUi">キャラクターウィンドウ上でモデルを選択するか、またはキャンセルしてください。</sys:String>
+    <sys:String x:Key="DialogMessage_ShowVRoidSdkUi">アバターウィンドウ上でモデルを選択するか、またはキャンセルしてください。</sys:String>
     <sys:String x:Key="DialogTitle_LoadPreviousVRoidModel">VRoid Hubに接続中</sys:String>
     <sys:String x:Key="DialogMessage_LoadPreviousVRoidModel">前回使用したモデルのロードを試みています。モデルをロードするか、またはキャンセルしてください。</sys:String>
     <sys:String x:Key="DialogTitle_LoadSavedVRoidModel">VRoid Hubに接続中</sys:String>
@@ -809,7 +809,7 @@ webカメラでの顔トラッキングを有効にする場合は
     <sys:String x:Key="DialogTitle_EnableAutomation">オートメーションの有効化</sys:String>
     <sys:String x:Key="DialogMessage_EnableAutomation" xml:space="preserve">オートメーションを有効化しますか？
 
-オートメーション機能ではGUIを操作せずにキャラクター、設定を切り替えられます。
+オートメーション機能ではGUIを操作せずにアバター、設定を切り替えられます。
 ライセンスを十分よく確認したモデルに対してのみ、この機能を使用して下さい。
 </sys:String>
 

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -44,7 +44,7 @@
     <sys:String x:Key="Home_VrmDragDropInstruction">ドラッグ &amp; ドロップでVRMをロード</sys:String>
 
     <sys:String x:Key="Home_LoadVrmOnNextStartup">次回の起動時にも同じVRMを読み込む</sys:String>
-    <sys:String x:Key="Home_AutoAdjust">キャラ体格で補正</sys:String>
+    <sys:String x:Key="Home_AutoAdjust">アバター体格で補正</sys:String>
 
     <sys:String x:Key="Home_Manual_Header">使い方</sys:String>
     <sys:String x:Key="Home_Manual_Open">マニュアルのURLにアクセス</sys:String>
@@ -277,7 +277,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Window_Basics">基本設定</sys:String>
     <sys:String x:Key="Window_BackgroundColor">背景色</sys:String>
     <sys:String x:Key="Window_Transparent">背景を透過</sys:String>
-    <sys:String x:Key="Window_Draggable">(透過中)キャラ付近を掴んでドラッグ</sys:String>
+    <sys:String x:Key="Window_Draggable">(透過中)アバター付近を掴んでドラッグ</sys:String>
     <sys:String x:Key="Window_TopMost">(透過中)アバターをつねに最前面で表示</sys:String>
     <sys:String x:Key="Window_ResetPosition">アバター位置のリセット</sys:String>
     
@@ -302,14 +302,14 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed2560Vertical">1440 x 2560 (固定)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed3840Vertical">2160 x 3840 (固定)</sys:String>
     
-    <sys:String x:Key="Window_TransparencySupport">キャラ透明化の詳細</sys:String>
-    <sys:String x:Key="Window_TransparencySupport_Level">キャラの透明化レベル</sys:String>
+    <sys:String x:Key="Window_TransparencySupport">アバター透明化の詳細</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level">アバターの透明化レベル</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Alpha">透明になるときの透明度(32-255)</sys:String>
     
     <sys:String x:Key="Window_TransparencySupport_Level_0">レベル0: つねに不透明です。</sys:String>
-    <sys:String x:Key="Window_TransparencySupport_Level_1">レベル1: 「キャラ付近を掴んでドラッグ」がオフで、かつキャラの近くにマウスポインタがあれば、半透明になります。</sys:String>
-    <sys:String x:Key="Window_TransparencySupport_Level_2">レベル2: キャラの近くにマウスポインタがあれば、半透明になります。</sys:String>
-    <sys:String x:Key="Window_TransparencySupport_Level_3">レベル3: 「キャラ付近を掴んでドラッグ」がオフならば、半透明になります。</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_1">レベル1: 「アバター付近を掴んでドラッグ」がオフで、かつアバターの近くにマウスポインタがあれば、半透明になります。</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_2">レベル2: アバターの近くにマウスポインタがあれば、半透明になります。</sys:String>
+    <sys:String x:Key="Window_TransparencySupport_Level_3">レベル3: 「アバター付近を掴んでドラッグ」がオフならば、半透明になります。</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Level_4">レベル4: つねに半透明になります。</sys:String>
         
     <!-- Motion -->
@@ -500,7 +500,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Devices_Gamepad_PreferDirectInput">DirectInputを使用 (DUAL SHOCK 4を使う場合オン)</sys:String>
     <sys:String x:Key="Devices_GamepadDeviceNumber">デバイス番号</sys:String>
     
-    <sys:String x:Key="Devices_GamepadLean">キャラ傾き入力</sys:String>
+    <sys:String x:Key="Devices_GamepadLean">アバター傾き入力</sys:String>
     <sys:String x:Key="Devices_GamepadLean_None">なし</sys:String>
     <sys:String x:Key="Devices_GamepadLean_LeftButtons">左十字キー</sys:String>
     <sys:String x:Key="Devices_GamepadLean_LeftStick">左スティック</sys:String>
@@ -532,7 +532,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
 
     <sys:String x:Key="Shadow">影</sys:String>
     <sys:String x:Key="Shadow_Enable">影を有効化</sys:String>
-    <sys:String x:Key="Shadow_Enable_Streaming">キャラの影</sys:String>
+    <sys:String x:Key="Shadow_Enable_Streaming">アバターの影</sys:String>
     <sys:String x:Key="Shadow_Intensity">濃さ[%]</sys:String>
     <sys:String x:Key="Shadow_Yaw">向き(横)[deg]</sys:String>
     <sys:String x:Key="Shadow_Pitch">向き(上下)[deg]</sys:String>
@@ -670,8 +670,8 @@ VMCPを使わない場合、「設定タブをメインウィンドウから非�
     <sys:String x:Key="SettingFile_Load">ロード</sys:String>
     <sys:String x:Key="SettingFile_Save_Instruction">保存先を選択して下さい。</sys:String>
     <sys:String x:Key="SettingFile_Load_Instruction">ロードするデータを選択して下さい。</sys:String>
-    <sys:String x:Key="SettingFile_LoadCharacter">キャラをロード</sys:String>
-    <sys:String x:Key="SettingFile_LoadNonCharacter">キャラ以外の情報をロード</sys:String>
+    <sys:String x:Key="SettingFile_LoadCharacter">アバターをロード</sys:String>
+    <sys:String x:Key="SettingFile_LoadNonCharacter">アバター以外の情報をロード</sys:String>
     <sys:String x:Key="SettingFile_Export">エクスポート</sys:String>
     <sys:String x:Key="SettingFile_Import">インポート</sys:String>
     
@@ -801,7 +801,7 @@ webカメラでの顔トラッキングを有効にする場合は
     <sys:String x:Key="DialogTitle_ConfirmSettingFileLoad">設定をロード</sys:String>
     <sys:String x:Key="DialogMessage_ConfirmSettingFileLoad" xml:space="preserve">設定 No.{0} をロードしますか？
         
-キャラ以外の設定をロードすると、現在の設定が上書きされます。</sys:String>
+アバター以外の設定をロードすると、現在の設定が上書きされます。</sys:String>
 
     <sys:String x:Key="DialogTitle_GuardSettingWindowDuringSaveLoad">セーブ/ロード操作中</sys:String>
     <sys:String x:Key="DialogMessage_GuardSettingWindowDuringSaveLoad">設定ファイルのセーブ/ロード中は設定ウィンドウは操作できません。</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -287,7 +287,9 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
 
     <sys:String x:Key="Window_SpoutOutput">Spout出力</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Instruction" xml:space="preserve">Spoutを用いて固定解像度で映像を出力できます。
-出力チャンネル名は"VMagicMirrorSpout"で固定です。</sys:String>
+
+- 出力チャンネル名は"VMagicMirrorSpout"で固定です。
+- 縦長の解像度を選ぶとキャラクターウィンドウの左右が黒く表示されることがありますが、これは正常な動作です。</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Enable">Spoutを有効化</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution">解像度:</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_SameAsScreen">ウィンドウと同じ</sys:String>
@@ -295,6 +297,10 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1920">1920 x 1080 (固定)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed2560">2560 x 1440 (固定)</sys:String>
     <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed3840">3840 x 2160 (固定)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1280Vertical">720 x 1280 (固定)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed1920Vertical">1080 x 1920 (固定)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed2560Vertical">1440 x 2560 (固定)</sys:String>
+    <sys:String x:Key="Window_SpoutOutput_Resolution_Fixed3840Vertical">2160 x 3840 (固定)</sys:String>
     
     <sys:String x:Key="Window_TransparencySupport">キャラ透明化の詳細</sys:String>
     <sys:String x:Key="Window_TransparencySupport_Level">キャラの透明化レベル</sys:String>

--- a/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataViewModel.cs
@@ -50,7 +50,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         public ActionCommand CancelCommand { get; }
 
-        //デフォルトではキャラロードだけ有効にして、「同じモデルで服が違うのをパッと切り替えます」みたいなUXを重視しておく。
+        //デフォルトではアバターロードだけ有効にして、「同じモデルで服が違うのをパッと切り替えます」みたいなUXを重視しておく。
         public RProperty<bool> LoadCharacterWhenSettingLoaded { get; }
         public RProperty<bool> LoadNonCharacterWhenSettingLoaded { get; } 
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WindowSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/WindowSettingViewModel.cs
@@ -111,6 +111,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             new(SpoutResolutionType.Fixed1920, "Window_SpoutOutput_Resolution_Fixed1920"),
             new(SpoutResolutionType.Fixed2560, "Window_SpoutOutput_Resolution_Fixed2560"),
             new(SpoutResolutionType.Fixed3840, "Window_SpoutOutput_Resolution_Fixed3840"),
+            new(SpoutResolutionType.Fixed1280Vertical, "Window_SpoutOutput_Resolution_Fixed1280Vertical"),
+            new(SpoutResolutionType.Fixed1920Vertical, "Window_SpoutOutput_Resolution_Fixed1920Vertical"),
+            new(SpoutResolutionType.Fixed2560Vertical, "Window_SpoutOutput_Resolution_Fixed2560Vertical"),
+            new(SpoutResolutionType.Fixed3840Vertical, "Window_SpoutOutput_Resolution_Fixed3840Vertical"),
         };
     }
 }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

- 立っている状態を出力するうえで横長よりも効率的なケースがある…というのを踏まえた改修です。
- 横長解像度の場合と異なり、アバターウィンドウ側では画面の左右を黒くして中央のみに描画するようなスタイルにします。
    - こうしないとspoutのoff -> onでアバターウィンドウ側でアバターが極端に拡大されて何が起こってるか分からなくなるため
    - この点で普通よりはちょっとピーキーなオプションです

## How to confirm

ビルド版で動作すること

## Note

- このPR自体との関連は非常に薄いですが、ついでで「キャラクター」表記を「アバター」に修正してます
    - (単に表記ブレである & アプリケーションの挙動からするとアバター表記のほうが妥当であるため)
    - doc側の記載も直したほうがいいですが、これは別PRで(内容に基づいてdevelop & master branch向けに)実施します