### PR TITLE
update midijack package

### DIFF
--- a/VMagicMirror/Packages/manifest.json
+++ b/VMagicMirror/Packages/manifest.json
@@ -15,7 +15,7 @@
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity#v4.4.0",
     "com.hecomi.udesktopduplication": "https://github.com/hecomi/uDesktopDuplication.git#upm@1.8.0",
     "com.hecomi.uosc": "https://github.com/hecomi/uOSC.git#upm@2.2.0",
-    "com.malaybaku.managed-midijack": "https://github.com/malaybaku/MidiJack.git?path=/Assets/MidiJack",
+    "com.malaybaku.managed-midijack": "https://github.com/malaybaku/MidiJack.git?path=/Assets/MidiJack#1.0.0",
     "com.svermeulen.extenject": "https://github.com/Mathijs-Bakker/Extenject.git?path=UnityProject/Assets/Plugins/Zenject/Source#9.3.1",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.barracuda": "3.0.0",

--- a/VMagicMirror/Packages/packages-lock.json
+++ b/VMagicMirror/Packages/packages-lock.json
@@ -57,11 +57,11 @@
       "hash": "3788ab28702c44330bfea7323b2e05bc4d23c213"
     },
     "com.malaybaku.managed-midijack": {
-      "version": "https://github.com/malaybaku/MidiJack.git?path=/Assets/MidiJack",
+      "version": "https://github.com/malaybaku/MidiJack.git?path=/Assets/MidiJack#1.0.0",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "5a4c5b8ccfb7a73b9ced2f05e741f3caec3add3f"
+      "hash": "61d20a906dae5c2fb1aaa337e5551b44d5aa170e"
     },
     "com.svermeulen.extenject": {
       "version": "https://github.com/Mathijs-Bakker/Extenject.git?path=UnityProject/Assets/Plugins/Zenject/Source#9.3.1",


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixes #1210 

- 下記PRでメモリリークや明らかなパフォーマンス劣化に繋がりそうな問題を対策したのを取り込む
    - https://github.com/malaybaku/MidiJack/pull/3
- MidiJack側のrelease tag運用がきちんとしてなかったのも問題だったため、明示的にタグを指定するようにした

## How to confirm

Buildに対して3台のMIDIデバイス(うちNoteが送れるのは2台)を接続してMIDI入力を有効にしたとき

- Note番号を割り当てて表情等が変更できること
- 時間経過してもメモリ使用量が増えてしまわないこと
