### PR TITLE
カメラで手をトラッキングできている間は別のIKを適用するのを避ける

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -540,12 +540,13 @@ namespace Baku.VMagicMirror
             );
         }
 
-        private bool CanChangeState(HandTargetType current, HandTargetType target)
+        private bool CanChangeState(HandTargetType current, HandTargetType target, bool isLeft)
         {
             //書いてる通りだが、
             // - 同じ状態には遷移できない
             // - 拍手は実行優先度がすごく高いので、他の状態に遷移できない
             // - 手下げモード有効時は手下げ, ハンドトラッキング, 拍手のどれかにしか遷移できない
+            // - ハンドトラッキングで手をトラッキングできてる間は他に遷移しない (拍手はWord to Motionで動くものなので例外)
 
             if (current == target)
             {
@@ -563,12 +564,20 @@ namespace Baku.VMagicMirror
                 return false;
             }
             
-            return true; 
+            if (current is HandTargetType.ImageBaseHand &&
+                target is not HandTargetType.ClapMotion &&
+                _mediaPipeHand.IsTracked(isLeft)
+               )
+            {
+                return false;
+            }
+            
+            return true;
         }
         
         private void SetLeftHandState(IHandIkState state)
         {
-            if (!CanChangeState(_leftTargetType.Value, state.TargetType))
+            if (!CanChangeState(_leftTargetType.Value, state.TargetType, true))
             {
                 return;
             }
@@ -591,7 +600,7 @@ namespace Baku.VMagicMirror
 
         private void SetRightHandState(IHandIkState state)
         {
-            if (!CanChangeState(_rightTargetType.Value, state.TargetType))
+            if (!CanChangeState(_rightTargetType.Value, state.TargetType, false))
             {
                 return;
             }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

ハンドトラッキングについて

- 右手でマウス操作
- 左手をカメラの正面にあげてハンドトラッキング

をすると、デフォルト設定(=左右反転する設定)ではアバターの右手がマウス操作とハンドトラッキングの手を行ったりきたりしてしまう…という問題があったので、それを対策するPRです。

カメラでのハンドトラッキングについて以下のように振る舞います。

- トラッキング中、およびごく短時間のトラッキングロスト中は手IKの種類が変化しない
- トラッキングロスト扱いになって手を下げ始めると他の手IKに遷移できるようになる

## How to confirm

Unity Editor + WPF Buildで確認
