### PR TITLE
ハンドトラッキング時の手首のローカル回転制限を復活させる

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
@@ -11,14 +11,16 @@ namespace Baku.VMagicMirror
 
     public class MediaPipeHandLocalRotLimiter : PresenterBase
     {
-        // Twistじゃない方向の回転全体に対して角度制限をするときの上限角度
+        // Twistを除いた回転全体に対して回転量制限をする場合の上限角度 [deg]
         private const float ClampSwing = 30f;
         
-        // 屈伸方向の制限角度
+        // 屈伸方向の制限角度 [deg]
         private const float ClampSwingBendStretch = 70f;
-        // 「さよなら」とかで手を振る方向の制限角度
-        // 現実の人体ではこの方向の曲げ角は20-30degが上限だが、VMMのIKではヒジを締めて手IKで動かす(=手首側に回転成分を押し付けがち)ので、
-        // 少し緩めの制限にしている
+
+        // 「さよなら」とかで手を振る方向の制限角度 [deg]
+        // NOTE: 現実の人体ではこの方向の曲げ角は20-30degが上限。
+        // ただしVMMのIKではヒジを締めて手IKで動かす(=手首側に回転成分を押し付けやすい)ので、制限しすぎると全然曲がらなく見える
+        // …という特性を踏まえて、少し緩めの角度制限にしている
         private const float ClampSwingLeftRight = 40f;
 
         private const float BendAngleMax = Mathf.Deg2Rad * ClampSwingBendStretch;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
@@ -83,7 +83,7 @@ namespace Baku.VMagicMirror
             }
         }
 
-        // 簡単だがキレイじゃない版: swing-twist分解して、swingの方に定数で制限をかける
+        // 簡単だが角度制限として建付けが悪いので使ってない実装: swing-twist分解して、swingの方に定数で制限をかける
         private static Quaternion GetClampedRotationNaive(Quaternion localRotation)
         {
             DecomposeSwingTwist(localRotation, out var swing, out var twist);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSystemInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSystemInstaller.cs
@@ -31,8 +31,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             Container.BindInterfacesAndSelfTo<MediaPipeTrackerStatusPreviewSender>().AsSingle();
 
             // NOTE: 基本のトラッキングシステムというよりはモーション適用時の後処理みたいなやつ
-            // 骨折対策として入れていたが、安定してないので無効化している
-            // Container.BindInterfacesTo<MediaPipeHandLocalRotLimiter>().AsSingle();
+            Container.BindInterfacesTo<MediaPipeHandLocalRotLimiter>().AsSingle();
         }
     }
 }


### PR DESCRIPTION
## PR category

- [x] Improve existing feature

## What the PR does

#1127 で塞いでいた実装を改善して入れ直すPR。

- `eulerAngles` を見に行く実装では幾何的に問題があるので書き直したうえで適用し直した
- known issueとして手首->中指のベクトルが `y <= 0` 方向になるようなトラッキングは全体的に反映されなくなる
    - これは現行の肘IKの実装 (肘がつねに腰付近に固定されやすい) を踏まえると許容していいと思うので許容する
    - ここをちゃんとしたい場合は #1157 をやる

## How to Confirm

- Unity Editor + WPF Buildでハンドトラッキングしてみて、目につく破綻が増えてないこと