### PR TITLE
VRMのロード方式として内部からのロードも対応できるような口を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ sysinfo.txt
 /VMagicMirror/Assets/RawInputSharp/
 /VMagicMirror/Assets/VRMShaders/
 /VMagicMirror/Assets/MeshUtility/
+/VMagicMirror/Assets/Misc/
 /VMagicMirror/Assets/MiscAssets/
 /VMagicMirror/Assets/uWindowCapture/
 /VMagicMirror/Assets/uOSC/
@@ -105,6 +106,7 @@ sysinfo.txt
 /VMagicMirror/Assets/RawInputSharp.meta
 /VMagicMirror/Assets/VRMShaders.meta
 /VMagicMirror/Assets/MeshUtility.meta
+/VMagicMirror/Assets/Misc.meta
 /VMagicMirror/Assets/MiscAssets.meta
 /VMagicMirror/Assets/uWindowCapture.meta
 /VMagicMirror/Assets/uOSC.meta

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyLayoutUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyLayoutUpdater.cs
@@ -172,12 +172,14 @@ namespace Baku.VMagicMirror.Buddy
                 {
                     if (TryGetBuddyTransform2DLayout(msg, out var layout2d))
                     {
-                        Debug.Log($"AddOrUpdate Layout2D, {json}");
+                        //NOTE: BuddyLoggerにVerboseで流すようにして復活するのもアリ
+                        //Debug.Log($"AddOrUpdate Layout2D, {json}");
                         layouts.AddOrUpdate(msg.Name, layout2d);
                     }
                     else if (TryGetBuddyTransform3DLayout(msg, out var layout3d))
                     {
-                        Debug.Log($"AddOrUpdate Layout3D, {json}");
+                        //NOTE: BuddyLoggerにVerboseで流すようにして復活するのもアリ
+                        //Debug.Log($"AddOrUpdate Layout3D, {json}");
                         layouts.AddOrUpdate(msg.Name, layout3d);
                     }
                 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/ModelLoadInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/ModelLoadInstaller.cs
@@ -26,6 +26,7 @@ namespace Baku.VMagicMirror.Installer
             
             container.BindInterfacesAndSelfTo<VRM10LoadController>().AsSingle();
             container.BindInterfacesTo<VRMPreviewPresenter>().AsSingle();
+            container.BindInterfacesAndSelfTo<VRMPreloadDataOverrider>().AsSingle();
             
             container.Bind<SettingAutoAdjuster>().AsCached();
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// MainViewerシーンの実行時点でロード対象のモデルが判別出来ている場合にそのデータを保持するインターフェース。
+    /// </summary>
+    /// <remarks>
+    /// アプリケーションにデフォルトモデル等を定義できる場合のI/Fとして検証も兼ねて追加しています。
+    /// </remarks>
+    public interface IVRMPreloadData
+    {
+        public bool HasData { get; }
+
+        /// <summary> VRMのバイナリです。 </summary>
+        public byte[] GetData();
+
+        /// <summary>
+        /// 対象のVRMが1.0かどうかを取得します。不明な場合、nullを返します。
+        /// </summary>
+        /// <returns></returns>
+        public bool? IsVrm10();
+    }
+
+    /// <summary>
+    /// プリロードするデータが特にないようなVRMPreloadDataの実装。
+    /// </summary>
+    /// <remarks>
+    /// 特にIVRMPreloadDataを使わないときの実体としてコレを使う
+    /// </remarks>
+    public class EmptyVRMPreloadData : IVRMPreloadData
+    {
+        public bool HasData => false;
+        public byte[] GetData() => Array.Empty<byte>();
+        public bool? IsVrm10() => null;
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs
@@ -14,12 +14,6 @@ namespace Baku.VMagicMirror
 
         /// <summary> VRMのバイナリです。 </summary>
         public byte[] GetData();
-
-        /// <summary>
-        /// 対象のVRMが1.0かどうかを取得します。不明な場合、nullを返します。
-        /// </summary>
-        /// <returns></returns>
-        public bool? IsVrm10();
     }
 
     /// <summary>
@@ -32,6 +26,5 @@ namespace Baku.VMagicMirror
     {
         public bool HasData => false;
         public byte[] GetData() => Array.Empty<byte>();
-        public bool? IsVrm10() => null;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs
@@ -1,4 +1,5 @@
 using System;
+using UniRx;
 
 namespace Baku.VMagicMirror
 {
@@ -10,10 +11,13 @@ namespace Baku.VMagicMirror
     /// </remarks>
     public interface IVRMPreloadData
     {
-        public bool HasData { get; }
+        bool HasData { get; }
 
         /// <summary> VRMのバイナリです。 </summary>
-        public byte[] GetData();
+        byte[] GetData();
+
+        /// <summary> MainViewerシーンの起動よりも後でVRMの再読み込みが要求されると発火します。 </summary>
+        IObservable<Unit> ReloadRequested { get; }
     }
 
     /// <summary>
@@ -26,5 +30,6 @@ namespace Baku.VMagicMirror
     {
         public bool HasData => false;
         public byte[] GetData() => Array.Empty<byte>();
+        public IObservable<Unit> ReloadRequested => Observable.Empty<Unit>();
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/IVRMPreloadData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92d5ba87d4d35c94cb89eeea5d9247c4

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -58,7 +58,7 @@ namespace Baku.VMagicMirror
             ErrorIndicateSender errorSender,
             ErrorInfoFactory errorInfoFactory,
             LocomotionSupportedAnimatorControllers animatorControllers,
-            VRMPreloadDataOverrider preloadDataOverrider
+            VRMPreloadDataOverrider preloadData
             )
         {
             _sender = sender;
@@ -68,6 +68,7 @@ namespace Baku.VMagicMirror
             _errorSender = errorSender;
             _errorInfoFactory = errorInfoFactory;
             _animatorControllers = animatorControllers;
+            _preloadData = preloadData;
         }
 
         public void Initialize()
@@ -76,7 +77,7 @@ namespace Baku.VMagicMirror
                 VmmCommands.OpenVrmPreview,
                 message =>
                 {
-                    if (!_preloadData.ShouldIgnoreNonPreloadData)
+                    if (_preloadData.ShouldIgnoreNonPreloadData)
                     {
                         return;
                     }
@@ -87,7 +88,7 @@ namespace Baku.VMagicMirror
                 VmmCommands.OpenVrm,
                 message =>
                 {
-                    if (!_preloadData.ShouldIgnoreNonPreloadData)
+                    if (_preloadData.ShouldIgnoreNonPreloadData)
                     {
                         return;
                     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -74,12 +74,24 @@ namespace Baku.VMagicMirror
         {
             _receiver.AssignCommandHandler(
                 VmmCommands.OpenVrmPreview,
-                message => LoadModelForPreview(message.GetStringValue()).Forget()
-            );
+                message =>
+                {
+                    if (!_preloadData.ShouldIgnoreNonPreloadData)
+                    {
+                        return;
+                    }
+
+                    LoadModelForPreview(message.GetStringValue()).Forget();
+                });
             _receiver.AssignCommandHandler(
                 VmmCommands.OpenVrm,
                 message =>
                 {
+                    if (!_preloadData.ShouldIgnoreNonPreloadData)
+                    {
+                        return;
+                    }
+
                     _previewBroker.RequestHide();
                     LoadModelFromFileAsync(message.GetStringValue()).Forget();
                 });
@@ -91,6 +103,7 @@ namespace Baku.VMagicMirror
             _previewBroker.VRoidModelLoaded
                 .Subscribe(v =>
                 {
+                    // OpenVrm/OpenVrmPreviewと異なり、VRoidのデータはロードまで進んでたら通す(通してしまうほうがリークとかも起きにくいので)
                     OnVrmLoadedFromVRoidHub(v.modelId, v.instance, v.isVrm10);
                 })
                 .AddTo(_disposable);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -39,14 +39,14 @@ namespace Baku.VMagicMirror
         private readonly ErrorIndicateSender _errorSender;
         private readonly ErrorInfoFactory _errorInfoFactory;
         private readonly LocomotionSupportedAnimatorControllers _animatorControllers;
+        private readonly VRMPreloadDataOverrider _preloadData;
 
-        private readonly CompositeDisposable _disposable = new CompositeDisposable();
-        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly CompositeDisposable _disposable = new();
+        private readonly CancellationTokenSource _cts = new();
 
         private Vrm10Instance _instance = null;
         
-        private readonly ReactiveProperty<CurrentModelVersion> _modelVersion =
-            new ReactiveProperty<CurrentModelVersion>(CurrentModelVersion.Unloaded);
+        private readonly ReactiveProperty<CurrentModelVersion> _modelVersion = new(CurrentModelVersion.Unloaded);
         public IReadOnlyReactiveProperty<CurrentModelVersion> ModelVersion => _modelVersion;
         
         [Inject]
@@ -57,7 +57,8 @@ namespace Baku.VMagicMirror
             IKTargetTransforms ikTargets,
             ErrorIndicateSender errorSender,
             ErrorInfoFactory errorInfoFactory,
-            LocomotionSupportedAnimatorControllers animatorControllers
+            LocomotionSupportedAnimatorControllers animatorControllers,
+            VRMPreloadDataOverrider preloadDataOverrider
             )
         {
             _sender = sender;
@@ -92,6 +93,10 @@ namespace Baku.VMagicMirror
                 {
                     OnVrmLoadedFromVRoidHub(v.modelId, v.instance, v.isVrm10);
                 })
+                .AddTo(_disposable);
+
+            _preloadData.LoadRequested
+                .Subscribe(value => LoadModelFromBytesAsync(value.Data).Forget())
                 .AddTo(_disposable);
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMPreloadDataOverrider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMPreloadDataOverrider.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UniRx;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// プリロード対象のVRMがあるときにロード要求を発火させたり、
+    /// 通常のファイル/VRoidHubからのロードを無視したりすることを要求するクラス
+    /// </summary>
+    public class VRMPreloadDataOverrider : PresenterBase
+    {
+        public readonly struct PreloadDataLoadRequest
+        {
+            public PreloadDataLoadRequest(byte[] data)
+            {
+                Data = data;
+            }
+
+            public byte[] Data { get; }
+        }
+        
+        private readonly IMessageReceiver _receiver;
+        private readonly CancellationTokenSource _cts = new();
+
+        [Inject]
+        public VRMPreloadDataOverrider(
+            IMessageReceiver receiver,
+            [InjectOptional] IVRMPreloadData preloadData)
+        {
+            _receiver = receiver;
+            PreloadData = preloadData ?? new EmptyVRMPreloadData();
+            ShouldIgnoreNonPreloadData = PreloadData.HasData;
+        }
+
+        public IVRMPreloadData PreloadData { get; }
+        public bool ShouldIgnoreNonPreloadData { get; private set; }
+
+        private readonly Subject<PreloadDataLoadRequest> _loadRequested = new();
+        public IObservable<PreloadDataLoadRequest> LoadRequested => _loadRequested;
+        
+        public override void Initialize()
+        {
+            if (!PreloadData.HasData)
+            {
+                return;
+            }
+
+            // WPFの起動時に投げられたVRMのロードリクエストは無視する(プリロードデータのほうが偉い)が、その後にモデルを交代するのはOK
+            _receiver.AssignCommandHandler(
+                VmmCommands.StartupEnded,
+                _ => ShouldIgnoreNonPreloadData = false
+            );
+
+            // NOTE: 遅延をつけるのは、GUIからのリクエストでモデルをロードするときの挙動にちょっと近づけるため
+            RequestLoadAsync(_cts.Token).Forget();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            _cts.Cancel();
+            _cts.Dispose();
+        }
+
+        private async UniTaskVoid RequestLoadAsync(CancellationToken ct)
+        {
+            await UniTask.NextFrame(ct);
+            _loadRequested.OnNext(new PreloadDataLoadRequest(PreloadData.GetData()));
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMPreloadDataOverrider.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMPreloadDataOverrider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ec1a5368bc42d54b88842d78e7bc443


### PR DESCRIPTION
## PR category

PR type: 

- [x] Other

## What the PR does

- ビルトインモデルの導入等に向けた検証を行ったうち、現時点でコードとして整備出来てる範囲のを入れるPR
- UIは据え置き、かつビルトインモデル自体があるわけでもないので、とくにユーザーから見える変化はないです

NOTE:

- `IpcMessageDispatcher` についてはサブキャラの導入時に改変したものの、デバッグ等で不便だったり、Query用のhandlerの配列がsparseすぎるのが気になったり…といったことがあったのでDictionary方式に戻した

## How to confirm

- Unity Editor + WPF Buildで従来通り動くこと
