### PR TITLE
手をカメラ画像の端付近で検出した場合ハンドトラッキングを開始しないようにする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/SetterComponents/MediaPipeKinematicSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/SetterComponents/MediaPipeKinematicSetter.cs
@@ -123,6 +123,9 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             }
         }
 
+        public bool IsRawLeftHandTracked() => IsHandMirrored ? _hasRightHandPose.Value : _hasLeftHandPose.Value;
+        public bool IsRawRightHandTracked() => IsHandMirrored ? _hasLeftHandPose.Value : _hasRightHandPose.Value;
+
         // NOTE: maybeLostは、トラッキングロストが始まってるかもしれないときにtrueになる。トラッキングロスト動作の前で惰性を演出したい場合に用いる
         public bool TryGetLeftHandPose(out Pose result, out bool maybeLost)
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/HandTask.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/HandTask.cs
@@ -98,14 +98,18 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 switch (categoryName)
                 {
                     case LeftHandHandednessName:
-                        if (!IsCrossedWristPos(result.handLandmarks[i].landmarks[0], true))
+                        var leftWristLandmark = result.handLandmarks[i].landmarks[0];
+                        if (!IsWristPosOnEdgeAndUntracked(leftWristLandmark, true) &&
+                            !IsCrossedWristPos(leftWristLandmark, true))
                         {
                             SetLeftHandPose(result.handLandmarks[i], result.handWorldLandmarks[i], _fingerPoseCalculator);
                             hasLeftHand = true;
                         }
                         break;
                     case RightHandHandednessName:
-                        if (!IsCrossedWristPos(result.handLandmarks[i].landmarks[0], false))
+                        var rightWristLandmark = result.handLandmarks[i].landmarks[0];
+                        if (!IsWristPosOnEdgeAndUntracked(rightWristLandmark, false) &&
+                            !IsCrossedWristPos(rightWristLandmark, false))
                         {
                             SetRightHandPose(result.handLandmarks[i], result.handWorldLandmarks[i], _fingerPoseCalculator);
                             hasRightHand = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/HandTaskV2.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/HandTaskV2.cs
@@ -75,9 +75,11 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         {
             var hasLeftHand =
                 result.HasLeftHandResult() &&
+                !IsWristPosOnEdgeAndUntracked(result.leftHandLandmarks.landmarks[0], true) &&
                 !IsCrossedWristPos(result.leftHandLandmarks.landmarks[0], true);
             var hasRightHand = 
                 result.HasRightHandResult() &&
+                !IsWristPosOnEdgeAndUntracked(result.rightHandLandmarks.landmarks[0], false) &&
                 !IsCrossedWristPos(result.rightHandLandmarks.landmarks[0], false);
 
             // NOTE: Poseの信頼性がないケースは甘めに見て通す: バストアップしか映ってないときにconfidenceが下がる可能性があるので

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/MediaPipeTrackerTaskBase.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Tasks/MediaPipeTrackerTaskBase.cs
@@ -121,7 +121,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         }
 
         // 手の位置が交差しており、それを問題視する(トラッキングロスト相当に扱いたい)場合はtrueを返す
-        public bool IsCrossedWristPos(NormalizedLandmark wristLandmark, bool isLeft)
+        protected bool IsCrossedWristPos(NormalizedLandmark wristLandmark, bool isLeft)
         {
             if (!SettingsRepository.GuardCrossingHand.Value)
             {
@@ -139,6 +139,16 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 (false, < -0.15f) => true,
                 _ => false,
             };
+        }
+
+        // 手のトラッキングが開始しておらず、かつ手首が画像の十分内側に映ってない(=トラッキング開始に適さないと考えられる)場合にはtrueを返す
+        protected bool IsWristPosOnEdgeAndUntracked(NormalizedLandmark wristLandmark, bool isLeft)
+        {
+            var isTracked = isLeft
+                ? MediaPipeKinematicSetter.IsRawLeftHandTracked()
+                : MediaPipeKinematicSetter.IsRawRightHandTracked();
+
+            return !isTracked && MediapipeMathUtil.IsOutOfEdge(wristLandmark, 0.05f);
         }
         
         protected void SetLeftHandPose(NormalizedLandmarks landmarks, Landmarks worldLandmarks, MediaPipeFingerPoseCalculator fingerPoseCalculator)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Utils/MediapipeMathUtil.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/Utils/MediapipeMathUtil.cs
@@ -84,6 +84,11 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             );
         }
 
+        // 点が画像の端に近すぎるかどうか判定する。marginには 0.5 未満の値を指定する
+        public static bool IsOutOfEdge(NormalizedLandmark landmark, float margin) =>
+            landmark.x < margin || landmark.x > 1f - margin ||
+            landmark.y < margin || landmark.y > 1f - margin;
+
         public static (Vector2 leftBottom, Vector2 rightTop) GetNormalizedPointsFromBound(
             Rect bound, float webCamTextureWidth, float webCamTextureHeight)
         {


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixes: #1184 

issue側に記述していた下記の方針で対策した。

> トラッキング開始時は顔や手の検出エリアが画面端から一定以上内側であることを条件とする = トラッキングロスするかしないかの際ではトラッキングを始めないようにする

なお現行挙動を観察したところ、カメラ画像の下端付近では画像の下端より下に手首がある状況(y>1)で手が検出されていたため、以下のようにしている:

- 「画面端から一定以上内側」として、手首の特徴点がほぼカメラ画像内に入ってればOK、とした
- この判定はカメラの左右や上で手が見切れるケースに強くないが、手がカメラで見切れるのは下端がメジャーケースのはずなので、これで十分…ということにする

## How to confirm

Unity Editor + WPF Buildで、WPF側の検出結果プレビューを使いながら確認

