### PR TITLE
`VMCPHeadPose.IsConnected` の初期値ミスによってエラーが起こる様になっていたのを修正

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPHeadPose.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPHeadPose.cs
@@ -11,7 +11,7 @@ namespace Baku.VMagicMirror.VMCP
         private readonly ReactiveProperty<bool> _isActive = new(false);
         public ReadOnlyReactiveProperty<bool> IsActive => _isActive;
 
-        private readonly ReactiveProperty<bool> _isConnected = new(true);
+        private readonly ReactiveProperty<bool> _isConnected = new(false);
         public ReadOnlyReactiveProperty<bool> IsConnected => _isConnected;
 
         /// <summary>


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

- #1145 の副作用で、頭部姿勢をVMCPで受信していないと毎フレームエラーが起きることがある問題が出てしまっていたのを修正します
- 問題の根本原因としては、VMCP受信が未接続にもかかわらず頭部姿勢が受信中扱いになっていて、無効なHumanoidのボーンを取りに行ったり何だりする…というのが起こっていたので、それを直しています。
