### PR TITLE
GCAlloc頻度をいくらか改善

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/ExpressionAccumulator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/ExpressionAccumulator.cs
@@ -11,8 +11,8 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class ExpressionAccumulator : IInitializable
     {
-        private readonly Dictionary<ExpressionKey, float> _values = new Dictionary<ExpressionKey, float>();
-        private readonly HashSet<ExpressionKey> _keys = new HashSet<ExpressionKey>();
+        private readonly Dictionary<ExpressionKey, float> _values = new();
+        private readonly HashSet<ExpressionKey> _keys = new();
         private readonly IVRMLoadable _vrmLoadable;
 
         private bool _hasModel;
@@ -60,7 +60,7 @@ namespace Baku.VMagicMirror
         public void Apply()
         {
             PreApply?.Invoke(_values);
-            _expression?.SetWeights(_values);
+            _expression?.SetWeightsNonAlloc(_values);
         }
 
         public void ResetValues()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
@@ -7,7 +7,7 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
-    public readonly struct FaceSwitchKeyApplyContent
+    public readonly struct FaceSwitchKeyApplyContent : IEquatable<FaceSwitchKeyApplyContent>
     {
         private FaceSwitchKeyApplyContent(bool hasValue, bool keepLipSync, ExpressionKey key, string accessoryName)
         {
@@ -18,8 +18,8 @@ namespace Baku.VMagicMirror
         }
 
         //NOTE: default指定してName == nullになってると怒られる事があるので便宜的にneutralで代用している
-        public static FaceSwitchKeyApplyContent Empty()
-            => new(false, false, ExpressionKey.Neutral, "");
+        public static FaceSwitchKeyApplyContent Empty { get; } 
+            = new(false, false, ExpressionKey.Neutral, "");
 
         public static FaceSwitchKeyApplyContent Create(ExpressionKey key, bool keepLipSync, string accessoryName) =>
             new(true, keepLipSync, key, accessoryName);
@@ -28,6 +28,17 @@ namespace Baku.VMagicMirror
         public bool KeepLipSync { get; }
         public ExpressionKey Key { get; }
         public string AccessoryName { get; }
+
+        public bool Equals(FaceSwitchKeyApplyContent other) => 
+            HasValue == other.HasValue &&
+            KeepLipSync == other.KeepLipSync &&
+            Key.Equals(other.Key) &&
+            AccessoryName == other.AccessoryName;
+
+        public override bool Equals(object obj) => 
+            obj is FaceSwitchKeyApplyContent other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(HasValue, KeepLipSync, Key, AccessoryName);
     }
 
     public class FaceSwitchUpdater : PresenterBase
@@ -65,8 +76,8 @@ namespace Baku.VMagicMirror
         private ActiveFaceSwitchItem _faceSwitchItem = ActiveFaceSwitchItem.Empty;
 
         // NOTE: 上記の値に対してExpressionKeyへの変換、およびトラッキングロスしたケースもケアした、公開可能なFaceSwitchの値
-        private readonly ReactiveProperty<FaceSwitchKeyApplyContent> _currentValue
-            = new(FaceSwitchKeyApplyContent.Empty());
+        private readonly ReactiveProperty<FaceSwitchKeyApplyContent> _currentValue 
+            = new(FaceSwitchKeyApplyContent.Empty);
         public ReadOnlyReactiveProperty<FaceSwitchKeyApplyContent> CurrentValue => _currentValue;
         
         public bool HasClipToApply => _currentValue.Value.HasValue;
@@ -105,7 +116,7 @@ namespace Baku.VMagicMirror
             _hasModel = false;
             _faceSwitch.AvatarBlendShapeNames = Array.Empty<string>();
             _faceSwitchItem = ActiveFaceSwitchItem.Empty;
-            _currentValue.Value = FaceSwitchKeyApplyContent.Empty();
+            _currentValue.Value = FaceSwitchKeyApplyContent.Empty;
         }
 
         private void SetFaceSwitchSetting(string json)
@@ -178,7 +189,7 @@ namespace Baku.VMagicMirror
             }
             else
             {
-                _currentValue.Value = FaceSwitchKeyApplyContent.Empty();
+                _currentValue.Value = FaceSwitchKeyApplyContent.Empty;
             }
 
             _faceSwitch.ResetUpdateCalledFlag();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Repository/BuddyRuntimeObjectRepository.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Repository/BuddyRuntimeObjectRepository.cs
@@ -12,7 +12,8 @@ namespace Baku.VMagicMirror.Buddy
         [Inject]
         public BuddyRuntimeObjectRepository() { }
 
-        public IEnumerable<SingleBuddyObjectInstanceRepository> GetRepositories() => _repositories.Values;
+        public Dictionary<BuddyId, SingleBuddyObjectInstanceRepository>.ValueCollection GetRepositories() 
+            => _repositories.Values;
         
         public bool TryGet(BuddyId buddyId, out SingleBuddyObjectInstanceRepository result)
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyTalkTextUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyTalkTextUpdater.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using UnityEngine;
 using Zenject;
 
@@ -23,11 +22,12 @@ namespace Baku.VMagicMirror.Buddy
         void ITickable.Tick()
         {
             var dt = Time.deltaTime;
-            foreach (var tt in _repository
-                .GetRepositories()
-                .SelectMany(r => r.TalkTexts))
+            foreach (var repository in _repository.GetRepositories())
             {
-                tt.UpdateTextState(dt);
+                foreach (var tt in repository.TalkTexts)
+                {
+                    tt.UpdateTextState(dt);
+                }
             }
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/Interface/FaceTrackSourceProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/Interface/FaceTrackSourceProvider.cs
@@ -14,8 +14,7 @@ namespace Baku.VMagicMirror.ExternalTracker
         /// <summary> 顔トラッキング情報が更新されるとUIスレッド上で発火します。 </summary>
         public event Action<IFaceTrackSource> FaceTrackUpdated;
 
-        protected void RaiseFaceTrackUpdated()
-            => FaceTrackUpdated?.Invoke(FaceTrackSource);
+        protected void RaiseFaceTrackUpdated() => FaceTrackUpdated?.Invoke(FaceTrackSource);
 
         //NOTE: デフォルトは「キャリブレーションをそもそもサポートしてません！」みたいな状態に相当
         public virtual void Calibrate() { }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapDataParseUtil.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapDataParseUtil.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine.Profiling;
+
+namespace Baku.VMagicMirror.ExternalTracker.iFacialMocap
+{
+    public static class iFacialMocapDataParseUtil
+    {
+        private static readonly string[] BlendShapeNames = new[]
+        {
+            //目
+            iFacialMocapBlendShapeNames.eyeBlinkLeft,
+            iFacialMocapBlendShapeNames.eyeLookUpLeft,
+            iFacialMocapBlendShapeNames.eyeLookDownLeft,
+            iFacialMocapBlendShapeNames.eyeLookInLeft,
+            iFacialMocapBlendShapeNames.eyeLookOutLeft,
+            iFacialMocapBlendShapeNames.eyeWideLeft,
+            iFacialMocapBlendShapeNames.eyeSquintLeft,
+
+            iFacialMocapBlendShapeNames.eyeBlinkRight,
+            iFacialMocapBlendShapeNames.eyeLookUpRight,
+            iFacialMocapBlendShapeNames.eyeLookDownRight,
+            iFacialMocapBlendShapeNames.eyeLookInRight,
+            iFacialMocapBlendShapeNames.eyeLookOutRight,
+            iFacialMocapBlendShapeNames.eyeWideRight,
+            iFacialMocapBlendShapeNames.eyeSquintRight,
+
+            //あご
+            iFacialMocapBlendShapeNames.jawOpen,
+            iFacialMocapBlendShapeNames.jawForward,
+            iFacialMocapBlendShapeNames.jawLeft,
+            iFacialMocapBlendShapeNames.jawRight,
+
+            //まゆげ
+            iFacialMocapBlendShapeNames.browDownLeft,
+            iFacialMocapBlendShapeNames.browOuterUpLeft,
+            iFacialMocapBlendShapeNames.browDownRight,
+            iFacialMocapBlendShapeNames.browOuterUpRight,
+            iFacialMocapBlendShapeNames.browInnerUp,
+
+            //口(多い)
+            iFacialMocapBlendShapeNames.mouthLeft,
+            iFacialMocapBlendShapeNames.mouthSmileLeft,
+            iFacialMocapBlendShapeNames.mouthFrownLeft,
+            iFacialMocapBlendShapeNames.mouthPressLeft,
+            iFacialMocapBlendShapeNames.mouthUpperUpLeft,
+            iFacialMocapBlendShapeNames.mouthLowerDownLeft,
+            iFacialMocapBlendShapeNames.mouthStretchLeft,
+            iFacialMocapBlendShapeNames.mouthDimpleLeft,
+
+            iFacialMocapBlendShapeNames.mouthRight,
+            iFacialMocapBlendShapeNames.mouthSmileRight,
+            iFacialMocapBlendShapeNames.mouthFrownRight,
+            iFacialMocapBlendShapeNames.mouthPressRight,
+            iFacialMocapBlendShapeNames.mouthUpperUpRight,
+            iFacialMocapBlendShapeNames.mouthLowerDownRight,
+            iFacialMocapBlendShapeNames.mouthStretchRight,
+            iFacialMocapBlendShapeNames.mouthDimpleRight,
+
+            iFacialMocapBlendShapeNames.mouthClose,
+            iFacialMocapBlendShapeNames.mouthFunnel,
+            iFacialMocapBlendShapeNames.mouthPucker,
+            iFacialMocapBlendShapeNames.mouthShrugUpper,
+            iFacialMocapBlendShapeNames.mouthShrugLower,
+            iFacialMocapBlendShapeNames.mouthRollUpper,
+            iFacialMocapBlendShapeNames.mouthRollLower,
+
+            //鼻
+            iFacialMocapBlendShapeNames.noseSneerLeft,
+            iFacialMocapBlendShapeNames.noseSneerRight,
+
+            //ほお
+            iFacialMocapBlendShapeNames.cheekPuff,
+            iFacialMocapBlendShapeNames.cheekSquintLeft,
+            iFacialMocapBlendShapeNames.cheekSquintRight,
+
+            //舌
+            iFacialMocapBlendShapeNames.tongueOut,
+        };
+
+        private static readonly Dictionary<int, string[]> LengthAndNames = new();
+
+        static iFacialMocapDataParseUtil()
+        {
+            var listBasedDict = new Dictionary<int, List<string>>();
+            foreach (var key in BlendShapeNames)
+            {
+                if (!listBasedDict.ContainsKey(key.Length))
+                {
+                    listBasedDict[key.Length] = new List<string>();
+                }
+                listBasedDict[key.Length].Add(key);
+            }
+
+            foreach (var kv in listBasedDict)
+            {
+                LengthAndNames[kv.Key] = kv.Value.ToArray();
+            }
+        }
+
+        public static bool TryGetBlendShapeName(ReadOnlySpan<char> span, out string result)
+        {
+            if (!LengthAndNames.TryGetValue(span.Length, out var keys))
+            {
+                result = null;
+                return false;
+            }
+
+            foreach (var key in keys)
+            {
+                if (span.SequenceEqual(key.AsSpan()))
+                {
+                    result = key;
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        /// <summary>
+        /// カンマ区切りのfloat値を、maxCountで指定した数を最大値として読み取る
+        /// </summary>
+        /// <param name="span"></param>
+        /// <param name="result"></param>
+        /// <param name="maxCount"></param>
+        public static void ParseCommaSeparatedFloats(ReadOnlySpan<char> span, List<float> result, int maxCount)
+        {
+            result.Clear();
+            while (result.Count < maxCount)
+            {
+                var commaIndex = span.IndexOf(',');
+                var isLast = commaIndex < 0;
+                // commaがない場合、末尾の有効な値を読んでる可能性があることに注意
+                var part = isLast ? span : span[..commaIndex];
+                if (ParseUtil.FloatParse(part, out var value))
+                {
+                    result.Add(value);
+                }
+                else
+                {
+                    // 一つでもパースできなければ中断(普通は通過しないはず)
+                    return;
+                }
+
+                if (!isLast)
+                {
+                    span = span[(commaIndex + 1)..];
+                }
+            }
+        }
+
+        public static int FindEqualCharIndex(StringBuilder src)
+        {
+            var findCount = 0;
+            var result = -1;
+            for (var i = 0; i < src.Length; i++)
+            {
+                if (src[i] == '=')
+                {
+                    if (findCount == 0)
+                    {
+                        findCount = 1;
+                        result = i;
+                    }
+                    else
+                    {
+                        return -1;
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapDataParseUtil.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/ExternalTracker/iFacialMocap/iFacialMocapDataParseUtil.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e45e87f2b752d0149b230d431dcb0b07

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/ParseUtil.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Utils/ParseUtil.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 
 namespace Baku.VMagicMirror
@@ -7,6 +8,8 @@ namespace Baku.VMagicMirror
         private static readonly CultureInfo Culture = CultureInfo.InvariantCulture;
         
         public static bool FloatParse(string input, out float result) 
+            => float.TryParse(input, NumberStyles.Float, Culture, out result);
+        public static bool FloatParse(ReadOnlySpan<char> input, out float result) 
             => float.TryParse(input, NumberStyles.Float, Culture, out result);
     }
 }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature

## What the PR does

GCAllocをいくらか削ってるPRです

対象の考え方

- 毎フレーム発生していてGCAllocの回数が多い
- オフにしたオプションに関する処理に対して毎フレーム発生している

実装と動作チェック

- iFacialMocapのメッセージのパースだけ他より差分が大きい
    - これは根本的には部分文字列の取り扱いを`Span<char>`ベースに置き換えてるのが原因
- 動作チェックについても、iFacialMocap連携だけ怪しいので確認しています

## How to confirm

- iFacialMocap連携が正常に動作すること 
