### PR TITLE
ハンドトラッキングで動かす親指のOpen角度の可動域を狭める

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFingerPoseCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFingerPoseCalculator.cs
@@ -180,7 +180,9 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                     // 各パラメータはVRoidモデルをリファレンスにして調整していて、モデルによっては指の曲がりすぎ/曲げ不足も起きうる
                     var thumbDistal = GetThumbDistalBendAngle(j2, j1, tips);
 
-                    var thumbOpenAngle = Mathf.Clamp(thumbDistal * 0.3f, 0f, 30f);
+                    // Openも適当に動かすと破綻しやすい(とくにモデルのT-Pose依存性も結構ある)ので控えめにしとく
+                    // NOTE: FingerControllerが内部的にMuscleで動いたらもうちょっと可動域を増やしても破綻しないかも
+                    var thumbOpenAngle = Mathf.Clamp(thumbDistal * 0.3f, 0f, 15f);
                     _openAngles[angleIndex] = thumbOpenAngle * (isLeft ? -1 : 1);
                     // 親指の第3関節のbendは値が大きいときの見た目を保証しづらいので、ほぼノータッチ
                     _bendAngles[3 * angleIndex] = thumbDistal * 0.05f;


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

- モデルによっては現行の指の曲げ実装では親指がヘンな方向に曲がりやすい…というのがわかったので可動域を縮める方向で対策する
- コードコメントに書いた通り、根本対策としては指をMuscleで動かす改修が要りそう
