### PR TITLE
Unity 6移行でビルド用のcmdファイルの更新が漏れていたのを修正

### DIFF
--- a/Batches/build_unity.cmd
+++ b/Batches/build_unity.cmd
@@ -5,7 +5,7 @@ REM example: `build_unity.cmd full dev`
 
 REM use following instead, if editor is NOT from Hub
 REM set UNITY_EXE="%ProgramFiles%\Unity\Editor\Unity.exe"
-set UNITY_EXE="%ProgramFiles%\Unity\Hub\Editor\2022.3.7f1\Editor\Unity.exe"
+set UNITY_EXE="%ProgramFiles%\Unity\Hub\Editor\6000.0.33f1\Editor\Unity.exe"
 
 cd %~dp0
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

- タイトルの通り
- #1098 での動作確認はUnity Editorを開いた状態でのエディタ拡張から行ったため、ビルド特有の問題が追加で検出されることはないはず

## How to confirm

- [x] ビルドコマンドの実行によってビルドしたVMMが起動できて動作すること
