### PR TITLE
サブキャラ用のログフォルダの初期化をフォルダ全体の再生成ではなくファイル削除のみで行う

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Logger/BuddyFileLogger.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Logger/BuddyFileLogger.cs
@@ -21,11 +21,18 @@ namespace Baku.VMagicMirror.Buddy
 
         private void RefreshLogDirectory(string dir)
         {
-            if (Directory.Exists(dir))
+            if (!Directory.Exists(dir))
             {
-                Directory.Delete(dir, true);
+                Directory.CreateDirectory(dir);
+                return;
             }
-            Directory.CreateDirectory(dir);
+
+            // ディレクトリが存在する場合、直下のファイルのみ削除
+            var files = Directory.GetFiles(dir);
+            foreach (var file in files)
+            {
+                File.Delete(file);
+            }
         }
 
         public void Log(BuddyFolder folder, string content)


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixes: #1120 

フォルダの再帰削除とファイルの自動同期の相性が悪いようなので、挙動が最小限になるようにした

- サブキャラのログ用フォルダがなければ作る
- サブキャラのログ用フォルダ直下にあるファイルは消す。フォルダはそのままにしておく

## How to confirm

Unity Editor + WPF Buildで以下が動作すること

- サブキャラが全てオフのときに起動できる
- Play Mode起動後に `Logs\DefaultBuddy` フォルダや `Logs\Buddy` フォルダがない場合は生成される
- Play Mode起動後、上記フォルダの直下にファイルがあると削除され、ディレクトリは削除されない
- とくにデフォルトではないサブキャラについて、ログが何らかの形で出力できる
