### PR TITLE
体型調整ブレンドシェイプを複数指定できるようにする

### DIFF
--- a/WPF/VMagicMirrorConfig/Model/Avatar/FaceBlendshapeNameStore.cs
+++ b/WPF/VMagicMirrorConfig/Model/Avatar/FaceBlendshapeNameStore.cs
@@ -28,11 +28,11 @@ namespace Baku.VMagicMirrorConfig
 
         //Unityで読み込まれたアバターのブレンドシェイプ名の一覧です。
         //NOTE: この値は標準ブレンドシェイプ名を含んでいてもいなくてもOK。ただし現行動作では標準ブレンドシェイプ名は含まない。
-        private string[] _avatarClipNames = Array.Empty<string>();
+        private string[] _avatarClipNames = [];
 
         //設定ファイルから読み込んだ設定で使われていたブレンドシェイプ名の一覧。
         //NOTE: この値に標準ブレンドシェイプ名とそうでないのが混在することがあるが、それはOK
-        private string[] _settingUsedNames = Array.Empty<string>();
+        private string[] _settingUsedNames = [];
 
         /// <summary>
         /// ロードされたVRMの標準以外のブレンドシェイプ名を指定して、名前一覧を更新します。
@@ -48,12 +48,20 @@ namespace Baku.VMagicMirrorConfig
         /// <summary>
         /// ファイルからロードされたはずの設定を参照し、その中で使われているブレンドシェイプ名を参考にして名前一覧を更新します。
         /// </summary>
-        /// <param name="neutralClipName"></param>
-        /// <param name="offsetClipName"></param>
+        /// <param name="neutralClipName">Neutralクリップ。1つ指定するか、null/空文字列等を指定する</param>
+        /// <param name="offsetClipName">体型調整ブレンドシェイプ。複数ある場合、tab文字で区切ったものを渡す</param>
         public void Refresh(string? neutralClipName, string? offsetClipName)
         {
-            //NOTE: Refreshの挙動上、ここで""だけを2つ入れたりしても大丈夫。
-            _settingUsedNames = new string[] { neutralClipName ?? "", offsetClipName ?? "" };
+            if (string.IsNullOrEmpty(offsetClipName))
+            {
+                //NOTE: Refreshの挙動上、ここで""だけを2つ入れたりしても大丈夫。
+                _settingUsedNames = [neutralClipName ?? "", ""];
+            }
+            else
+            {
+                _settingUsedNames = [neutralClipName ?? "", .. offsetClipName.Split('\t')];
+            }
+
             RefreshInternal();
         }
 

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -65,6 +65,7 @@
         public int FaceDefaultFun { get; set; } = 0;
 
         public string FaceNeutralClip { get; set; } = "";
+        // NOTE: 複数ある場合、tab文字で区切ったものをAlphabetical orderで保存する
         public string FaceOffsetClip { get; set; } = "";
 
         public bool DisableBlendShapeInterpolate { get; set; } = false;

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -479,7 +479,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
 　デフォルト表情をNeutralなどでカスタムしている場合に使用します。</sys:String>    
     <sys:String x:Key="Motion_Face_OffsetClip">体型調整ブレンドシェイプ</sys:String>
     <sys:String x:Key="Motion_Face_OffsetClip_Help" xml:space="preserve">※体型調整ブレンドシェイプはつねに適用されます。
-　体格や輪郭の調整をブレンドシェイプで行っている場合に使用します。</sys:String>
+　体型の調整やパーツの表示切り替えをブレンドシェイプで行っている場合に使用します。</sys:String>
     <sys:String x:Key="Motion_Face_DisableBlendShapeInterpolate">表情切り替えを補間しない</sys:String>
     
     <!-- Layout Setting -->

--- a/WPF/VMagicMirrorConfig/View/Code/Converter/OffsetClipNameConverter.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/Converter/OffsetClipNameConverter.cs
@@ -4,18 +4,21 @@ using System.Windows.Data;
 
 namespace Baku.VMagicMirrorConfig.View
 {
-    public class TabCharToCommaConverter : IValueConverter
+    public class OffsetClipNameConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is string s)
-            {
-                return s.Replace('\t', ',');
-            }
-            else
+            if (value is not string s)
             {
                 return Binding.DoNothing;
             }
+
+            if (string.IsNullOrEmpty(s))
+            {
+                return LocalizedString.GetString("CommonUi_None");
+            }
+
+            return s.Replace("\t", ", ");
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/WPF/VMagicMirrorConfig/View/Code/Converter/TabCharToCommaConverter.cs
+++ b/WPF/VMagicMirrorConfig/View/Code/Converter/TabCharToCommaConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Baku.VMagicMirrorConfig.View
+{
+    public class TabCharToCommaConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string s)
+            {
+                return s.Replace('\t', ',');
+            }
+            else
+            {
+                return Binding.DoNothing;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => Binding.DoNothing;
+    }
+}

--- a/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml
+++ b/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml
@@ -1,4 +1,4 @@
-﻿<ComboBox 
+﻿<UserControl
     x:Class="Baku.VMagicMirrorConfig.View.OffsetClipSelector"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,24 +7,31 @@
     xmlns:v="clr-namespace:Baku.VMagicMirrorConfig.View"
     xmlns:vm="clr-namespace:Baku.VMagicMirrorConfig.ViewModel"
     mc:Ignorable="d"
-    IsEditable="True"
-    IsReadOnly="True"
-    StaysOpenOnEdit="True"
-    Text="{Binding SelectedItemText.Value}"
     d:DesignHeight="40" d:DesignWidth="160"
     d:DataContext="{d:DesignInstance vm:OffsetClipViewModel}"
     >
-    <ComboBox.DataContext>
+    <UserControl.Resources>
+        <v:TabCharToCommaConverter x:Key="TabCharToCommaConverter" />
+    </UserControl.Resources>
+    <UserControl.DataContext>
         <vm:OffsetClipViewModel />
-    </ComboBox.DataContext>
-    <ComboBox.ItemTemplate>
-        <DataTemplate>
-            <CheckBox 
+    </UserControl.DataContext>
+    <ComboBox
+        Style="{StaticResource MaterialDesignComboBox}"
+        IsEditable="True"
+        IsReadOnly="True"
+        StaysOpenOnEdit="True"
+        Text="{Binding OffsetClipName.Value, Converter={StaticResource TabCharToCommaConverter}}"
+        >
+        <ComboBox.ItemTemplate>
+            <DataTemplate>
+                <CheckBox 
                 Content="{Binding DisplayName}" 
                 IsChecked="{Binding IsSelected, Mode=TwoWay}" 
                 VerticalAlignment="Center"
                 Padding="4,0,0,0"
                 />
-        </DataTemplate>
-    </ComboBox.ItemTemplate>
-</ComboBox>
+            </DataTemplate>
+        </ComboBox.ItemTemplate>
+    </ComboBox>
+</UserControl>

--- a/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml
+++ b/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml
@@ -1,0 +1,30 @@
+﻿<ComboBox 
+    x:Class="Baku.VMagicMirrorConfig.View.OffsetClipSelector"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+    xmlns:v="clr-namespace:Baku.VMagicMirrorConfig.View"
+    xmlns:vm="clr-namespace:Baku.VMagicMirrorConfig.ViewModel"
+    mc:Ignorable="d"
+    IsEditable="True"
+    IsReadOnly="True"
+    StaysOpenOnEdit="True"
+    Text="{Binding SelectedItemText.Value}"
+    d:DesignHeight="40" d:DesignWidth="160"
+    d:DataContext="{d:DesignInstance vm:OffsetClipViewModel}"
+    >
+    <ComboBox.DataContext>
+        <vm:OffsetClipViewModel />
+    </ComboBox.DataContext>
+    <ComboBox.ItemTemplate>
+        <DataTemplate>
+            <CheckBox 
+                Content="{Binding DisplayName}" 
+                IsChecked="{Binding IsSelected, Mode=TwoWay}" 
+                VerticalAlignment="Center"
+                Padding="4,0,0,0"
+                />
+        </DataTemplate>
+    </ComboBox.ItemTemplate>
+</ComboBox>

--- a/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml
+++ b/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml
@@ -11,27 +11,44 @@
     d:DataContext="{d:DesignInstance vm:OffsetClipViewModel}"
     >
     <UserControl.Resources>
-        <v:TabCharToCommaConverter x:Key="TabCharToCommaConverter" />
+        <v:OffsetClipNameConverter x:Key="OffsetClipNameConverter" />
     </UserControl.Resources>
     <UserControl.DataContext>
         <vm:OffsetClipViewModel />
     </UserControl.DataContext>
-    <ComboBox
-        Style="{StaticResource MaterialDesignComboBox}"
-        IsEditable="True"
-        IsReadOnly="True"
-        StaysOpenOnEdit="True"
-        Text="{Binding OffsetClipName.Value, Converter={StaticResource TabCharToCommaConverter}}"
-        >
-        <ComboBox.ItemTemplate>
-            <DataTemplate>
-                <CheckBox 
-                Content="{Binding DisplayName}" 
-                IsChecked="{Binding IsSelected, Mode=TwoWay}" 
-                VerticalAlignment="Center"
-                Padding="4,0,0,0"
-                />
-            </DataTemplate>
-        </ComboBox.ItemTemplate>
-    </ComboBox>
+    <Grid>
+        <ComboBox
+            Style="{StaticResource MaterialDesignComboBox}"
+            IsReadOnly="True"
+            StaysOpenOnEdit="True"
+            ItemsSource="{Binding Items}"
+            >
+            <ComboBox.ItemContainerStyle>
+                <Style TargetType="ComboBoxItem" 
+                       BasedOn="{StaticResource MaterialDesignComboBoxItemStyle}">
+                    <Setter Property="Padding" Value="0" />
+                </Style>
+            </ComboBox.ItemContainerStyle>
+            <ComboBox.ItemTemplate>
+                <DataTemplate DataType="vm:OffsetClipItemViewModel">
+                    <CheckBox 
+                        Margin="0"
+                        Content="{Binding DisplayName}" 
+                        IsChecked="{Binding Selected.Value, Mode=TwoWay}" 
+                        VerticalAlignment="Center"
+                        Padding="4,0,0,0"
+                    />
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+        
+        <!-- ComboBoxを隠す感じの配置になる -->
+        <TextBlock
+            IsHitTestVisible="False"
+            Margin="12,0,20,0"
+            Text="{Binding OffsetClipName.Value, Converter={StaticResource OffsetClipNameConverter}}"
+            TextWrapping="NoWrap"
+            TextTrimming="CharacterEllipsis"
+            />
+    </Grid>
 </UserControl>

--- a/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml.cs
+++ b/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Baku.VMagicMirrorConfig.View
+{
+    public partial class OffsetClipSelector : ComboBox
+    {
+        public OffsetClipSelector()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml.cs
+++ b/WPF/VMagicMirrorConfig/View/FaceSetting/OffsetClipSelector.xaml.cs
@@ -2,7 +2,7 @@
 
 namespace Baku.VMagicMirrorConfig.View
 {
-    public partial class OffsetClipSelector : ComboBox
+    public partial class OffsetClipSelector : UserControl
     {
         public OffsetClipSelector()
         {

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
@@ -475,7 +475,14 @@
                                    Text="{DynamicResource Motion_Face_OffsetClip_Help}"
                                    TextWrapping="Wrap"
                                      />
-                        <ComboBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
+
+                        <view:OffsetClipSelector
+                            Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
+                            Style="{StaticResource MaterialDesignComboBox}"
+                            Margin="5"
+                            />
+
+                        <!--<ComboBox Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
                                   HorizontalAlignment="Stretch"
                                   Margin="5"
                                   ItemsSource="{Binding BlendShapeNames}"
@@ -493,7 +500,7 @@
                                     </TextBlock>
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
-                        </ComboBox>
+                        </ComboBox>-->
 
                     </Grid>
 

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
@@ -478,7 +478,6 @@
 
                         <view:OffsetClipSelector
                             Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2"
-                            Style="{StaticResource MaterialDesignComboBox}"
                             Margin="5"
                             />
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/OffsetClipViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/OffsetClipViewModel.cs
@@ -74,13 +74,13 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                         noneItem.Selected.Value = false;
                     }
                 }
-            });
 
-            // NOTE: 「なし」だけが選択されてる場合には空文字列になるのがポイント
-            _model.FaceOffsetClip.Value = string.Join(
-                "\t",
-                _items.Where(i => i.Selected.Value).Select(i => i.BlendShapeName).OrderBy(v => v, StringComparer.InvariantCulture)
-                );
+                // NOTE: 「なし」だけが選択されてる場合には空文字列になるのがポイント
+                _model.FaceOffsetClip.Value = string.Join(
+                    "\t",
+                    _items.Where(i => i.Selected.Value).Select(i => i.BlendShapeName).OrderBy(v => v, StringComparer.InvariantCulture)
+                    );
+            });
         }
 
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/OffsetClipViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/OffsetClipViewModel.cs
@@ -13,7 +13,12 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         private readonly FaceMotionBlendShapeNameStore _blendShapeNameStore;
         private bool _isSilentMode;
 
-        public OffsetClipViewModel() : this(null!, null!) { }
+        public OffsetClipViewModel() : this(
+            ModelResolver.Instance.Resolve<MotionSettingModel>(),
+            ModelResolver.Instance.Resolve<FaceMotionBlendShapeNameStore>()
+            ) 
+        {
+        }
 
         internal OffsetClipViewModel(
             MotionSettingModel model,
@@ -38,7 +43,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             }
         }
 
-        private readonly ObservableCollection<OffsetClipItemViewModel> _items = new();
+        private readonly ObservableCollection<OffsetClipItemViewModel> _items = [];
         public ReadOnlyObservableCollection<OffsetClipItemViewModel> Items { get; }
 
         // NOTE: タブ文字区切りになってる事に関してはView側でよしなにしてもらう

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/OffsetClipViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/OffsetClipViewModel.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    public class OffsetClipViewModel : ViewModelBase
+    {
+        private readonly MotionSettingModel _model;
+        private readonly FaceMotionBlendShapeNameStore _blendShapeNameStore;
+        private bool _isSilentMode;
+
+        public OffsetClipViewModel() : this(null!, null!) { }
+
+        internal OffsetClipViewModel(
+            MotionSettingModel model,
+            FaceMotionBlendShapeNameStore blendShapeNameStore
+            )
+        {
+            _model = model;
+            _blendShapeNameStore = blendShapeNameStore;
+            Items = new(_items);
+
+            if (!IsInDesignMode)
+            {
+                _model.FaceOffsetClip.AddWeakEventHandler(OnModelOffsetClipChanged);
+
+                WeakEventManager<INotifyCollectionChanged, NotifyCollectionChangedEventArgs>.AddHandler(
+                    _blendShapeNameStore.BlendShapeNames,
+                    nameof(INotifyCollectionChanged.CollectionChanged), 
+                    OnBlendShapeNamesChanged
+                    );
+
+                RefreshItems();
+            }
+        }
+
+        private readonly ObservableCollection<OffsetClipItemViewModel> _items = new();
+        public ReadOnlyObservableCollection<OffsetClipItemViewModel> Items { get; }
+
+        // NOTE: タブ文字区切りになってる事に関してはView側でよしなにしてもらう
+        public RProperty<string> OffsetClipName => _model.FaceOffsetClip;
+
+        private void OnBlendShapeNamesChanged(object? sender, NotifyCollectionChangedEventArgs e) => RefreshItems();
+
+        private void OnModelOffsetClipChanged(object? sender, PropertyChangedEventArgs e) => RefreshSelectedItems();
+
+        private void OnItemSelectedChanged(OffsetClipItemViewModel item)
+        {
+            DoSilently(() =>
+            {
+                if (string.IsNullOrEmpty(item.BlendShapeName) && item.Selected.Value)
+                {
+                    // 「なし」をオンにすると、他のぜんぶの選択が解除される
+                    foreach (var item in _items.Where(i => !string.IsNullOrEmpty(i.BlendShapeName)))
+                    {
+                        item.Selected.Value = false;
+                    }
+                }
+                else if (!string.IsNullOrEmpty(item.BlendShapeName) && item.Selected.Value)
+                {
+                    //「なし」以外をオンにすると、「なし」の選択が解除される
+                    var noneItem = _items.FirstOrDefault(i => string.IsNullOrEmpty(i.BlendShapeName));
+                    if (noneItem != null)
+                    {
+                        noneItem.Selected.Value = false;
+                    }
+                }
+            });
+
+            // NOTE: 「なし」だけが選択されてる場合には空文字列になるのがポイント
+            _model.FaceOffsetClip.Value = string.Join(
+                "\t",
+                _items.Where(i => i.Selected.Value).Select(i => i.BlendShapeName).OrderBy(v => v, StringComparer.InvariantCulture)
+                );
+        }
+
+
+        // BlendShapeの内訳が変わったときに呼ぶことでItemsを全て作り直す
+        private void RefreshItems()
+        {
+            DoSilently(() =>
+            {
+                _items.Clear();
+                foreach (var blendShapeName in _blendShapeNameStore.BlendShapeNames)
+                {
+                    var displayName = string.IsNullOrEmpty(blendShapeName) ? LocalizedString.GetString("CommonUi_None") : blendShapeName;
+                    var item = new OffsetClipItemViewModel(blendShapeName, displayName);
+                    item.Selected.PropertyChanged += (_, __) => OnItemSelectedChanged(item);
+                    _items.Add(item);
+                }
+            });
+            RefreshSelectedItems();
+        }
+
+        // Model側の状態が変化したときに呼ぶことで、各要素のOn/Offの状態をModelに合わせる
+        private void RefreshSelectedItems() => DoSilently(() =>
+        {
+            var selectedNames = _model.FaceOffsetClip.Value.Split('\t');
+            foreach (var item in _items)
+            {
+                if (string.IsNullOrEmpty(item.BlendShapeName))
+                {
+                    // 「なし」の適用条件だけContainsでは評価できないことに注意
+                    item.Selected.Value = selectedNames.Length == 0;
+                }
+                else
+                {
+                    item.Selected.Value = selectedNames.Contains(item.BlendShapeName);
+                }
+            }
+        });
+
+        private void DoSilently(Action action)
+        {
+            if (_isSilentMode)
+            {
+                return;
+            }
+
+            _isSilentMode = true;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                _isSilentMode = false;
+            }
+        }
+    }
+
+    public class OffsetClipItemViewModel : ViewModelBase
+    {
+        public OffsetClipItemViewModel(string blendShapeName, string displayName)
+        {
+            BlendShapeName = blendShapeName;
+            DisplayName = displayName;
+        }
+
+        public string BlendShapeName { get; }
+        public string DisplayName { get; private set; }
+        public RProperty<bool> Selected { get; } = new(false);
+    }
+}


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

体型調整ブレンドシェイプ (FaceOffsetClip) の値を改変します。

- 保存するデータ: `\t` 区切りで対象になるブレンドシェイプを並べたもの
- UI: ComboBoxをExpandすると個別にチェックがon/offできる
- Unity上での取り扱い: `\t` でBlendShape名をSplitしたものを適用

stabilityについて:

- この変更後、FaceOffsetClipに複数ブレンドシェイプを指定したセーブデータを作った状態でダウングレードすると正しく動かない (= 体型調整ブレンドシェイプが未設定の状態とほぼ等価に扱われる)
    - 起動即クラッシュとかではないので許容
- そもそもVRMのブレンドシェイプ名に`\t`が入ってると正しく読まれない
    - 相当レアだと思うので許容

## How to confirm

- [ ] Unity Editor + WPF Build + カスタムブレンドシェイプが多いVRMで期待挙動になること
