### PR TITLE
`.glb` のアクセサリーがMToonのマテリアル拡張データを持っている場合はそれを使う

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryFileReader.cs
@@ -3,6 +3,7 @@ using System.IO;
 using UniGLTF;
 using UnityEngine;
 using UnityEngine.Rendering;
+using UniVRM10;
 
 namespace Baku.VMagicMirror
 { 
@@ -76,7 +77,11 @@ namespace Baku.VMagicMirror
 
         private static AccessoryFileContext<GameObject> LoadGlbOrGltf(GltfData data)
         {
-            var context = new ImporterContext(data);
+            // NOTE: MaterialGeneratorをVRM10用にすることで、GLBにMToonが入ってたら読めるようにしておく
+            var context = new ImporterContext(
+                data,
+                materialGenerator: new BuiltInVrm10MaterialDescriptorGenerator()
+                );
             var instance = context.Load();
             instance.ShowMeshes();
             instance.EnableUpdateWhenOffscreen();


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

アクセサリー機能の改善。

- [UnityMToonGltfExtension](https://github.com/malaybaku/UnityMToonGltfExtension) をUniVRMに横付けすると、Mtoon入りの`.glb`ファイルが出力できる
- それを本branchのVMMから読むと、ちゃんとMToonが入った`.glb`として扱える

## How to confirm

- Unity Editor上で、MToon入りのglbファイル製アクセサリーを読み込んでoutline等が動作することを確認 + Inspectorの内容的にも大丈夫そうなのを確認

## Note

- 機能宣伝するにあたって上述の [UnityMToonGltfExtension](https://github.com/malaybaku/UnityMToonGltfExtension) も紹介する必要があることに注意する
    - つまり、本PRは(少なくとも現時点では)Unity上でセットアップしてエクスポートしたオブジェクトを使う前提を持つので、機能的にはAdvancedなものとして扱う必要がありそう
