### PR TITLE
指を曲げるときの回転軸の決め方を改善

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerRotationAxisGetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerRotationAxisGetter.cs
@@ -1,0 +1,108 @@
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public static class FingerRotationAxisGetter
+    {
+        public static Vector3 GetFingerBendAngle(int fingerNumber, Transform[][] fingers)
+        {
+            return fingerNumber < 5
+                ? GetLeftHandFingerBendAngle(fingerNumber, fingers)
+                : GetRightHandFingerBendAngle(fingerNumber, fingers);
+        }
+        
+        private static Vector3 GetLeftHandFingerBendAngle(int fingerNumber, Transform[][] fingers)
+        {
+            if (fingerNumber == FingerConsts.LeftThumb)
+            {
+                return GetLeftThumbRotationAxis(fingers);
+            }
+
+            // 親指以外では「Tポーズのときに指がすでにちょっと開いてるかどうか」だけ踏まえて微調整する。
+            // 回転軸はほぼ +z/-z 軸に沿っているが、モデルの状態によってはx軸成分も入る
+            if (fingers[fingerNumber] == null || fingers[fingerNumber].Length < 3)
+            {
+                return Vector3.forward;
+            }
+            
+            // VRM的に「キレイなTポーズ」では、このベクトルが -x 方向になるが、モデルによって多少ブレる
+            var diff = fingers[fingerNumber][0].position - fingers[fingerNumber][2].position;
+            diff.y = 0f;
+            if (IsSmall(diff))
+            {
+                return Vector3.forward;
+            }
+
+            // NOTE: diffからy成分を除去してdiffとupが直交なのを保証しているため、必ずCrossの計算結果が単位ベクトルになる
+            return Vector3.Cross(-diff.normalized, Vector3.up);
+        }
+        
+        private static Vector3 GetRightHandFingerBendAngle(int fingerNumber, Transform[][] fingers)
+        {
+            if (fingerNumber == FingerConsts.RightThumb)
+            {
+                return GetRightThumbRotationAxis(fingers);
+            }
+
+            if (fingers[fingerNumber] == null || fingers[fingerNumber].Length < 3)
+            {
+                return Vector3.back;
+            }
+
+            var diff = fingers[fingerNumber][0].position - fingers[fingerNumber][2].position;
+            diff.y = 0f;
+            if (IsSmall(diff))
+            {
+                return Vector3.back;
+            }
+
+            return Vector3.Cross(-diff.normalized, Vector3.up);
+        }
+            
+        private static Vector3 GetLeftThumbRotationAxis(Transform[][] fingers)
+        {
+            // 計算アプローチ
+            // - 「手首 - 親指第2関節 - 人差し指の付け根」 で平面を張っていることにする
+            // - 「人指 - 親指」の正規化したベクトルを回転軸にする
+            // - 必要なボーンが足りない場合、諦めてVector3.upとかVector3.downを返す
+            
+            if (fingers[0] == null || fingers[0].Length < 3 || fingers[1] == null || fingers[1].Length < 2)
+            {
+                return Vector3.down;
+            }
+            
+            var thumbProximal = fingers[0][2].position;
+            var fingerProximal = fingers[1][2].position;
+
+            var diff = fingerProximal - thumbProximal;
+            if (IsSmall(diff))
+            {
+                return Vector3.down;
+            }
+            
+            // NOTE: 左手ではマイナスをつけないと正の角度に対しておかしくなるので注意
+            return -(diff.normalized);
+        }
+        
+        private static Vector3 GetRightThumbRotationAxis(Transform[][] fingers)
+        {
+            if (fingers[5] == null || fingers[5].Length < 3 || fingers[6] == null || fingers[6].Length < 2)
+            {
+                return Vector3.up;
+            }
+            
+            var thumbProximal = fingers[5][2].position;
+            var fingerProximal = fingers[6][2].position;
+            
+            var diff = fingerProximal - thumbProximal;
+            if (IsSmall(diff))
+            {
+                return Vector3.up;
+            }
+            return diff.normalized;
+        }
+
+        // ベクトルが小さすぎて計算が怪しいのを判定するやつ
+        private static bool IsSmall(Vector3 v) => v.sqrMagnitude < (0.001f * 0.001f);
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerRotationAxisGetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerRotationAxisGetter.cs
@@ -4,14 +4,14 @@ namespace Baku.VMagicMirror
 {
     public static class FingerRotationAxisGetter
     {
-        public static Vector3 GetFingerBendAngle(int fingerNumber, Transform[][] fingers)
+        public static Vector3 GetFingerBendRotationAxis(int fingerNumber, Transform[][] fingers)
         {
             return fingerNumber < 5
-                ? GetLeftHandFingerBendAngle(fingerNumber, fingers)
-                : GetRightHandFingerBendAngle(fingerNumber, fingers);
+                ? GetLeftHandFingerBendRotationAxis(fingerNumber, fingers)
+                : GetRightHandFingerBendRotationAxis(fingerNumber, fingers);
         }
         
-        private static Vector3 GetLeftHandFingerBendAngle(int fingerNumber, Transform[][] fingers)
+        private static Vector3 GetLeftHandFingerBendRotationAxis(int fingerNumber, Transform[][] fingers)
         {
             if (fingerNumber == FingerConsts.LeftThumb)
             {
@@ -37,7 +37,7 @@ namespace Baku.VMagicMirror
             return Vector3.Cross(-diff.normalized, Vector3.up);
         }
         
-        private static Vector3 GetRightHandFingerBendAngle(int fingerNumber, Transform[][] fingers)
+        private static Vector3 GetRightHandFingerBendRotationAxis(int fingerNumber, Transform[][] fingers)
         {
             if (fingerNumber == FingerConsts.RightThumb)
             {
@@ -71,10 +71,11 @@ namespace Baku.VMagicMirror
                 return Vector3.down;
             }
             
-            var thumbProximal = fingers[0][2].position;
-            var fingerProximal = fingers[1][2].position;
+            // NOTE: thumbは distal ~ proximalのどれをリファレンスにするかがちょっと悩ましい (一長一短ある)
+            var thumbPos = fingers[0][1].position;
+            var indexProximal = fingers[1][2].position;
 
-            var diff = fingerProximal - thumbProximal;
+            var diff = indexProximal - thumbPos;
             if (IsSmall(diff))
             {
                 return Vector3.down;
@@ -91,10 +92,10 @@ namespace Baku.VMagicMirror
                 return Vector3.up;
             }
             
-            var thumbProximal = fingers[5][2].position;
-            var fingerProximal = fingers[6][2].position;
+            var thumbPos = fingers[5][1].position;
+            var indexProximal = fingers[6][2].position;
             
-            var diff = fingerProximal - thumbProximal;
+            var diff = indexProximal - thumbPos;
             if (IsSmall(diff))
             {
                 return Vector3.up;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerRotationAxisGetter.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerRotationAxisGetter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e8b0a49ea3e93e42b163c6338575afd

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFingerPoseCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeFingerPoseCalculator.cs
@@ -176,17 +176,16 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                     // - 観察: distal以外の曲げ検出があまり成功しない + distalの曲げも過小評価されやすい
                     // - 要件: グーのときにきれいに動いてほしい
                     // - 曲げ方: distalの曲げ具合を親指の全関節の曲げに波及させる
-                    //   - ただし、1自由度で動いて見えると絵的につまらないので、intermediateの計算値も効かせておく
+                    //   - ただし、1自由度で動いて見えると絵的につまらないので、intermediateの計算値も少しだけ利かす
                     // 各パラメータはVRoidモデルをリファレンスにして調整していて、モデルによっては指の曲がりすぎ/曲げ不足も起きうる
                     var thumbDistal = GetThumbDistalBendAngle(j2, j1, tips);
 
-                    // Openも適当に動かすと破綻しやすい(とくにモデルのT-Pose依存性も結構ある)ので控えめにしとく
-                    // NOTE: FingerControllerが内部的にMuscleで動いたらもうちょっと可動域を増やしても破綻しないかも
-                    var thumbOpenAngle = Mathf.Clamp(thumbDistal * 0.3f, 0f, 15f);
+                    // Openは動かすと破綻しやすいので、かなり控えめに効かせる
+                    var thumbOpenAngle = Mathf.Clamp(thumbDistal * 0.3f, 0f, 10f);
                     _openAngles[angleIndex] = thumbOpenAngle * (isLeft ? -1 : 1);
-                    // 親指の第3関節のbendは値が大きいときの見た目を保証しづらいので、ほぼノータッチ
-                    _bendAngles[3 * angleIndex] = thumbDistal * 0.05f;
-                    _bendAngles[3 * angleIndex + 1] = Mathf.Clamp(thumbDistal * 0.4f + intermediate * 0.6f, 0f, 70f);
+                    // NOTE: MediaPipeHand側で平均して使ってることには注意
+                    _bendAngles[3 * angleIndex] = thumbDistal;
+                    _bendAngles[3 * angleIndex + 1] = thumbDistal * 0.7f + intermediate * 0.3f;
                     _bendAngles[3 * angleIndex + 2] = thumbDistal;
 
                     continue;
@@ -220,9 +219,9 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
         private static float GetThumbDistalBendAngle(Vector3 j2, Vector3 j1, Vector3 tips)
         {
-            // NOTE: 曲げが過小評価されやすいので、60度になった時点で曲げきった扱いにする
+            // NOTE: 曲げが過小評価されやすいので、ある程度曲がったら曲げきった扱いにする
             var rawAngle = Mathf.Clamp(GetBendAngle(j2, j1, tips), 0f, 60f);
-            return CubicInOutEase(rawAngle / 60f) * 90f;
+            return CubicInOutEase(rawAngle / 70f) * 90f;
         }
 
         // 指の付け根側から「手首、第(3|2|1)関節、指先」の位置を渡すことで、第(3|2|1)関節の折り曲げ角度を返す。


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

#1164 の要望をMuscleは使わずに解決します。

- 具体的には `FingerController` で行っているForward Kinematicベースの指曲げで、従来よりはTポーズ時のポーズに依存しない形で指の回転軸を扱う
    - 親指: Tポーズ時に親指が人差し指側にピッタリくっついてない前提で計算していろいろ整合するようする
    - 親指以外: Tポーズの時点で指が多少開いてたりするとき、その開いてる状態を考慮してBendの回転軸を覚える
- この変更の影響範囲はFK全般にわたるが、見かけとしてはハンドトラッキング時の親指の曲げ方が変わるのが顕著で、他ではそこまで劇的な変化は見られない想定

## How to confirm

- [ ] Unity EditorでVRoid製を含むVRM数体を動かしてみて、露骨に破綻してないこと
