### PR TITLE
カメラ位置についてアバターの身長の変動を加味した調整を行う

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
@@ -167,14 +167,12 @@ namespace Baku.VMagicMirror
             {
                 // セーブデータと現在のアバター双方のHeadボーンの位置が分かっている場合、
                 // セーブデータの頭位置に対して身長差を加味した値を実際の値とする。
-                // どちらか片方だけでも不明な場合、
+                // どちらか片方だけでも不明な場合、補正はしない
                 var headDiff = _headPosition - _referenceHeadPosition;
                 cam.transform.SetPositionAndRotation(
                     _customCameraPosition + headDiff,
                     Quaternion.Euler(_customCameraRotationEuler)
                 );
-
-                Debug.Log($"補正付きでカメラ位置を更新: head - ref={_headPosition.y:0.000} - {_referenceHeadPosition.y:0.000} = {headDiff.y:0.000}");
             }
             else
             {
@@ -182,8 +180,6 @@ namespace Baku.VMagicMirror
                     _customCameraPosition,
                     Quaternion.Euler(_customCameraRotationEuler)
                 );
-
-                Debug.Log($"補正なしでカメラ位置を更新");
             }
         }
 
@@ -194,7 +190,6 @@ namespace Baku.VMagicMirror
                 // アプリ起動後、2体目以降のアバターロードで通過
                 var diff = _headPosition - _prevModelHeadPosition;
                 cam.transform.position += diff;
-                Debug.Log($"アバター切り替えぶんカメラ位置を更新: head - prev={_headPosition.y:0.000} - {_prevModelHeadPosition.y:0.000} = {diff.y:0.000}");
                 return;
             }
 
@@ -202,7 +197,6 @@ namespace Baku.VMagicMirror
             {
                 // アプリ起動後の1体目のロードより前に ReferenceHeadPosition がついたカメラ姿勢が設定済みだと通過
                 var diff = _headPosition - _referenceHeadPosition;
-                Debug.Log($"初回ロードしたアバターとカメラ設定を照合して位置を調整: head - ref={_headPosition.y:0.000} - {_referenceHeadPosition.y:0.000} = {diff.y:0.000}");
                 cam.transform.position += diff;
                 return;
             }
@@ -216,7 +210,6 @@ namespace Baku.VMagicMirror
         {
             if (_hasModel && HasValidCustomCameraPose() && !_hasReferenceHeadPosition)
             {
-                Debug.Log($"リファレンスの頭部位置がないため、現在のアバターの頭部姿勢を適用");
                 _hasReferenceHeadPosition = true;
                 _referenceHeadPosition = _headPosition;
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
@@ -14,14 +14,42 @@ namespace Baku.VMagicMirror
         private Vector3 _defaultCameraPosition = Vector3.zero;
         private Vector3 _defaultCameraRotationEuler = Vector3.zero;
 
+        // NOTE: 下記4つの値は基本WPFから渡された値をリスペクトして使うが、
+        // Unity側では以下2ケースにおいて、現在のアバターのHeadボーン位置を _headPositionFor~ に有効値としてsetする。
+        // つまり、頭の基準位置が不明なカメラ姿勢を受け取った場合、現在のアバターの頭位置を基準位置にする。
+        // これにより、初回のロード後に
+        //
+        // - ケース1:
+        //   - _customCameraPosition, _customCameraRotationEuler いずれかが非ゼロ、かつ _hasHeadPositionFor~ がfalse
+        //   - その状態でアバターをロードした
+        // - ケース2:
+        //   - アバターがロード済みである
+        //   - その状態で、 _hasHeadPosition が false であるようなカメラ姿勢をWPFから受け取った
         private Vector3 _customCameraPosition = Vector3.zero;
         private Vector3 _customCameraRotationEuler = Vector3.zero;
+        private bool _hasReferenceHeadPosition;
+        private Vector3 _referenceHeadPosition;
 
-        public bool IsInFreeCameraMode { get; private set; }
-
+        private bool _hasModel;
+        private Vector3 _headPosition;
+        
         [Inject]
-        public void Initialize(IMessageReceiver receiver)
+        public void Initialize(IVRMLoadable vrmLoadable, IMessageReceiver receiver)
         {
+            vrmLoadable.VrmLoaded += info =>
+            {
+                _headPosition = info.animator.GetBoneTransform(HumanBodyBones.Head).position;
+                _hasModel = true;
+                UpdateCameraPose();
+                ApplyReferenceHeadPositionIfAvailable();
+            };
+
+            vrmLoadable.VrmDisposing += () =>
+            {
+                _hasModel = false;
+                _headPosition = Vector3.zero;
+            };
+            
             receiver.AssignCommandHandler(
                 VmmCommands.Chromakey, 
                 message =>
@@ -38,13 +66,13 @@ namespace Baku.VMagicMirror
             receiver.AssignCommandHandler(
                 VmmCommands.SetCustomCameraPosition, 
                 message => 
-                    SetCustomCameraPosition(message.GetStringValue(), true)
+                    SetCustomCameraPosition(message.GetStringValue())
                     );
 
             receiver.AssignCommandHandler(
                 VmmCommands.QuickLoadViewPoint, 
                 message => 
-                    SetCustomCameraPosition(message.GetStringValue(), true)
+                    SetCustomCameraPosition(message.GetStringValue())
                     );
 
             receiver.AssignCommandHandler(
@@ -59,15 +87,17 @@ namespace Baku.VMagicMirror
                     var t = cam.transform;
                     var angles = t.rotation.eulerAngles;
                     var pos = t.position;
-                    query.Result = JsonUtility.ToJson(new SerializedCameraPosition(new[]
-                    {
-                        pos.x,
-                        pos.y,
-                        pos.z,
-                        angles.x,
-                        angles.y,
-                        angles.z,
-                    }));
+                    
+                    var headPosition =
+                        _hasModel ? _headPosition :
+                        _hasReferenceHeadPosition ? _referenceHeadPosition :
+                        Vector3.zero;
+
+                    query.Result = JsonUtility.ToJson(new SerializedCameraPosition(
+                        new[] { pos.x, pos.y, pos.z, angles.x, angles.y, angles.z },
+                        _hasModel || _hasReferenceHeadPosition,
+                        headPosition
+                        ));
                 });
         }
 
@@ -76,101 +106,96 @@ namespace Baku.VMagicMirror
             var camTransform = cam.transform;
             _defaultCameraPosition = camTransform.position;
             _defaultCameraRotationEuler = camTransform.rotation.eulerAngles;
-
         }
 
-        public void SetCameraBackgroundColor(float a, float r, float g, float b)
-        {
-            cam.backgroundColor = new Color(r, g, b, a);
-        }
+        public void SetCameraBackgroundColor(float a, float r, float g, float b) 
+            => cam.backgroundColor = new Color(r, g, b, a);
 
         private void EnableFreeCameraMode(bool v)
-        {
-            IsInFreeCameraMode = v;
-            transformController.enabled = v;
-        }
+            => transformController.enabled = v;
 
         private void ResetCameraPosition()
         {
             _customCameraPosition = _defaultCameraPosition;
             _customCameraRotationEuler = _defaultCameraRotationEuler;
-            UpdateCameraTransform(true);
+            _hasReferenceHeadPosition = false;
+            _referenceHeadPosition = Vector3.zero;
+
+            UpdateCameraPose();
         }
 
 
-        private void SetCustomCameraPosition(string content, bool forceUpdateInFreeCameraMode)
+        private void SetCustomCameraPosition(string content)
         {
-            //note: ここはv0.9.0以降ではシリアライズしたJson、それより前ではfloatのカンマ区切り配列。
-            //Jsonシリアライズを導入したのは、OSのロケールによっては(EU圏とかで)floatの小数点が","になる問題をラクして避けるため。
-            float[] values = new float[0];
             try
             {
-                //シリアライズ: 普通はこれで通る
-                values = JsonUtility.FromJson<SerializedCameraPosition>(content)
-                    .values
-                    .ToArray();
+                var data = JsonUtility.FromJson<SerializedCameraPosition>(content);
+
+                // カメラ位置自体が完全にゼロな場合、無効値として無視
+                var values = data.values.ToArray();
+                if (values.All(v => Mathf.Abs(v) < Mathf.Epsilon))
+                {
+                    return;
+                }
+
+                _customCameraPosition = new Vector3(values[0], values[1], values[2]);
+                _customCameraRotationEuler = new Vector3(values[3], values[4], values[5]);
+                _hasReferenceHeadPosition = data.hasHeadPosition;
+                _referenceHeadPosition = data.headPosition;
+
+                UpdateCameraPose();
+                ApplyReferenceHeadPositionIfAvailable();
             }
             catch(Exception ex)
             {
                 LogOutput.Instance.Write(ex);
             }
-
-            if (values.Length != 6)
-            {
-                try
-                {
-                    //旧バージョンから設定をインポートしたときはこれでうまくいく
-                    values = content.Split(',')
-                        .Select(float.Parse)
-                        .ToArray();
-                }
-                catch (Exception ex)
-                {
-                    LogOutput.Instance.Write(ex);
-                }
-            }
-
-            if (values.Length != 6)
-            {
-                return;
-            }
-
-            //ぜんぶ0な場合、無効値として無視
-            if (values.All(v => Mathf.Abs(v) < Mathf.Epsilon))
-            {
-                return;
-            }
-
-            _customCameraPosition = new Vector3(
-                values[0], values[1], values[2]
-                );
-
-            _customCameraRotationEuler = new Vector3(
-                values[3], values[4], values[5]
-                );
-
-            UpdateCameraTransform(forceUpdateInFreeCameraMode);
         }
 
-        private void UpdateCameraTransform(bool forceUpdateInFreeCameraMode)
+        private void UpdateCameraPose()
         {
-            if (IsInFreeCameraMode && !forceUpdateInFreeCameraMode)
+            // NOTE: WPF側がきちんと設定を持ってないと6DoF=0,0,0,0,0,0を指定したようになるため、そのときに入力を無視する
+            if (!(_customCameraPosition.magnitude > Mathf.Epsilon ||
+                _customCameraRotationEuler.magnitude > Mathf.Epsilon
+                ))
             {
+                cam.transform.SetPositionAndRotation(
+                    _defaultCameraPosition,
+                    Quaternion.Euler(_defaultCameraRotationEuler)
+                );
                 return;
             }
 
-            //NOTE: WPF側がきちんと設定を持ってないと6DoF=0,0,0,0,0,0を指定したようになるため、そのときに入力を無視する
-            if (_customCameraPosition.magnitude > Mathf.Epsilon ||
-                _customCameraRotationEuler.magnitude > Mathf.Epsilon
-                )
+            if (_hasModel && _hasReferenceHeadPosition)
             {
-                cam.transform.position = _customCameraPosition;
-                cam.transform.rotation = Quaternion.Euler(_customCameraRotationEuler);
+                // セーブデータと現在のアバター双方のHeadボーンの位置が分かっている場合、
+                // セーブデータの頭位置に対して身長差を加味した値を実際の値とする。
+                // どちらか片方だけでも不明な場合、
+                var headDiff = _headPosition - _referenceHeadPosition;
+                cam.transform.SetPositionAndRotation(
+                    _customCameraPosition + headDiff,
+                    Quaternion.Euler(_customCameraRotationEuler)
+                );
             }
             else
             {
-                cam.transform.position = _defaultCameraPosition;
-                cam.transform.rotation = Quaternion.Euler(_defaultCameraRotationEuler);
+                cam.transform.SetPositionAndRotation(
+                    _customCameraPosition,
+                    Quaternion.Euler(_customCameraRotationEuler)
+                );
+            }
+        }
+
+        private void ApplyReferenceHeadPositionIfAvailable()
+        {
+            if (_hasModel &&
+                (_customCameraPosition.magnitude > Mathf.Epsilon ||
+                _customCameraRotationEuler.magnitude > Mathf.Epsilon) &&
+                !_hasReferenceHeadPosition
+                )
+            {
+                _hasReferenceHeadPosition = true;
+                _referenceHeadPosition = _headPosition;
             }
         }
     }
@@ -178,19 +203,20 @@ namespace Baku.VMagicMirror
     [Serializable]
     public class SerializedCameraPosition
     {
-        public List<float> values = new List<float>();
+        public List<float> values = new();
 
-        public SerializedCameraPosition(float[] v)
+        // v4.2.1から追加:
+        // valuesで定まるカメラ位置を使っているアバターの頭ボーン位置 (※ロード直後のTポーズ時) をペアで保存する
+        // インストール後や旧バージョンではこの値は保存されていないが、
+        // VMMが起動してアバターを読み込むと (フリーカメラを使わないでも) ポーリングによって値が送られる
+        public bool hasHeadPosition;
+        public Vector3 headPosition;
+
+        public SerializedCameraPosition(float[] values, bool hasHeadPosition, Vector3 headPosition)
         {
-            if (v == null)
-            {
-                return;
-            }
-            
-            for(int i = 0; i < v.Length; i++)
-            {
-                values.Add(v[i]);
-            }
+            this.values = new List<float>(values);
+            this.hasHeadPosition = hasHeadPosition;
+            this.headPosition = headPosition;
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -14,7 +14,7 @@
         CurrentMicrophoneDeviceName,
         MicrophoneDeviceNames,
 
-        // Camera
+        // Layout, Camera
         CurrentCameraPosition,
         
         // Web Camera


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

Headボーンを身長のリファレンスとして、アバター変更時にはHeadボーンの位置の変動ぶんだけ自動でカメラを移動する。

- これにより、身長が異なるアバターを読み込んだとき、アバターが急に視界からいなくなったり、視点が低くなりすぎたりする問題を緩和する
- 体や頭全体が大きい/小さいアバターについては効果が薄いが、そこはとくに頑張らない
