### PR TITLE
MToon入りの `.glb` を作るときの手順を少し更新

### DIFF
--- a/docs/langs/_english/tips/use_mtoon_defined_glb.md
+++ b/docs/langs/_english/tips/use_mtoon_defined_glb.md
@@ -24,7 +24,19 @@ You need to setup and export model data by following steps.
 #### 1. Create Unity Project to Export .glb File
 {: .doc-sec2 }
 
-Install Unity 6 or later version and create a new project. Then, introduce following packages.
+Install Unity 2022.3 or later version and create a new project. Choose Built-in Render Pipeline for the project.
+
+<div class="note-area" markdown="1">
+
+**NOTE**
+
+VMagicMirror uses Built-in Render Pipeline.
+
+Please select Built-in Render Pipeline so that your object to export looks similarly in Unity Editor and VMagicMirror.
+
+</div>
+
+In the new project, introduce following packages.
 
 - [UniVRM v0.121.0](https://github.com/vrm-c/UniVRM/releases/tag/v0.121.0)
 - [UnityMToonGltfExtension v0.1.0](https://github.com/malaybaku/UnityMToonGltfExtension/releases/tag/v0.1.0)
@@ -49,6 +61,8 @@ Select `+` button at the top left of the window, select `Add Package from git UR
 Create or import 3D asset prefab into the project, and attach material with MToon shader and setup parameters. Note that you can use several formats (`.fbx` or other data) in this step.
 
 Open export window from `MToonGltf -> Export MToon glTF...`. Select the prefab and export the data as `.glb`.
+
+You might see some warnings about material fallback in export window, but you can ignore them.
 
 If you want to check export is successful, you can test it by importing exported `.glb` file.
 

--- a/docs/langs/_japanese/tips/use_mtoon_defined_glb.md
+++ b/docs/langs/_japanese/tips/use_mtoon_defined_glb.md
@@ -23,7 +23,19 @@ title: アクセサリ機能でGLBファイルにMToonのマテリアルを適�
 #### 1. GLB出力用のUnityプロジェクトを準備する
 {: .doc-sec2 }
 
-Unity 6以降のバージョンのUnityプロジェクトを新規作成します。
+Unity 2022.3またはUnity 6以降のバージョンのUnityプロジェクトを新規作成します。
+
+プロジェクトの新規作成時にはBuilt-in Render Pipelineを選択します。
+
+<div class="note-area" markdown="1">
+
+**NOTE**
+
+VMagicMirrorはv4.2.1時点でBuilt-in Render Pipelineを使用しています。
+
+Unity Editor上での見え方とVMagicMirrorに読み込んだときの見た目の一致度を上げるために、特に理由がない限りはBuilt-in Render Pipelineのプロジェクトを使用して下さい。
+
+</div>
 
 その後、プロジェクトに下記を導入します。
 
@@ -50,6 +62,8 @@ Unity 6以降のバージョンのUnityプロジェクトを新規作成しま�
 上記のプロジェクト上で、3Dデータのprefabを準備して、MToonシェーダーを用いたマテリアルを適用し、パラメータを調整します。このprefabのベースとなるモデルは `.fbx` をインポートしたものなど、 `.glb` 以外の形式でも問題ありません。
 
 prefabをセットアップ後、メニューバーの `MToonGltf -> Export MToon glTF...` からエクスポート用ウィンドウを開きます。エクスポートしたいprefabを選択して `.glb` ファイルをエクスポートします。
+
+エクスポート用ウィンドウでマテリアルに関する警告が表示されることがありますが、警告は無視して構いません。
 
 なお、出力結果の `.glb` を同じプロジェクトでインポートすると、GLBファイルにMToonの情報が正しく格納されたかどうかチェックできます。
 このチェックを行うにはメニューバーの `MToonGltf -> Use MToon glTF Importer` をオンにしてから、プロジェクト上に `.glb` ファイルを Drag & Dropします。


### PR DESCRIPTION
## PR category

PR type: 

- [x] Documentation fix / update

## What the PR does

#1168 で追加したTipsの文書について下記を修正します。

- エクスポート用Projectの作成方法を修正
    - Unity 2022.3でプロジェクトを作ってもよい、とする
    - (VMMと見えが揃うように) Built-in Render Pipelineを推奨する旨を明記
- `.glb` のエクスポート中にマテリアルのフォールバックに関する警告が出るけど無視していい旨を追記
