### PR TITLE
固定影ライトのデフォルトの向きが正しくなかったのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/FixedShadow.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/FixedShadow.prefab
@@ -111,13 +111,13 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8350776202964844118}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.7848855, y: 0.21130913, z: 0.45315388, w: 0.36599815}
+  m_LocalRotation: {x: 0.2113091, y: -0.78488564, z: 0.45315388, w: 0.36599815}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6508690384579827967}
-  m_LocalEulerAnglesHint: {x: -130, y: 60, z: 0}
+  m_LocalEulerAnglesHint: {x: 60, y: -130, z: 0}
 --- !u!108 &7740033759932116743
 Light:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/FixedShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/FixedShadowController.cs
@@ -1,6 +1,7 @@
 using Baku.VMagicMirror.VMCP;
 using R3;
 using UnityEngine;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
@@ -21,8 +22,9 @@ namespace Baku.VMagicMirror
         public ReactiveProperty<bool> FixedShadowEnabled => _fixedShadowEnabled;
 
         //TODOかも: +- の扱い
-        private Vector3 _fixedShadowLightRotationEuler = new(30, 50, 0);
+        private Vector3 _fixedShadowLightRotationEuler = new(60, -130, 0);
         
+        [Inject]
         public FixedShadowController(
             IMessageReceiver receiver,
             BodyMotionModeController bodyMotionModeController,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPNaiveBoneTransfer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPNaiveBoneTransfer.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
-using VeryAnimation;
 using Zenject;
 
 namespace Baku.VMagicMirror.VMCP


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

- 前PRで入れた機能のうち、「ゲーム入力モード or 下半身姿勢を受信するVMCPが有効なとき、影をワールド固定にする」の影用ライトの向きの初期レイアウトが間違っており、初期状態だと影が正しく映らなくなってしまってたのを修正しています。
- `NaiveBoneTransfer`の差分は手元でのみ導入してるパッケージに対するusingが誤って入ってしまってたのを修正してます。
