### PR TITLE
「つねに手下げ」モードのときハンドトラッキングは動作してよいことにする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -545,7 +545,7 @@ namespace Baku.VMagicMirror
             //書いてる通りだが、
             // - 同じ状態には遷移できない
             // - 拍手は実行優先度がすごく高いので、他の状態に遷移できない
-            // - 手下げモード有効時は手下げ or 拍手にしか遷移できない
+            // - 手下げモード有効時は手下げ, ハンドトラッキング, 拍手のどれかにしか遷移できない
 
             if (current == target)
             {
@@ -557,8 +557,8 @@ namespace Baku.VMagicMirror
                 return false;
             }
             
-            if (AlwaysHandDown.Value && target != HandTargetType.AlwaysDown &&
-                target != HandTargetType.ClapMotion)
+            if (AlwaysHandDown.Value && 
+                target is not (HandTargetType.AlwaysDown or HandTargetType.ImageBaseHand or HandTargetType.ClapMotion))
             {
                 return false;
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFingerPoseCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFingerPoseCalculator.cs
@@ -56,6 +56,9 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         public void SetLeftHandPose(Landmarks worldLandmarks) => SetHandPose(worldLandmarks, true);
         public void SetRightHandPose(Landmarks worldLandmarks) => SetHandPose(worldLandmarks, false);
 
+        public void ResetLeftHandPose() => ResetHandPose(true);
+        public void ResetRightHandPose() => ResetHandPose(false);
+        
         public (float proximal, float intermediate, float distal, float open) GetFingerAngles(
             int fingerIndex, bool mirror)
         {
@@ -126,6 +129,30 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             {
                 RightHandRotation = handRotation;
                 RightHandPoseHasValidValue = true;
+            }
+        }
+
+        private void ResetHandPose(bool isLeft)
+        {
+            if (isLeft)
+            {
+                LeftHandPoseHasValidValue = false;
+                LeftHandRotation = Quaternion.identity;
+            }
+            else
+            {
+                RightHandPoseHasValidValue = false;
+                RightHandRotation = Quaternion.identity;
+            }
+            
+            for (var i = 0; i < 15; i++)
+            {
+                _bendAngles[(isLeft ? i : i + 15)] = 0f;
+            }
+
+            for (var i = 0; i < 5; i++)
+            {
+                _openAngles[(isLeft ? i : i + 5)] = 0f;
             }
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
@@ -331,9 +331,9 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 }
             }
 
+            // NOTE: トラッキング値の受信前やトラッキングロスト後にHoldを呼ばないためのガード関数
             private bool CanHoldFinger(bool isLeft, bool mirrored)
             {
-                // トラッキング値の受信前やトラッキングロスト後はHoldを呼ばない…という判定のための措置
                 if (mirrored)
                 {
                     isLeft = !isLeft;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/TrackingLostHandCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/TrackingLostHandCalculator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using Baku.VMagicMirror.IK;
 using Cysharp.Threading.Tasks;
+using R3;
 using UnityEngine;
 using Zenject;
 
@@ -30,6 +31,12 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         private float TrackingLostPoseDuration => 
             _poseSetterSettings.TrackingLostMotionDuration + _poseSetterSettings.TrackingLostRotationDelay;
 
+        private readonly Subject<Unit> _leftHandTrackingLostMotionCompleted = new();
+        public Observable<Unit> LeftHandTrackingLostMotionCompleted => _leftHandTrackingLostMotionCompleted;
+        
+        private readonly Subject<Unit> _rightHandTrackingLostMotionCompleted = new();
+        public Observable<Unit> RightHandTrackingLostMotionCompleted => _rightHandTrackingLostMotionCompleted;
+        
         // NOTE: Cancelを呼ばない限り、トラッキングロストの終端姿勢が適用され終わったあともずっとtrueになる
         public bool LeftHandTrackingLostRunning => _leftHandCts != null;
         public bool RightHandTrackingLostRunning => _rightHandCts != null;
@@ -140,6 +147,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             }
 
             LeftHandTrackingLostMotionInProgress = false;
+            _leftHandTrackingLostMotionCompleted.OnNext(Unit.Default);
 
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -180,6 +188,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             }
             
             RightHandTrackingLostMotionInProgress = false;
+            _rightHandTrackingLostMotionCompleted.OnNext(Unit.Default);
 
             while (!cancellationToken.IsCancellationRequested)
             {

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -244,10 +244,6 @@ Get Full Edition to remove the effect.</sys:String>
     <sys:String x:Key="HandTracking_BodyMotionModeIncorrect" xml:space="preserve">*Body Motion Style is now "Standing Only."
 Use "Default" to apply hand tracking result.</sys:String>
 
-    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Title">Hand tracking result will not be applied with current option.</sys:String>
-    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Instruction">Switch Body Motion Style option to "Default" to apply hand tracking result.</sys:String>
-    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Fix">Use "Default" Option</sys:String>
-    
     <sys:String x:Key="HandTracking_DetectionResult">Detection Status:</sys:String>
     <sys:String x:Key="HandTracking_NotDetected">(Not Detected: Try raising hands next to the face)</sys:String>
     <sys:String x:Key="HandTracking_DetectionResult_Notice" xml:space="preserve">Tips:
@@ -900,7 +896,6 @@ Detailed settings about VMCP send and receive is kept after the tab is hidden.</
     <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">Selected Mic Disconnected: {0}</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">Selected Mic Detected: {0}</sys:String>
     <sys:String x:Key="Snackbar_CameraReconnected_Format">Selected Camera Detected: {0}</sys:String>    
-    <sys:String x:Key="Snackbar_BodyMotionStyle_Set_Default">Body Motion Style is set to: "Default"</sys:String>
     <sys:String x:Key="Snackbar_Buddy_LogFileNotFound_Format">The log file of the buddy does not exist: {0}</sys:String>
 
     <!-- Other: Not on Dialog, but used from code -->

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -243,12 +243,6 @@
     <sys:String x:Key="HandTracking_OffsetX">手の広げ方を調整 (cm)</sys:String>
     <sys:String x:Key="HandTracking_OffsetY">手の高さを調整 (cm)</sys:String>
     
-    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Title">現在のオプションではハンドトラッキングの結果が適用されません！</sys:String>
-    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Instruction" xml:space="preserve">動きかたのオプションを「つねに手下げ」から「デフォルト」に変更することで、
-ハンドトラッキングの結果が適用されます。</sys:String>
-
-    <sys:String x:Key="HandTracking_BodyMotionModeIncorrect_Fix">オプションを「デフォルト」に変更</sys:String>
-    
     <sys:String x:Key="HandTracking_ShowAreaChecker">手の検出状況を表示(※カメラ映像は表示されません)</sys:String> 
     <sys:String x:Key="HandTracking_DetectionResult">手の検出状況:</sys:String>
     <sys:String x:Key="HandTracking_DetectionResult_Notice" xml:space="preserve">ヒント:

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -902,7 +902,6 @@ VMCPのデータを送受信中の場合、この操作をすることで送受�
     <sys:String x:Key="Snackbar_MicrophoneDisconnected_Format">選択されたマイクが切断しました: {0}</sys:String>
     <sys:String x:Key="Snackbar_MicrophoneReconnected_Format">選択されたマイクの接続を検出しました: {0}</sys:String>
     <sys:String x:Key="Snackbar_CameraReconnected_Format">選択されたカメラの接続を検出しました: {0}</sys:String>
-    <sys:String x:Key="Snackbar_BodyMotionStyle_Set_Default">動きかたのオプションを「デフォルト」に変更しました</sys:String>    
     <sys:String x:Key="Snackbar_Buddy_LogFileNotFound_Format">指定したサブキャラのログファイルは存在しません: {0}</sys:String>
 
     <!-- Other: Not on Dialog, but used from code -->

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/HandTrackingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/HandTrackingPanel.xaml
@@ -79,35 +79,6 @@
                                   />
                     </Grid>
 
-                    <md:Card Margin="15,5,5,0" 
-                         Visibility="{Binding BodyMotionStyleIncorrectForHandTracking.Value,
-                                              Converter={StaticResource BooleanToVisibilityConverter}}"
-                         HorizontalAlignment="Stretch"
-                         Padding="3">
-                        <StackPanel HorizontalAlignment="Left">
-                            <StackPanel Orientation="Horizontal"
-                                        Background="{StaticResource SecondaryAccentBrush}">
-                                <md:PackIcon Kind="WarningOutline"
-                                             VerticalAlignment="Center"
-                                             Margin="4"
-                                             />
-                                <TextBlock Text="{DynamicResource HandTracking_BodyMotionModeIncorrect_Title}" 
-                                            TextWrapping="Wrap"
-                                            />
-                            </StackPanel>
-                            <TextBlock Text="{DynamicResource HandTracking_BodyMotionModeIncorrect_Instruction}" 
-                                           TextWrapping="Wrap"
-                                           />
-                            <Button Style="{StaticResource MaterialDesignOutlinedButton}"
-                                Content="{DynamicResource HandTracking_BodyMotionModeIncorrect_Fix}"
-                                Command="{Binding FixBodyMotionStyleCommand}"
-                                HorizontalAlignment="Left"
-                                Padding="2"
-                                Margin="5"
-                                />
-                        </StackPanel>
-                    </md:Card>
-
                     <CheckBox Margin="35,0,10,0" 
                                 VerticalContentAlignment="Center"
                                 Content="{DynamicResource HandTracking_ShowEffectDuringTracking}" 

--- a/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
@@ -32,7 +32,6 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
             OpenFullEditionDownloadUrlCommand = new ActionCommand(() => UrlNavigate.Open("https://baku-dreameater.booth.pm/items/3064040"));
             OpenHandTrackingPageUrlCommand = new ActionCommand(() => UrlNavigate.Open(LocalizedString.GetString("URL_docs_hand_tracking")));
-            FixBodyMotionStyleCommand = new ActionCommand(FixBodyMotionStyle);
 
             if (!IsInDesignMode)
             {
@@ -40,10 +39,6 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 // NOTE: ここでは表示にのみ影響するメッセージを受け取るため、ViewModelではあるが直接Receiverのイベントを見に行く
                 // NOTE: WeakEvent Patternになっていないが、HandTrackingのタブのライフサイクルはアプリ全体と同じなので問題にはならないはず
                 receiver.ReceivedCommand += OnReceivedCommand;
-
-                _model.EnableImageBasedHandTracking.AddWeakEventHandler(BodyMotionStyleIncorrectMaybeChanged);
-                _model.EnableNoHandTrackMode.AddWeakEventHandler(BodyMotionStyleIncorrectMaybeChanged);
-                UpdateBodyMotionStyleCorrectness();
             }
         }
 
@@ -67,22 +62,6 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             CameraDeviceName.Value = _model.CameraDeviceName.Value;
         }
 
-        private void BodyMotionStyleIncorrectMaybeChanged(object? sender, PropertyChangedEventArgs e)
-            => UpdateBodyMotionStyleCorrectness();
-
-        private void UpdateBodyMotionStyleCorrectness()
-        {
-            BodyMotionStyleIncorrectForHandTracking.Value =
-                _model.EnableImageBasedHandTracking.Value &&
-                _model.EnableNoHandTrackMode.Value;
-        }
-
-        private void FixBodyMotionStyle()
-        {
-            _model.EnableNoHandTrackMode.Value = false;
-            _model.EnableGameInputLocomotionMode.Value = false;
-            SnackbarWrapper.Enqueue(LocalizedString.GetString("Snackbar_BodyMotionStyle_Set_Default"));
-        }
 
         public RProperty<bool> EnableImageBasedHandTracking => _model.EnableImageBasedHandTracking;
         private readonly RProperty<bool> _alwaysOn = new RProperty<bool>(true);
@@ -98,11 +77,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public HandTrackingResultViewModel HandTrackingResult { get; } = new HandTrackingResultViewModel();
         public ActionCommand OpenFullEditionDownloadUrlCommand { get; }
         public ActionCommand OpenHandTrackingPageUrlCommand { get; }
-        public ActionCommand FixBodyMotionStyleCommand { get; }
 
         public RProperty<string> CameraDeviceName { get; }
         public ReadOnlyObservableCollection<string> CameraNames => _deviceListSource.CameraNames;
 
-        public RProperty<bool> BodyMotionStyleIncorrectForHandTracking { get; } = new(false);
     }
 }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixes: #1158 

- 「バグではないけどイマイチだった仕様の変更」みたいな位置づけになる
- WPF側の差分によって、ハンドトラッキング中に「デフォルト」動作をサジェストする挙動も廃止
- この変更が入ることで「トラッキングロス後に指の形が戻らないのがちょっと気になる」という問題がでたため、[d63f4aa](https://github.com/malaybaku/VMagicMirror/pull/1159/commits/d63f4aa4639ca34568c6773499a7a38444d6ba62) でトラッキングロスト時に指のHoldをやめるような処置を追加した

## How to confirm

Unity Editor + WPF Buildで「つねに手下げ」かつハンドトラッキング有効にするとハンドトラッキングの結果が適用されること

