### PR TITLE
デスクトップ画面の色による調光時にディスプレイ上に枠線が出ないようにする + 正式機能にする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/DesktopLightChecker.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/DesktopLightChecker.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 1403347864180823165}
   - component: {fileID: 1403347864180823164}
   - component: {fileID: 1403347864180823163}
-  - component: {fileID: 1403347864180823162}
   - component: {fileID: 1403347864180823166}
   - component: {fileID: 5573134021760853799}
   - component: {fileID: 75869827758438166}
@@ -44,7 +43,7 @@ MeshFilter:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1403347864180823161}
-  m_Mesh: {fileID: 4300002, guid: 785ad35802dd7e64cb3ac7adf3fcdfcf, type: 3}
+  m_Mesh: {fileID: 4300000, guid: f30f6cfd6aa37554ca886424cada7cbb, type: 3}
 --- !u!23 &1403347864180823163
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -68,7 +67,7 @@ MeshRenderer:
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 1ebb28175c99f574d895870a01e00d21, type: 2}
+  - {fileID: 2100000, guid: c181d333a7bee7a44b94c0f4e02c4bd4, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -90,36 +89,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!114 &1403347864180823162
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1403347864180823161}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6c150c011a6544b4b8054bba7ee5e5ca, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  searchTiming_: 2
-  type_: 1
-  altTabWindow_: 1
-  createChildWindows_: 0
-  childWindowPrefab: {fileID: 0}
-  childWindowZDistance: 0.02
-  partialWindowTitle_: Unity
-  desktopIndex_: 0
-  captureMode: 3
-  capturePriority: 0
-  captureRequestTiming: 0
-  captureFrameRate: 10
-  drawCursor: 0
-  updateTitle: 0
-  searchAnotherWindowWhenInvalid: 0
-  scaleControlType: 3
-  scalePer1000Pixel: 1
-  updateScaleForcely: 0
 --- !u!114 &1403347864180823166
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -134,6 +103,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ddTexture: {fileID: 5573134021760853799}
   desktopIndexCheckInterval: 10
+  desktopIndexCheckIntervalOnWindowMove: 1
   textureReadInterval: 0.1
   factorLerpFactor: 12
   colorMeanShader: {fileID: 7200000, guid: 122b7020d0d2a244ab65f4b45c3658eb, type: 3}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/DesktopLightChecker.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/DesktopLightChecker.prefab
@@ -13,6 +13,8 @@ GameObject:
   - component: {fileID: 1403347864180823163}
   - component: {fileID: 1403347864180823162}
   - component: {fileID: 1403347864180823166}
+  - component: {fileID: 5573134021760853799}
+  - component: {fileID: 75869827758438166}
   m_Layer: 0
   m_Name: DesktopLightChecker
   m_TagString: Untagged
@@ -27,12 +29,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1403347864180823161}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1403347864180823164
 MeshFilter:
@@ -53,11 +56,15 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 0
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -112,6 +119,7 @@ MonoBehaviour:
   searchAnotherWindowWhenInvalid: 0
   scaleControlType: 3
   scalePer1000Pixel: 1
+  updateScaleForcely: 0
 --- !u!114 &1403347864180823166
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -124,8 +132,39 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 928c26ee9c609c74594f977442966270, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  windowTexture: {fileID: 1403347864180823162}
+  ddTexture: {fileID: 5573134021760853799}
   desktopIndexCheckInterval: 10
   textureReadInterval: 0.1
   factorLerpFactor: 12
   colorMeanShader: {fileID: 7200000, guid: 122b7020d0d2a244ab65f4b45c3658eb, type: 3}
+--- !u!114 &5573134021760853799
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1403347864180823161}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb54a34570e4747429b1c5b66c69d356, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  invertX_: 0
+  invertY_: 0
+  useClip_: 0
+  clipPos: {x: 0, y: 0}
+  clipScale: {x: 0.2, y: 0.2}
+--- !u!114 &75869827758438166
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1403347864180823161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4dccb434f55ebee4f91bfb9935092bbf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debugMode: 0
+  retryReinitializationDuration: 1

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/DesktopLightChecker.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/DesktopLightChecker.prefab
@@ -161,7 +161,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1403347864180823161}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4dccb434f55ebee4f91bfb9935092bbf, type: 3}
   m_Name: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
@@ -1,5 +1,5 @@
+using uDesktopDuplication;
 using UnityEngine;
-using uWindowCapture;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -10,7 +10,7 @@ namespace Baku.VMagicMirror
         private const int Width = 32;
         private const int Height = 18;
 
-        [SerializeField] private UwcWindowTexture windowTexture;
+        [SerializeField] private uDesktopDuplication.Texture ddTexture;
         [SerializeField] private float desktopIndexCheckInterval = 10f;
         [SerializeField] private float textureReadInterval = 0.1f;
         [SerializeField] private float factorLerpFactor = 12f;
@@ -40,7 +40,7 @@ namespace Baku.VMagicMirror
                 }
 
                 _isEnabled = value;
-                windowTexture.enabled = value;
+                ddTexture.enabled = value;
 
                 if (value)
                 {
@@ -65,11 +65,6 @@ namespace Baku.VMagicMirror
 
         private void Start()
         {
-            //Program Filesとかに載せたときにログファイル出力が邪魔なので制限する
-            if (!Application.isEditor)
-            {
-                UwcManager.debugMode = DebugMode.None;
-            }
             _rt = new RenderTexture(Width, Height, 32, RenderTextureFormat.BGRA32, 0);
             _colorMeanKernelIndex = colorMeanShader.FindKernel("CalcMeanColor");
             _colorMeanResultBuffer = new ComputeBuffer(3, sizeof(float));
@@ -94,7 +89,10 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            if (windowTexture.window == null || !windowTexture.window.texture)
+            if (ddTexture.monitor == null ||
+                !ddTexture.monitor.exists ||
+                ddTexture.monitor.state != DuplicatorState.Running ||
+                ddTexture.monitor.texture == null)
             {
                 return;
             }
@@ -106,8 +104,7 @@ namespace Baku.VMagicMirror
             }
 
             _colorReadCount -= textureReadInterval;
-
-            var source = windowTexture.window.texture;
+            var source = ddTexture.monitor.texture;
             //GetColorWithRenderTexture(source);
             GetColorByComputeShader(source);
         }
@@ -127,7 +124,7 @@ namespace Baku.VMagicMirror
 
             //デスクトップの情報が出揃ってないうちは待つ(数フレーム程度)
             //ここで待たされる間は結果的にデスクトップ0が参照される
-            if (!CheckUwcDesktopsArePrepared())
+            if (!CheckUDesktopDuplicationPrepared())
             {
                 return;
             }
@@ -138,34 +135,35 @@ namespace Baku.VMagicMirror
 
         private void CheckDesktopIndexValidity()
         {
-            int count = UwcManager.desktopCount;
+            int count = Manager.monitorCount;
             if (count == 0 || count == 1)
             {
                 //そこそこ起きるケース: シングルモニターの場合は深く考えない
-                windowTexture.desktopIndex = 0;
+                ddTexture.monitorId = 0;
                 return;
             }
 
             var targetPos = GetTargetMonitorPos();
 
-            for (int i = 0; i < count; i++)
+            for (var i = 0; i < count; i++)
             {
-                var desktop = UwcManager.FindDesktop(i);
-                if (desktop.rawX == targetPos.x && desktop.rawY == targetPos.y)
+                // NOTE: 万が一タイミングバグでidの範囲外になった場合はプライマリモニタが戻るので、そこまでケアしない
+                var desktop = Manager.GetMonitor(i);
+                if (desktop.left == targetPos.x && desktop.top == targetPos.y)
                 {
-                    windowTexture.desktopIndex = i;
+                    ddTexture.monitorId = i;
                     return;
                 }
             }
 
             //何か検出に失敗した場合
             LogOutput.Instance.Write("failed to detect correct monitor about light...");
-            windowTexture.desktopIndex = 0;
+            ddTexture.monitorId = 0;
         }
 
-        private bool CheckUwcDesktopsArePrepared()
+        private static bool CheckUDesktopDuplicationPrepared()
         {
-            return UwcManager.desktopCount == NativeMethods.LoadAllMonitorRects().Count;
+            return Manager.monitorCount == NativeMethods.LoadAllMonitorRects().Count;
         }
 
         private void GetColorByComputeShader(Texture2D source)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
@@ -41,6 +41,7 @@ namespace Baku.VMagicMirror
 
                 _isEnabled = value;
                 ddTexture.enabled = value;
+                Manager.instance.enabled = value;
 
                 if (value)
                 {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
@@ -6,6 +6,9 @@ namespace Baku.VMagicMirror
 {
     public class DesktopLightEstimator : MonoBehaviour
     {
+        private static readonly int InputTexture = Shader.PropertyToID("inputTexture");
+        private static readonly int ResultColor = Shader.PropertyToID("resultColor");
+
         //やや画面アス比をリスペクトしつつ、ピクセル数を大幅に絞っていく
         private const int Width = 32;
         private const int Height = 18;
@@ -74,8 +77,8 @@ namespace Baku.VMagicMirror
             _rt = new RenderTexture(Width, Height, 32, RenderTextureFormat.BGRA32, 0);
             _colorMeanKernelIndex = colorMeanShader.FindKernel("CalcMeanColor");
             _colorMeanResultBuffer = new ComputeBuffer(3, sizeof(float));
-            colorMeanShader.SetTexture(_colorMeanKernelIndex, "inputTexture", _rt);
-            colorMeanShader.SetBuffer(_colorMeanKernelIndex, "resultColor", _colorMeanResultBuffer);
+            colorMeanShader.SetTexture(_colorMeanKernelIndex, InputTexture, _rt);
+            colorMeanShader.SetBuffer(_colorMeanKernelIndex, ResultColor, _colorMeanResultBuffer);
         }
 
         private void Update()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
@@ -11,7 +11,10 @@ namespace Baku.VMagicMirror
         private const int Height = 18;
 
         [SerializeField] private uDesktopDuplication.Texture ddTexture;
+        // Unityのウィンドウが動いてなくともモニターのindexを再チェックする周期(sec)
         [SerializeField] private float desktopIndexCheckInterval = 10f;
+        // Unityのウィンドウのサイズまたは位置が動いた場合にモニターのindexを再チェックする最短周期(sec)
+        [SerializeField] private float desktopIndexCheckIntervalOnWindowMove = 1f;
         [SerializeField] private float textureReadInterval = 0.1f;
         [SerializeField] private float factorLerpFactor = 12f;
         [SerializeField] private ComputeShader colorMeanShader;
@@ -21,7 +24,7 @@ namespace Baku.VMagicMirror
 
         private RenderTexture _rt;
         private float _colorReadCount;
-        private float _desktopIndexCheckCount;
+        private float _desktopIndexCheckTime;
 
         private int _colorMeanKernelIndex;
         private ComputeBuffer _colorMeanResultBuffer;
@@ -29,6 +32,8 @@ namespace Baku.VMagicMirror
 
         private bool _isEnabled = false;
 
+        private NativeMethods.RECT? _prevWindowRect;
+        
         public bool IsEnabled
         {
             get => _isEnabled;
@@ -45,7 +50,7 @@ namespace Baku.VMagicMirror
 
                 if (value)
                 {
-                    _desktopIndexCheckCount = desktopIndexCheckInterval;
+                    _desktopIndexCheckTime = desktopIndexCheckInterval;
                 }
                 else
                 {
@@ -76,7 +81,7 @@ namespace Baku.VMagicMirror
         private void Update()
         {
             UpdateRawFactor();
-            UpdateDesktopIndexValidity();
+            UpdateMonitorId();
             RgbFactor = IsEnabled
                 ? Vector3.Lerp(RgbFactor, _rawFactor, factorLerpFactor * Time.deltaTime)
                 : Vector3.one;
@@ -106,68 +111,54 @@ namespace Baku.VMagicMirror
 
             _colorReadCount -= textureReadInterval;
             var source = ddTexture.monitor.texture;
-            //GetColorWithRenderTexture(source);
-            GetColorByComputeShader(source);
+            _rawFactor = GetColorByComputeShader(source);
         }
 
-        private void UpdateDesktopIndexValidity()
+        private void UpdateMonitorId()
         {
             if (!IsEnabled)
             {
                 return;
             }
 
-            _desktopIndexCheckCount += Time.deltaTime;
-            if (_desktopIndexCheckCount < desktopIndexCheckInterval)
+            _desktopIndexCheckTime += Time.deltaTime;
+            // 条件によらず最短周期は担保
+            if (_desktopIndexCheckTime < desktopIndexCheckIntervalOnWindowMove)
             {
                 return;
             }
 
-            //デスクトップの情報が出揃ってないうちは待つ(数フレーム程度)
-            //ここで待たされる間は結果的にデスクトップ0が参照される
+            // デスクトップの情報が出揃ってないうちは待つ(数フレーム程度)
+            // ここで待たされる間は結果的にデスクトップ0が参照される
             if (!CheckUDesktopDuplicationPrepared())
             {
-                return;
-            }
-
-            _desktopIndexCheckCount = 0f;
-            CheckDesktopIndexValidity();
-        }
-
-        private void CheckDesktopIndexValidity()
-        {
-            int count = Manager.monitorCount;
-            if (count == 0 || count == 1)
-            {
-                //そこそこ起きるケース: シングルモニターの場合は深く考えない
+                _desktopIndexCheckTime = 0f;
                 ddTexture.monitorId = 0;
                 return;
             }
 
-            var targetPos = GetTargetMonitorPos();
-
-            for (var i = 0; i < count; i++)
+            // 書いてる通りではあるが、
+            // - シングルモニター環境では詳細チェックせず、単にプライマリモニターを使う
+            // - Unityのウィンドウ位置が取れない場合も諦めてプライマリモニターを使う
+            if (Manager.monitorCount <= 1 || !TryGetWindowRect(out var selfRect))
             {
-                // NOTE: 万が一タイミングバグでidの範囲外になった場合はプライマリモニタが戻るので、そこまでケアしない
-                var desktop = Manager.GetMonitor(i);
-                if (desktop.left == targetPos.x && desktop.top == targetPos.y)
-                {
-                    ddTexture.monitorId = i;
-                    return;
-                }
+                _desktopIndexCheckTime = 0f;
+                ddTexture.monitorId = 0;
+                return;
             }
 
-            //何か検出に失敗した場合
-            LogOutput.Instance.Write("failed to detect correct monitor about light...");
-            ddTexture.monitorId = 0;
+            // - ウィンドウ位置が変わった (or 初取得): ただちに再チェック
+            // - 十分な時間が経過した場合も再チェック
+            if (!_prevWindowRect.HasValue || !_prevWindowRect.Value.Equals(selfRect) ||
+                _desktopIndexCheckTime > desktopIndexCheckInterval)
+            {
+                _desktopIndexCheckTime = 0f;
+                _prevWindowRect = selfRect;
+                ddTexture.monitorId = CalculateMonitorId(selfRect);
+            }
         }
 
-        private static bool CheckUDesktopDuplicationPrepared()
-        {
-            return Manager.monitorCount == NativeMethods.LoadAllMonitorRects().Count;
-        }
-
-        private void GetColorByComputeShader(Texture2D source)
+        private Vector3 GetColorByComputeShader(Texture2D source)
         {
             //リサイズ
             Graphics.Blit(source, _rt);
@@ -178,18 +169,43 @@ namespace Baku.VMagicMirror
             _colorMeanResultBuffer.GetData(_colorMeanResult);
 
             var factor = new Vector3(_colorMeanResult[0], _colorMeanResult[1], _colorMeanResult[2]);
-            _rawFactor = GetLightFactor(factor);
+            return GetLightFactor(factor);
         }
 
-        //uWindowCaptureで取得したいデスクトップの座標を、WinAPIから取得できるX,Y座標として取得する
-        private Vector2Int GetTargetMonitorPos()
+        private static int CalculateMonitorId(NativeMethods.RECT selfRect)
         {
-            if (!NativeMethods.GetWindowRect(NativeMethods.GetUnityWindowHandle(), out var selfRect))
+            var targetPos = GetTargetMonitorLeftTop(selfRect);
+
+            var count = Manager.monitorCount;
+            for (var i = 0; i < count; i++)
             {
-                LogOutput.Instance.Write("Failed to get self window rect, could update desktop index");
-                return Vector2Int.zero;
+                // NOTE: 万が一タイミングバグでidの範囲外になった場合はプライマリモニタが戻るので、そこまでケアしない
+                var desktop = Manager.GetMonitor(i);
+                if (desktop.left == targetPos.x && desktop.top == targetPos.y)
+                {
+                    return i;
+                }
             }
 
+            //何か検出に失敗した場合
+            LogOutput.Instance.Write("failed to detect correct monitor about light...");
+            return 0;
+        }
+
+        private static bool TryGetWindowRect(out NativeMethods.RECT rect)
+        {
+            if (NativeMethods.GetWindowRect(NativeMethods.GetUnityWindowHandle(), out rect))
+            {
+                return true;
+            }
+
+            rect = default;
+            return false;
+        }
+        
+        //uDesktopDuplicationで取得したいデスクトップの座標を、WinAPIから取得できるX,Y座標として取得する。
+        private static Vector2Int GetTargetMonitorLeftTop(NativeMethods.RECT selfRect)
+        {
             var monitorRects = NativeMethods.LoadAllMonitorRects();
 
             var selfCenter = new Vector2Int(
@@ -230,6 +246,9 @@ namespace Baku.VMagicMirror
             //全ての検出に失敗: 0,0を返すことで「プライマリモニタでお願いします」というニュアンスにする
             return Vector2Int.zero;
         }
+
+        private static bool CheckUDesktopDuplicationPrepared() 
+            => Manager.monitorCount == NativeMethods.LoadAllMonitorRects().Count;
 
         private static Vector3 GetLightFactor(Vector3 values)
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DesktopLight/DesktopLightEstimator.cs
@@ -100,8 +100,7 @@ namespace Baku.VMagicMirror
 
             if (ddTexture.monitor == null ||
                 !ddTexture.monitor.exists ||
-                ddTexture.monitor.state != DuplicatorState.Running ||
-                ddTexture.monitor.texture == null)
+                ddTexture.monitor.state != DuplicatorState.Running)
             {
                 return;
             }
@@ -131,17 +130,7 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            // デスクトップの情報が出揃ってないうちは待つ(数フレーム程度)
-            // ここで待たされる間は結果的にデスクトップ0が参照される
-            if (!CheckUDesktopDuplicationPrepared())
-            {
-                _desktopIndexCheckTime = 0f;
-                ddTexture.monitorId = 0;
-                return;
-            }
-
-            // 書いてる通りではあるが、
-            // - シングルモニター環境では詳細チェックせず、単にプライマリモニターを使う
+            // - シングルモニター環境 (※モニター数が適切に取れてないケースも含む)では詳細チェックをせず、単にプライマリモニターを使う
             // - Unityのウィンドウ位置が取れない場合も諦めてプライマリモニターを使う
             if (Manager.monitorCount <= 1 || !TryGetWindowRect(out var selfRect))
             {
@@ -165,12 +154,10 @@ namespace Baku.VMagicMirror
         {
             //リサイズ
             Graphics.Blit(source, _rt);
-
             //リサイズしたテクスチャに対してGPUベースで色計算を行い、
             colorMeanShader.Dispatch(_colorMeanKernelIndex, 1, 1, 1);
             //CPUに引っ張り出す: このGetDataがちょっと重いことに留意すべし。
             _colorMeanResultBuffer.GetData(_colorMeanResult);
-
             var factor = new Vector3(_colorMeanResult[0], _colorMeanResult[1], _colorMeanResult[2]);
             return GetLightFactor(factor);
         }
@@ -249,9 +236,6 @@ namespace Baku.VMagicMirror
             //全ての検出に失敗: 0,0を返すことで「プライマリモニタでお願いします」というニュアンスにする
             return Vector2Int.zero;
         }
-
-        private static bool CheckUDesktopDuplicationPrepared() 
-            => Manager.monitorCount == NativeMethods.LoadAllMonitorRects().Count;
 
         private static Vector3 GetLightFactor(Vector3 values)
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/NativeMethods.cs
@@ -27,12 +27,18 @@ namespace Baku.VMagicMirror
         }
  
         [StructLayout(LayoutKind.Sequential)]
-        public struct RECT
+        public struct RECT : IEquatable<RECT>
         {
             public int left;
             public int top;
             public int right;
             public int bottom;
+
+            public bool Equals(RECT other) 
+                => left == other.left && top == other.top && right == other.right && bottom == other.bottom;
+
+            public override bool Equals(object obj) => obj is RECT other && Equals(other);
+            public override int GetHashCode() => HashCode.Combine(left, top, right, bottom);
         }
 
         [DllImport("user32.dll")]

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/ColorMeanExtractor.compute
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/ColorMeanExtractor.compute
@@ -3,23 +3,28 @@
 Texture2D<float4> inputTexture;
 RWStructuredBuffer<float3> resultColor;
 
-[numthreads(1, 1, 1)]
-void CalcMeanColor(uint3 groupThreadID : SV_GroupThreadID)
+// NOTE: kernelともども入力が32x18なことを前提としている
+groupshared float3 sdata[480];
+
+[numthreads(30, 16, 1)]
+void CalcMeanColor(uint3 id : SV_GroupThreadID)
 {
-    uint width, height;
-    inputTexture.GetDimensions(width, height);
+    // 画像端を1ピクセルだけ避けたピクセルを取ってきて配列に書き込む
+    // NOTE: 画面端を避けるのは、ウィンドウ枠やアプリケーションの周辺情報が入ったピクセルを無視するため
+    uint2 texCoord = id.xy + uint2(1, 1);
+    uint flatIndex = id.y * 30 + id.x;
 
-    //画像の端を避ける。画面端はウィンドウ枠とかアプリケーションの周辺情報が表示され、色を参照するのに適さないため
-    float3 sumColor;
-    uint pixelCount = 0;
-    for (uint x = 1; x < width - 1; x++)
+    sdata[flatIndex] = inputTexture[texCoord].xyz;
+    GroupMemoryBarrierWithGroupSync();
+
+    // シングルスレッドで合算
+    if (flatIndex == 0)
     {
-        for (uint y = 1; y < height - 1; y++)
+        float3 sum = float3(0, 0, 0);
+        for (int i = 0; i < 480; i++)
         {
-            sumColor += inputTexture[int2(x, y)].xyz;
-            pixelCount++;
+            sum += sdata[i];
         }
+        resultColor[0] = sum / 480.0;
     }
-
-    resultColor[0].xyz = sumColor / pixelCount;
 }

--- a/VMagicMirror/Packages/manifest.json
+++ b/VMagicMirror/Packages/manifest.json
@@ -13,6 +13,7 @@
     "com.cysharp.r3": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity#1.3.0",
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask#2.3.1",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.4.0",
+    "com.hecomi.udesktopduplication": "https://github.com/hecomi/uDesktopDuplication.git#upm@1.8.0",
     "com.hecomi.uosc": "https://github.com/hecomi/uOSC.git#upm@2.2.0",
     "com.hecomi.uwindowcapture": "https://github.com/hecomi/uWindowCapture.git#upm@1.1.2",
     "com.malaybaku.managed-midijack": "https://github.com/malaybaku/MidiJack.git?path=/Assets/MidiJack",

--- a/VMagicMirror/Packages/manifest.json
+++ b/VMagicMirror/Packages/manifest.json
@@ -15,7 +15,6 @@
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.4.0",
     "com.hecomi.udesktopduplication": "https://github.com/hecomi/uDesktopDuplication.git#upm@1.8.0",
     "com.hecomi.uosc": "https://github.com/hecomi/uOSC.git#upm@2.2.0",
-    "com.hecomi.uwindowcapture": "https://github.com/hecomi/uWindowCapture.git#upm@1.1.2",
     "com.malaybaku.managed-midijack": "https://github.com/malaybaku/MidiJack.git?path=/Assets/MidiJack",
     "com.svermeulen.extenject": "https://github.com/Mathijs-Bakker/Extenject.git?path=UnityProject/Assets/Plugins/Zenject/Source#9.3.1",
     "com.unity.2d.sprite": "1.0.0",

--- a/VMagicMirror/Packages/packages-lock.json
+++ b/VMagicMirror/Packages/packages-lock.json
@@ -42,6 +42,13 @@
         "com.unity.test-framework": "1.0.0"
       }
     },
+    "com.hecomi.udesktopduplication": {
+      "version": "https://github.com/hecomi/uDesktopDuplication.git#upm@1.8.0",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "affe799d167c464e94d11c1cb8dc4f2025b7bf1e"
+    },
     "com.hecomi.uosc": {
       "version": "https://github.com/hecomi/uOSC.git#upm@2.2.0",
       "depth": 0,

--- a/VMagicMirror/Packages/packages-lock.json
+++ b/VMagicMirror/Packages/packages-lock.json
@@ -56,13 +56,6 @@
       "dependencies": {},
       "hash": "3788ab28702c44330bfea7323b2e05bc4d23c213"
     },
-    "com.hecomi.uwindowcapture": {
-      "version": "https://github.com/hecomi/uWindowCapture.git#upm@1.1.2",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "0412fe09e11d3720197707a935f8114cc2454639"
-    },
     "com.malaybaku.managed-midijack": {
       "version": "https://github.com/malaybaku/MidiJack.git?path=/Assets/MidiJack",
       "depth": 0,

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -629,7 +629,7 @@ Please test by typing "joy".</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice_Keyboard">Keyboard (Num0 - Num9)</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice_Keyboard_Short">Keyboard</sys:String>
 
-    <sys:String x:Key="WordToMotion_AssignDevice_Select_Header">Device Assign</sys:String>
+    <sys:String x:Key="WordToMotion_AssignDevice_Select_Header">Input Device: </sys:String>
    
     
     <sys:String x:Key="WordToMotion_KeyAssign">Keys</sys:String>    

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -629,7 +629,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice_Keyboard">キーボード(数字の0-9)</sys:String>
     <sys:String x:Key="WordToMotion_AssignDevice_Keyboard_Short">キーボード</sys:String>
 
-    <sys:String x:Key="WordToMotion_AssignDevice_Select_Header">デバイスの割り当て</sys:String>
+    <sys:String x:Key="WordToMotion_AssignDevice_Select_Header">デバイス: </sys:String>
     
     <sys:String x:Key="WordToMotion_KeyAssign">キー割り当て</sys:String>
     <sys:String x:Key="WordToMotion_LoadDefaultSet">デフォルト設定にリセット</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
@@ -40,6 +40,8 @@ RawInputSharp: https://github.com/mfakane/rawinput-sharp
 SharpDX: https://github.com/sharpdx/SharpDX
 
 uWindowCapture: https://github.com/hecomi/uWindowCapture
+        
+uDesktopDuplication: https://github.com/hecomi/uDesktopDuplication
 
 uOSC: https://github.com/hecomi/uOSC
         
@@ -397,6 +399,19 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.        
 
+        
+        uDesktopDuplication
+        
+The MIT License (MIT)
+
+Copyright (c) 2016 hecomi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        
         
         uOSC
         

--- a/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/LicenseTextResource.xaml
@@ -39,8 +39,6 @@ RawInputSharp: https://github.com/mfakane/rawinput-sharp
         
 SharpDX: https://github.com/sharpdx/SharpDX
 
-uWindowCapture: https://github.com/hecomi/uWindowCapture
-        
 uDesktopDuplication: https://github.com/hecomi/uDesktopDuplication
 
 uOSC: https://github.com/hecomi/uOSC
@@ -386,19 +384,6 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         
-        
-        uWindowCapture
-        
-The MIT License (MIT)
-
-Copyright (c) 2018 hecomi
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.        
-
         
         uDesktopDuplication
         

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
@@ -517,6 +517,12 @@
                                   Content="{DynamicResource Wind_Enable_Streaming}"
                                   IsChecked="{Binding EnableWind.Value}"
                                   />
+
+                        <CheckBox Style="{StaticResource SmallMarginCheckBox}"
+                                  Content="{DynamicResource Light_BgAdjust}"
+                                  IsChecked="{Binding UseDesktopLightAdjust.Value}"
+                                  />
+
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/StreamingPanel.xaml
@@ -753,24 +753,32 @@
                                         />
                         </StackPanel>
 
-                        <TextBlock Margin="5,5"
-                                    Text="{DynamicResource WordToMotion_AssignDevice_Select_Header}"
-                                    />
-                        <ComboBox Grid.Column="1"
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0"
+                                   Margin="5"
+                                   Text="{DynamicResource WordToMotion_AssignDevice_Select_Header}"
+                                   />
+                            <ComboBox Grid.Column="1"
                                     HorizontalAlignment="Stretch"                                 
                                     Margin="5,0,5,5"
                                     ItemsSource="{Binding Devices}"
                                     SelectedItem="{Binding SelectedDevice, Mode=TwoWay}"
                                     md:HintAssist.Hint="Device"
                                     >
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding DisplayName}"/>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                        <!-- TODO: ここに簡易呼び出しで拍手、nod、shake、waveを足してみたいんですよ -->
-                        <StackPanel Orientation="Horizontal" Margin="5,5,5,12">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+
+                        </Grid>
+
+                        <StackPanel Orientation="Horizontal" Margin="5">
                             <StackPanel.DataContext>
                                 <vm:InstantWtmViewModel />
                             </StackPanel.DataContext>

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/StreamingTabViewModels.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/StreamingTabViewModels.cs
@@ -327,7 +327,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel.StreamingTabViewModels
         public RProperty<bool> EnableShadow => _effects.EnableShadow;
         public RProperty<bool> EnableWind => _effects.EnableWind;
 
-        //public RProperty<bool> UseDesktopLightAdjust => _effects.UseDesktopLightAdjust;
+        public RProperty<bool> UseDesktopLightAdjust => _effects.UseDesktopLightAdjust;
         public RProperty<bool> UseOutlineEffect => _effects.EnableOutlineEffect;
 
         /// <summary>

--- a/docs/credit_license.md
+++ b/docs/credit_license.md
@@ -66,6 +66,8 @@ In VMagicMirror, the materials are replaced for the visual consistency.
 
 [uWindowCapture](https://github.com/hecomi/uWindowCapture)
 
+[uDesktopDuplication](https://github.com/hecomi/uDesktopDuplication)
+
 [uOSC](https://github.com/hecomi/uOSC)
 
 [NuGetForUnity](https://github.com/GlitchEnzo/NuGetForUnity)
@@ -468,6 +470,19 @@ THE SOFTWARE.
 The MIT License (MIT)
 
 Copyright (c) 2018 hecomi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+#### uDesktopDuplication
+
+The MIT License (MIT)
+
+Copyright (c) 2016 hecomi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixes #1205 

- モニター全体のキャプチャAPIが適切じゃなかった (DXGI Desktop Duplication APIを使うほうが適していた)ので、キャプチャに使う処理をuWindowCaptureから[uDesktopDuplication](https://github.com/hecomi/uDesktopDuplication)に乗り換えた
- この改修によってライト調整機能のユーザビリティが十分良くなるので、「配信」タブに機能を復帰させる
- (ついで) アバターウィンドウがモニターをまたいだときの検出頻度が10secあたり1回だったが、Unityウィンドウ自身が明らかに移動している場合には1secあたり1回で再チェックするよいようにした
    - これにより、マルチモニター環境でウィンドウを移動させたときの反応が改善した

## How to confirm

- [x] ビルド + マルチモニター環境で、モニターの背景色に応じたライティングが適用できる
- [x] GUI側で「配信」タブに調光機能が表示されていて利用でき、かつExperimentalという表記が外れている
- [x] docにOSSのuDesktopDuplicationの記載を追記してある
- [x] GUIのOSS一覧にuDesktopDuplicationの記載を追記してある
- [x] 異なる背景色を持つマルチモニター環境において、アバターウィンドウをモニターをまたいで移動させたとき、モニターの色に馴染むまでが十分早い

## Note

- uWindowCaptureを選定していた経緯を探したが、導入時点ではそもそもuDesktopDuplication使う発想が無かったっぽい: https://github.com/malaybaku/VMagicMirror/pull/638
- パフォーマンス上の難点としてモニターと同じ解像度のテクスチャを取ってしまうのが贅沢すぎると思っているが、以下の理由から許容する
    - API的に調整余地がなさそう
    - 負荷の主な帰着先がGPU
    - デフォルトでオフの機能であり、UI上でも軽量な処理であるという主張まではしてない
- 負荷/FPSの対策として出来そうだがやってないこととしては下記らへんがある:
    - uDD.Textureの`shouldBeUpdated`フラグが立つ頻度を10fps程度に抑えることでテクスチャの更新頻度をケチる
    - ComputeShaderの結果をAsyncGPUReadbackで読むようにしてメインスレッドの硬直を削る