### PR TITLE
ハンドトラッキングのon/off/toggleのホットキーを追加

### DIFF
--- a/WPF/VMagicMirrorConfig/Model/HotKey/HotKeyActionRunner.cs
+++ b/WPF/VMagicMirrorConfig/Model/HotKey/HotKeyActionRunner.cs
@@ -96,6 +96,15 @@ namespace Baku.VMagicMirrorConfig
                 case HotKeyActions.ToggleWindVisibility:
                     _lightSetting.EnableWind.Value = !_lightSetting.EnableWind.Value;
                     break;
+                case HotKeyActions.EnableHandTracking:
+                    _motionSetting.EnableImageBasedHandTracking.Value = true;
+                    break;
+                case HotKeyActions.DisableHandTracking:
+                    _motionSetting.EnableImageBasedHandTracking.Value = false;
+                    break;
+                case HotKeyActions.ToggleHandTracking:
+                    _motionSetting.EnableImageBasedHandTracking.Value = !_motionSetting.EnableImageBasedHandTracking.Value;
+                    break;
                 case HotKeyActions.None:
                 default:
                     //何もしない

--- a/WPF/VMagicMirrorConfig/Model/HotKey/HotKeyItem.cs
+++ b/WPF/VMagicMirrorConfig/Model/HotKey/HotKeyItem.cs
@@ -16,6 +16,9 @@ namespace Baku.VMagicMirrorConfig
         ToggleShadowVisibility,
         ToggleOutlineVisibility,
         ToggleWindVisibility, // NOTE: Windに対してVisibilityという言い方をするのは「表示」タブにあるから
+        EnableHandTracking,
+        DisableHandTracking,
+        ToggleHandTracking,
     }
 
     public enum HotKeyActionBodyMotionStyle : int

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -714,6 +714,9 @@ Input favorite key combination in text area.
     <sys:String x:Key="Hotkey_Action_ToggleShadowVisibility">Visibility on/off: Shadow</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleOutlineVisibility">Visibility on/off: Outline</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleWindVisibility">Visibility on/off: Wind</sys:String>
+    <sys:String x:Key="Hotkey_Action_ToggleHandTracking">Toggle Hand Tracking Active</sys:String>
+    <sys:String x:Key="Hotkey_Action_DisableHandTracking">Enable Hand Tracking</sys:String>
+    <sys:String x:Key="Hotkey_Action_EnableHandTracking">Disable Hand Tracking</sys:String>
     
     <!-- Save/Load -->
     <sys:String x:Key="SettingFile_Header">Setting File Control</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -715,8 +715,8 @@ Input favorite key combination in text area.
     <sys:String x:Key="Hotkey_Action_ToggleOutlineVisibility">Visibility on/off: Outline</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleWindVisibility">Visibility on/off: Wind</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleHandTracking">Toggle Hand Tracking Active</sys:String>
-    <sys:String x:Key="Hotkey_Action_DisableHandTracking">Enable Hand Tracking</sys:String>
-    <sys:String x:Key="Hotkey_Action_EnableHandTracking">Disable Hand Tracking</sys:String>
+    <sys:String x:Key="Hotkey_Action_DisableHandTracking">Disable Hand Tracking</sys:String>
+    <sys:String x:Key="Hotkey_Action_EnableHandTracking">Enable Hand Tracking</sys:String>
     
     <!-- Save/Load -->
     <sys:String x:Key="SettingFile_Header">Setting File Control</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -716,6 +716,9 @@ VMCPを使わない場合、「設定タブをメインウィンドウから非�
     <sys:String x:Key="Hotkey_Action_ToggleShadowVisibility">表示on/off: 影</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleOutlineVisibility">表示on/off: 縁取り</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleWindVisibility">表示on/off: 風</sys:String>
+    <sys:String x:Key="Hotkey_Action_ToggleHandTracking">ハンドトラッキングon/off切り替え</sys:String>
+    <sys:String x:Key="Hotkey_Action_DisableHandTracking">ハンドトラッキングon</sys:String>
+    <sys:String x:Key="Hotkey_Action_EnableHandTracking">ハンドトラッキングoff</sys:String>
 
     <!-- Save/Load -->
     <sys:String x:Key="SettingFile_Header">設定ファイルの操作</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -717,8 +717,8 @@ VMCPを使わない場合、「設定タブをメインウィンドウから非�
     <sys:String x:Key="Hotkey_Action_ToggleOutlineVisibility">表示on/off: 縁取り</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleWindVisibility">表示on/off: 風</sys:String>
     <sys:String x:Key="Hotkey_Action_ToggleHandTracking">ハンドトラッキングon/off切り替え</sys:String>
-    <sys:String x:Key="Hotkey_Action_DisableHandTracking">ハンドトラッキングon</sys:String>
-    <sys:String x:Key="Hotkey_Action_EnableHandTracking">ハンドトラッキングoff</sys:String>
+    <sys:String x:Key="Hotkey_Action_DisableHandTracking">ハンドトラッキングoff</sys:String>
+    <sys:String x:Key="Hotkey_Action_EnableHandTracking">ハンドトラッキングon</sys:String>
 
     <!-- Save/Load -->
     <sys:String x:Key="SettingFile_Header">設定ファイルの操作</sys:String>

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/HotKeySupportedActionsViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/HotKeySupportedActionsViewModel.cs
@@ -20,7 +20,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         static HotKeySupportedActionsViewModel()
         {
-            ConstAvailableHotKeyActions = new HotKeySupportedActionViewModel[14 + 40];
+            const int WtmActionOffset = 17;
+            ConstAvailableHotKeyActions = new HotKeySupportedActionViewModel[WtmActionOffset + 40];
             ConstAvailableHotKeyActions[0] = new(new(HotKeyActions.None, 0, ""));
             ConstAvailableHotKeyActions[1] = new(new(HotKeyActions.SetCamera, 1, ""));
             ConstAvailableHotKeyActions[2] = new(new(HotKeyActions.SetCamera, 2, ""));
@@ -37,10 +38,13 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             ConstAvailableHotKeyActions[12] = new(new(HotKeyActions.ToggleOutlineVisibility, 0, ""));
             ConstAvailableHotKeyActions[13] = new(new(HotKeyActions.ToggleWindVisibility, 0, ""));
 
+            ConstAvailableHotKeyActions[14] = new(new(HotKeyActions.EnableHandTracking, 0, ""));
+            ConstAvailableHotKeyActions[15] = new(new(HotKeyActions.DisableHandTracking, 0, ""));
+            ConstAvailableHotKeyActions[16] = new(new(HotKeyActions.ToggleHandTracking, 0, ""));
 
             for (var i = 0; i < 40; i++)
             {
-                ConstAvailableHotKeyActions[14 + i] = new(new(HotKeyActions.CallWtm, i + 1, ""));
+                ConstAvailableHotKeyActions[WtmActionOffset + i] = new(new(HotKeyActions.CallWtm, i + 1, ""));
             }
         }
 
@@ -228,6 +232,15 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                     break;
                 case HotKeyActions.ToggleWindVisibility:
                     DisplayName = LocalizedString.GetString(DisplayNameKeyPrefix + nameof(HotKeyActions.ToggleWindVisibility));
+                    break;
+                case HotKeyActions.EnableHandTracking:
+                    DisplayName = LocalizedString.GetString(DisplayNameKeyPrefix + nameof(HotKeyActions.EnableHandTracking));
+                    break;
+                case HotKeyActions.DisableHandTracking:
+                    DisplayName = LocalizedString.GetString(DisplayNameKeyPrefix + nameof(HotKeyActions.DisableHandTracking));
+                    break;
+                case HotKeyActions.ToggleHandTracking:
+                    DisplayName = LocalizedString.GetString(DisplayNameKeyPrefix + nameof(HotKeyActions.ToggleHandTracking));
                     break;
                 case HotKeyActions.None:
                 default:


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

タイトルの通りで、カメラによるハンドトラッキングのon/off/toggle(=実行のたびに切り替え)の3つのショートカットを追加しました。

NOTE: 動き方オプションが「つねに手下げ」だと結局ハンドトラッキングが適用されないので、ユーザーが普段「つねに手下げ」を使っている場合は下記のペアを毎回使うことになるかも…

- モーション方式: デフォルト + ハンドトラッキングon
- モーション方式: つねに手下げ + ハンドトラッキングoff`

## How to confirm

Unity Editor + WPF Buildで

- 各ホットキーを割り当てて動作すること
- アプリケーションの終了 + 再起動時でホットキーの設定内容が維持されていること

