### PR TITLE
サブキャラに関するテキストで割当が間違ってたものを修正

### DIFF
--- a/WPF/VMagicMirrorConfig/View/ControlPanel/BuddyPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/BuddyPanel.xaml
@@ -54,7 +54,8 @@
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0"
                                    FontWeight="Bold"
-                                   Text="{DynamicResource HandTracking_EditionLimitationNote}"
+                                   Text="{DynamicResource Buddy_EditionLimitation}"
+                                   TextWrapping="Wrap"  
                                    />
                             <Button Grid.Column="1" 
                                     Width="NaN"


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

- サブキャラをStandard Editionで使ったときの制限に関する表記が誤ってハンドトラッキング用のものになっていたので修正
- この変更がUI的に影響するのはStandard Editionのみです

