### PR TITLE
切り抜き機能のdocの画像リンクが間違ってたのを修正

### DIFF
--- a/docs/langs/_english/docs/window.md
+++ b/docs/langs/_english/docs/window.md
@@ -42,7 +42,7 @@ Crop feature is available in VMM v4.4.0 and later.
 With this feature, the window is cropped by circle or rounded square shape.
 
 <div class="row">
-{% include docimg.html file="/images/docs/window_crop.jpg" customclass="col s12 m4 l4" imgclass="fit-doc-img" %}
+{% include docimg.html file="/images/docs/window_crop.jpg" customclass="col s12 m6 l6" imgclass="fit-doc-img" %}
 </div>
 
 <div class="doc-ul" markdown="1">

--- a/docs/langs/_english/docs/window.md
+++ b/docs/langs/_english/docs/window.md
@@ -42,7 +42,7 @@ Crop feature is available in VMM v4.4.0 and later.
 With this feature, the window is cropped by circle or rounded square shape.
 
 <div class="row">
-{% include docimg.html file="/images/docs/window_crop" customclass="col s12 m4 l4" imgclass="fit-doc-img" %}
+{% include docimg.html file="/images/docs/window_crop.jpg" customclass="col s12 m4 l4" imgclass="fit-doc-img" %}
 </div>
 
 <div class="doc-ul" markdown="1">

--- a/docs/langs/_japanese/docs/window.md
+++ b/docs/langs/_japanese/docs/window.md
@@ -46,7 +46,7 @@ title: Window
 この機能はVMM v4.4.0かそれ以降で使用でき、アバター表示ウィンドウを円または角丸の枠で切り抜きます。
 
 <div class="row">
-{% include docimg.html file="/images/docs/window_crop" customclass="col s12 m4 l4" imgclass="fit-doc-img" %}
+{% include docimg.html file="/images/docs/window_crop.jpg" customclass="col s12 m4 l4" imgclass="fit-doc-img" %}
 </div>
 
 以下のオプションが利用できます。

--- a/docs/langs/_japanese/docs/window.md
+++ b/docs/langs/_japanese/docs/window.md
@@ -46,7 +46,7 @@ title: Window
 この機能はVMM v4.4.0かそれ以降で使用でき、アバター表示ウィンドウを円または角丸の枠で切り抜きます。
 
 <div class="row">
-{% include docimg.html file="/images/docs/window_crop.jpg" customclass="col s12 m4 l4" imgclass="fit-doc-img" %}
+{% include docimg.html file="/images/docs/window_crop.jpg" customclass="col s12 m6 l6" imgclass="fit-doc-img" %}
 </div>
 
 以下のオプションが利用できます。


### PR DESCRIPTION
## PR category

PR type: 

- [x] Documentation fix / update

## What the PR does

- 拡張子の付け忘れのfix
- ついでに`m4 l4`だと映りが小さすぎる印象があったので、doc最上部の画像サイズと合わせた