### PR TITLE
v4.0.0のハンドトラッキングのうち回転に関する安定性を改善

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Logger/BuddyFileLogger.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Logger/BuddyFileLogger.cs
@@ -31,7 +31,16 @@ namespace Baku.VMagicMirror.Buddy
             var files = Directory.GetFiles(dir);
             foreach (var file in files)
             {
-                File.Delete(file);
+                try
+                {
+                    File.Delete(file);
+                }
+                catch (Exception ex)
+                {
+                    // NOTE: ここを通る場合LogOutput側でも似た問題(=ファイルのリフレッシュ失敗)が起こってログが出せないことがありうるが、
+                    // 本クラスではとくにケアしない
+                    LogOutput.Instance.Write(ex);
+                }
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
@@ -4,16 +4,13 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
-    // NOTE: 発火タイミングの調整がしたい(TwistRelaxerのちょっと後くらいにLateUpateが走ってほしい)のでMonoBehaviourでやる
+    // TODO: もうちょっと堅牢に動くようになったら復活してもよい。現在は回転値のジャンプが目につくのでBindしてない
     public class MediaPipeHandLocalRotLimiter : PresenterBase
     {
         // bye byeとかで手をふる方向の制限
         private const float ClampYaw = 30f;
         // come onみたいな動きのときにひねる方向
         private const float ClampRoll = 60f;
-        
-        // 左(右)上腕を右(左)に向けていい角度の上限
-        private const float UpperArmInsideAngleLimit = 0f;
         
         private readonly IVRMLoadable _vrmLoadable;
         private readonly LateUpdateSourceAfterFinalIK _lateUpdateSource;
@@ -22,8 +19,6 @@ namespace Baku.VMagicMirror
         private bool _hasModel;
         private Transform _leftHandBone;
         private Transform _rightHandBone;
-        private Transform _leftUpperArmBone;
-        private Transform _rightUpperArmBone;
         
         [Inject]
         public MediaPipeHandLocalRotLimiter(
@@ -43,8 +38,6 @@ namespace Baku.VMagicMirror
             {
                 _leftHandBone = info.animator.GetBoneTransform(HumanBodyBones.LeftHand);
                 _rightHandBone = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
-                _leftUpperArmBone = info.animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-                _rightUpperArmBone = info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
                 _hasModel = true;
             };
 
@@ -53,10 +46,9 @@ namespace Baku.VMagicMirror
                 _hasModel = false;
                 _leftHandBone = null;
                 _rightHandBone = null;
-                _leftUpperArmBone = null;
-                _rightUpperArmBone = null;
             };
             
+            // NOTE: 発火タイミングの調整がしたい(TwistRelaxerのちょっと後くらいにLateUpateが走ってほしい)のでMonoBehaviourでやる
             _lateUpdateSource.OnPreLateUpdate
                 .Subscribe(_ => LateUpdate())
                 .AddTo(this);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSystemInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSystemInstaller.cs
@@ -31,7 +31,8 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             Container.BindInterfacesAndSelfTo<MediaPipeTrackerStatusPreviewSender>().AsSingle();
 
             // NOTE: 基本のトラッキングシステムというよりはモーション適用時の後処理みたいなやつ
-            Container.BindInterfacesTo<MediaPipeHandLocalRotLimiter>().AsSingle();
+            // 骨折対策として入れていたが、安定してないので無効化している
+            // Container.BindInterfacesTo<MediaPipeHandLocalRotLimiter>().AsSingle();
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadControllerHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadControllerHelper.cs
@@ -21,6 +21,8 @@ namespace Baku.VMagicMirror
             var controlRigRoot = controlRig.GetBoneTransform(HumanBodyBones.Hips).parent;
             var bipedReferences = LoadReferencesFromVrm(controlRig, controlRigRoot);
             _ = AddFBBIK(controlRig.GetBoneTransform(HumanBodyBones.Hips).parent.gameObject, ikTargets, bipedReferences);
+            
+            // TODO: この辺でTwistRelaxerのセットアップコードを入れたい
 
             //NOTE: 要するに勝手にLookAt結果を代入しなければいい、という話.
             //VRM0ではCurveMapを勝手にいじってたが、これはモデルを尊重してない行為だと思うので廃止

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/BiQuadFilter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/BiQuadFilter.cs
@@ -8,11 +8,11 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class BiQuadFilterVector3
     {
-        private readonly BiQuadFilter _x = new BiQuadFilter();
-        private readonly BiQuadFilter _y = new BiQuadFilter();
-        private readonly BiQuadFilter _z = new BiQuadFilter();
+        private readonly BiQuadFilter _x = new();
+        private readonly BiQuadFilter _y = new();
+        private readonly BiQuadFilter _z = new();
 
-        public Vector3 Output => new Vector3(_x.Output, _y.Output, _z.Output);
+        public Vector3 Output => new(_x.Output, _y.Output, _z.Output);
         
         public void SetUpAsLowPassFilter(float samplingRate, Vector3 cutOffFrequency, Vector3 q)
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/LogOutput.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/LogOutput.cs
@@ -22,7 +22,7 @@ namespace Baku.VMagicMirror
             }
         }
 
-        private readonly object _writeLock = new object();
+        private readonly object _writeLock = new();
         private readonly string _logFilePath;
 
         public static string ExToString(Exception ex)


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

- ハンドトラッキング時の手首ボーンの回転制限を行うコードが悪さをしてrotationの急な変動を起こしていたため、回転制限を見直し
- それとは別で、手首を回したときの回転が手首ボーンに集中しすぎて見栄えが悪くなっていたため、TwistRelaxerコンポーネントを導入して対策

## How to confirm

Unity Editor + WPF Buildで

- 手首の角度の急変化が起こりにくくなっていること
- (todo: TwistRelaxerでこっちを対応予定) 手首ボーンが極端にねじれにくくなっていること

## Note


