### PR TITLE
ハンドトラッキング中に手が大きくクロスするようなトラッキング結果が出たらトラッキングロス相当に扱う

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSettingsRepository.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSettingsRepository.cs
@@ -51,7 +51,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         public Atomic<float> HandTrackingOffsetY { get; } = new(0f);
 
         // trueの場合、「右手は画像の大まかに左側にしか映らない」のようなヒューリスティックを適用することでアバターの手のクロスを防ぐ
-        public Atomic<bool> GuardCrossingHand { get; } = new(false);
+        public Atomic<bool> GuardCrossingHand { get; } = new(true);
 
         // NOTE: 手と表情を同時にトラッキングする場合だけtrueになりうる想定だが、そもそも使わなくなるかも。今のところIPCでは受けていない
         public Atomic<bool> UseInterlace { get; } = new(false);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSettingsRepository.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeTrackerSettingsRepository.cs
@@ -50,6 +50,9 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         public Atomic<float> HandTrackingOffsetX { get; } = new(0f);
         public Atomic<float> HandTrackingOffsetY { get; } = new(0f);
 
+        // trueの場合、「右手は画像の大まかに左側にしか映らない」のようなヒューリスティックを適用することでアバターの手のクロスを防ぐ
+        public Atomic<bool> GuardCrossingHand { get; } = new(false);
+
         // NOTE: 手と表情を同時にトラッキングする場合だけtrueになりうる想定だが、そもそも使わなくなるかも。今のところIPCでは受けていない
         public Atomic<bool> UseInterlace { get; } = new(false);
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/HandTask.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/HandTask.cs
@@ -98,12 +98,18 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 switch (categoryName)
                 {
                     case LeftHandHandednessName:
-                        SetLeftHandPose(result.handLandmarks[i], result.handWorldLandmarks[i]);
-                        hasLeftHand = true;
+                        if (!IsCrossedWristPos(result.handLandmarks[i].landmarks[0], true))
+                        {
+                            SetLeftHandPose(result.handLandmarks[i], result.handWorldLandmarks[i], _fingerPoseCalculator);
+                            hasLeftHand = true;
+                        }
                         break;
                     case RightHandHandednessName:
-                        SetRightHandPose(result.handLandmarks[i], result.handWorldLandmarks[i]);
-                        hasRightHand = true;
+                        if (!IsCrossedWristPos(result.handLandmarks[i].landmarks[0], false))
+                        {
+                            SetRightHandPose(result.handLandmarks[i], result.handWorldLandmarks[i], _fingerPoseCalculator);
+                            hasRightHand = true;
+                        }
                         break;
                     default:
                         // 来ないはず
@@ -136,28 +142,6 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             LandmarksVisualizer.Visualizer2D.SetPositions(
                 landmarks.landmarks.Select(m => m.ToVector2()
                 ));
-        }
-        
-        private void SetLeftHandPose(NormalizedLandmarks landmarks, Landmarks worldLandmarks)
-        {
-            // 指のFK + 手首のローカル回転の取得までは下記で実施
-            _fingerPoseCalculator.SetLeftHandPose(worldLandmarks);
-
-            // 手首の位置は normalized の画像座標に基づいた値を言う。このとき、縦横のスケールだけ合わせる
-            var wristLandmark = landmarks.landmarks[0];
-            var normalizedPos = MediapipeMathUtil.GetTrackingNormalizePosition(wristLandmark, WebCamTextureAspect);
-            var posOffset = MediapipeMathUtil.GetNormalized2DofPositionDiff(normalizedPos, Calibrator.GetCalibrationData());
-            MediaPipeKinematicSetter.SetLeftHandPose(posOffset, _fingerPoseCalculator.LeftHandRotation);
-        }
-
-        private void SetRightHandPose(NormalizedLandmarks landmarks, Landmarks worldLandmarks)
-        {
-            _fingerPoseCalculator.SetRightHandPose(worldLandmarks);
-
-            var wristLandmark = landmarks.landmarks[0];
-            var normalizedPos = MediapipeMathUtil.GetTrackingNormalizePosition(wristLandmark, WebCamTextureAspect);
-            var posOffset = MediapipeMathUtil.GetNormalized2DofPositionDiff(normalizedPos, Calibrator.GetCalibrationData());
-            MediaPipeKinematicSetter.SetRightHandPose(posOffset, _fingerPoseCalculator.RightHandRotation);
         }
     }
 }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

以下の理由から、アバターの右手(左手)が大きく左(右)に行くことが予想されるようなハンドトラッキング結果は無視するようにします。

- 手が部分的に隠れると(例: スマホを持っている状態など)、手の左右判定が失敗して実際にアバターの右手(左手)が大きく左(右)に持っていかれて姿勢がヘンになることがある
- VMMの現行の手/肘のIKの実装を踏まえると、腕の見栄えをキレイに保ちながら右手(左手)を大きく左(右)に持っていく正常系のユースケースが無さそうであり、全部塞いでもいいはず

## How to confirm

※環境依存性が大きいので参考程度に

Unity Editor + WPF Buildで

- 左手にスマホを持って手のひらや手の甲を見せる姿勢にしながらハンドトラッキングしたとき、アバターの手が交差せず、かつ`IsCrossedWristPos`が`true`を返すコードパスを通ってるのが確認できること
