### PR TITLE
test: add save/load usecase unit tests

### DIFF
--- a/WPF/VMagicMirrorConfig/Properties/AssemblyInfo.cs
+++ b/WPF/VMagicMirrorConfig/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using System.Windows;
 
 // ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
@@ -24,3 +25,5 @@ using System.Windows;
                                               //(リソースがページ、
                                               //アプリケーション、またはいずれのテーマ固有のリソース ディクショナリにも見つからない場合に使用されます)
 )]
+
+[assembly: InternalsVisibleTo("VMagicMirrorTest")]

--- a/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/ISaveLoadDataService.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/ISaveLoadDataService.cs
@@ -1,0 +1,11 @@
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal interface ISaveLoadDataService
+    {
+        int FileCount { get; }
+        int FocusedFileIndex { get; }
+        bool CheckFileExist(int index);
+        void LoadSetting(int index, bool loadCharacter, bool loadNonCharacter, bool fromAutomation);
+        void SaveCurrentSetting(int index);
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataService.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataService.cs
@@ -1,0 +1,19 @@
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal sealed class SaveLoadDataService : ISaveLoadDataService
+    {
+        private readonly SaveFileManager _model;
+
+        public SaveLoadDataService(SaveFileManager model)
+        {
+            _model = model;
+        }
+
+        public int FileCount => SaveFileManager.FileCount;
+        public int FocusedFileIndex => _model.FocusedFileIndex;
+        public bool CheckFileExist(int index) => _model.CheckFileExist(index);
+        public void LoadSetting(int index, bool loadCharacter, bool loadNonCharacter, bool fromAutomation)
+            => _model.LoadSetting(index, loadCharacter, loadNonCharacter, fromAutomation);
+        public void SaveCurrentSetting(int index) => _model.SaveCurrentSetting(index);
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataUseCase.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataUseCase.cs
@@ -6,16 +6,16 @@ namespace Baku.VMagicMirrorConfig.ViewModel
     internal sealed class SaveLoadDataUseCase
     {
         private readonly RootSettingModel? _rootModel;
-        private readonly SaveFileManager _model;
+        private readonly ISaveLoadDataService _service;
         private readonly ISaveLoadDataInteraction _interaction;
 
         public SaveLoadDataUseCase(
             RootSettingModel? rootModel,
-            SaveFileManager model,
+            ISaveLoadDataService service,
             ISaveLoadDataInteraction interaction)
         {
             _rootModel = rootModel;
-            _model = model;
+            _service = service;
             _interaction = interaction;
         }
 
@@ -26,7 +26,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             Action closeDialog)
         {
             // オートセーブ(0番)もロード対象として扱う。
-            if (index < 0 || index > SaveFileManager.FileCount || !_model.CheckFileExist(index))
+            if (index < 0 || index > _service.FileCount || !_service.CheckFileExist(index))
             {
                 return;
             }
@@ -42,7 +42,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             // 先に閉じないと、VRoidロード時にダイアログが閉じきれない場合がある。
             closeDialog();
 
-            _model.LoadSetting(
+            _service.LoadSetting(
                 index,
                 loadCharacterWhenSettingLoaded,
                 loadNonCharacterWhenSettingLoaded,
@@ -60,7 +60,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public async Task ExecuteSaveAsync(int index, Action refresh)
         {
             // 保存は手動スロットのみ。0番(オートセーブ)は対象外。
-            if (index <= 0 || index > SaveFileManager.FileCount)
+            if (index <= 0 || index > _service.FileCount)
             {
                 return;
             }
@@ -71,7 +71,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 return;
             }
 
-            _model.SaveCurrentSetting(index);
+            _service.SaveCurrentSetting(index);
 
             // ファイル単位の操作結果は通知を出す。
             _interaction.NotifySaveCompleted(index);

--- a/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataViewModel.cs
@@ -26,10 +26,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             ISaveLoadDataInteraction interaction)
         {
             _rootModel = rootModel;
-            _model = model;
+            _service = new SaveLoadDataService(model);
             _actToClose = actToClose;
             _interaction = interaction;
-            _useCase = new SaveLoadDataUseCase(_rootModel, _model, _interaction);
+            _useCase = new SaveLoadDataUseCase(_rootModel, _service, _interaction);
             Items = new ReadOnlyObservableCollection<SaveLoadFileItemViewModel>(_items);
             CancelCommand = new ActionCommand(CloseDialog);
 
@@ -44,7 +44,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         }
 
         private readonly RootSettingModel? _rootModel;
-        private readonly SaveFileManager _model;
+        private readonly ISaveLoadDataService _service;
         private readonly Action _actToClose;
         private readonly ISaveLoadDataInteraction _interaction;
         private readonly SaveLoadDataUseCase _useCase;
@@ -68,7 +68,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             {
                 var meta = SettingFileOverview.CreateOverviewFromFile(SpecialFilePath.GetSaveFilePath(i), i);
                 _items.Add(new SaveLoadFileItemViewModel(
-                    IsLoadMode, i == _model.FocusedFileIndex, meta, this
+                    IsLoadMode, i == _service.FocusedFileIndex, meta, this
                     ));
             }
         }

--- a/WPF/VMagicMirrorTest/ViewModel/SaveFileManage/SaveLoadDataUseCaseTests.cs
+++ b/WPF/VMagicMirrorTest/ViewModel/SaveFileManage/SaveLoadDataUseCaseTests.cs
@@ -1,0 +1,168 @@
+using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using Baku.VMagicMirrorConfig.ViewModel;
+
+namespace Baku.VMagicMirrorConfig.Test.ViewModel.SaveFileManage
+{
+    public class SaveLoadDataUseCaseTests
+    {
+        [Test]
+        public async Task ExecuteLoadAsync_存在しないファイルでは何もしない()
+        {
+            var service = new FakeSaveLoadDataService { FileExists = false };
+            var interaction = new FakeSaveLoadDataInteraction();
+            var useCase = new SaveLoadDataUseCase(null, service, interaction);
+
+            bool dialogClosed = false;
+            await useCase.ExecuteLoadAsync(1, true, true, () => dialogClosed = true);
+
+            Assert.That(interaction.LoadConfirmRequestedCount, Is.EqualTo(0));
+            Assert.That(service.LoadCallCount, Is.EqualTo(0));
+            Assert.That(dialogClosed, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteLoadAsync_確認キャンセル時はロードしない()
+        {
+            var service = new FakeSaveLoadDataService { FileExists = true };
+            var interaction = new FakeSaveLoadDataInteraction { LoadConfirmResult = false };
+            var useCase = new SaveLoadDataUseCase(null, service, interaction);
+
+            bool dialogClosed = false;
+            await useCase.ExecuteLoadAsync(1, true, false, () => dialogClosed = true);
+
+            Assert.That(interaction.LoadConfirmRequestedCount, Is.EqualTo(1));
+            Assert.That(service.LoadCallCount, Is.EqualTo(0));
+            Assert.That(dialogClosed, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteLoadAsync_確認OK時はロードしてダイアログを閉じる()
+        {
+            var service = new FakeSaveLoadDataService { FileExists = true };
+            var interaction = new FakeSaveLoadDataInteraction { LoadConfirmResult = true };
+            var useCase = new SaveLoadDataUseCase(null, service, interaction);
+
+            bool dialogClosed = false;
+            await useCase.ExecuteLoadAsync(2, true, false, () => dialogClosed = true);
+
+            Assert.That(service.LoadCallCount, Is.EqualTo(1));
+            Assert.That(service.LastLoadIndex, Is.EqualTo(2));
+            Assert.That(service.LastLoadCharacter, Is.True);
+            Assert.That(service.LastLoadNonCharacter, Is.False);
+            Assert.That(interaction.LoadNotifiedCount, Is.EqualTo(1));
+            Assert.That(dialogClosed, Is.True);
+        }
+
+        [Test]
+        public async Task ExecuteSaveAsync_不正インデックスでは何もしない()
+        {
+            var service = new FakeSaveLoadDataService();
+            var interaction = new FakeSaveLoadDataInteraction();
+            var useCase = new SaveLoadDataUseCase(null, service, interaction);
+
+            bool refreshed = false;
+            await useCase.ExecuteSaveAsync(0, () => refreshed = true);
+
+            Assert.That(interaction.SaveConfirmRequestedCount, Is.EqualTo(0));
+            Assert.That(service.SaveCallCount, Is.EqualTo(0));
+            Assert.That(refreshed, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteSaveAsync_確認キャンセル時は保存しない()
+        {
+            var service = new FakeSaveLoadDataService();
+            var interaction = new FakeSaveLoadDataInteraction { SaveConfirmResult = false };
+            var useCase = new SaveLoadDataUseCase(null, service, interaction);
+
+            bool refreshed = false;
+            await useCase.ExecuteSaveAsync(1, () => refreshed = true);
+
+            Assert.That(interaction.SaveConfirmRequestedCount, Is.EqualTo(1));
+            Assert.That(service.SaveCallCount, Is.EqualTo(0));
+            Assert.That(refreshed, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteSaveAsync_確認OK時は保存してリフレッシュを開始する()
+        {
+            var service = new FakeSaveLoadDataService();
+            var interaction = new FakeSaveLoadDataInteraction { SaveConfirmResult = true };
+            var useCase = new SaveLoadDataUseCase(null, service, interaction);
+
+            bool refreshed = false;
+            await useCase.ExecuteSaveAsync(3, () => refreshed = true);
+
+            Assert.That(service.SaveCallCount, Is.EqualTo(1));
+            Assert.That(service.LastSaveIndex, Is.EqualTo(3));
+            Assert.That(interaction.SaveNotifiedCount, Is.EqualTo(1));
+            Assert.That(interaction.BeginRefreshCount, Is.EqualTo(1));
+            Assert.That(refreshed, Is.True);
+        }
+
+        private sealed class FakeSaveLoadDataService : ISaveLoadDataService
+        {
+            public int FileCount { get; set; } = 15;
+            public int FocusedFileIndex { get; set; }
+            public bool FileExists { get; set; } = true;
+
+            public int LoadCallCount { get; private set; }
+            public int SaveCallCount { get; private set; }
+            public int LastLoadIndex { get; private set; } = -1;
+            public bool LastLoadCharacter { get; private set; }
+            public bool LastLoadNonCharacter { get; private set; }
+            public int LastSaveIndex { get; private set; } = -1;
+
+            public bool CheckFileExist(int index) => FileExists;
+
+            public void LoadSetting(int index, bool loadCharacter, bool loadNonCharacter, bool fromAutomation)
+            {
+                LoadCallCount++;
+                LastLoadIndex = index;
+                LastLoadCharacter = loadCharacter;
+                LastLoadNonCharacter = loadNonCharacter;
+            }
+
+            public void SaveCurrentSetting(int index)
+            {
+                SaveCallCount++;
+                LastSaveIndex = index;
+            }
+        }
+
+        private sealed class FakeSaveLoadDataInteraction : ISaveLoadDataInteraction
+        {
+            public bool LoadConfirmResult { get; set; } = true;
+            public bool SaveConfirmResult { get; set; } = true;
+
+            public int LoadConfirmRequestedCount { get; private set; }
+            public int SaveConfirmRequestedCount { get; private set; }
+            public int LoadNotifiedCount { get; private set; }
+            public int SaveNotifiedCount { get; private set; }
+            public int BeginRefreshCount { get; private set; }
+
+            public Task<bool> ConfirmLoadAsync(int index)
+            {
+                LoadConfirmRequestedCount++;
+                return Task.FromResult(LoadConfirmResult);
+            }
+
+            public Task<bool> ConfirmSaveAsync(int index)
+            {
+                SaveConfirmRequestedCount++;
+                return Task.FromResult(SaveConfirmResult);
+            }
+
+            public void NotifyLoadCompleted(int index) => LoadNotifiedCount++;
+            public void NotifySaveCompleted(int index) => SaveNotifiedCount++;
+
+            public void BeginRefresh(Action refreshAction)
+            {
+                BeginRefreshCount++;
+                refreshAction();
+            }
+        }
+    }
+}

--- a/maintainer/task-board.md
+++ b/maintainer/task-board.md
@@ -10,7 +10,7 @@
 
 ## Doing
 
-- [ ] WPF: `SaveLoadDataViewModel` の分離設計（境界 interface の定義）
+- [ ] WPF: 次の分離候補のDiscovery（HomeViewModel / SettingIoViewModelの比較）
 
 ## Review
 
@@ -23,6 +23,7 @@
 - [x] 2026-03-08 WPF build/test コマンド実行確認（build成功、test 32件成功）
 - [x] 2026-03-08 WPFテスト性改善タスクを Phase 単位に分解
 - [x] 2026-03-08 WPF ViewModel のUI直接依存ホットスポットを棚卸し
+- [x] 2026-03-08 SaveLoadDataUseCase のユニットテスト追加（6件、合計38件成功）
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- introduce ISaveLoadDataService abstraction for SaveLoadDataUseCase
- adapt SaveLoadDataViewModel to use service wrapper
- add unit tests for SaveLoadDataUseCase (load/save branches)
- update maintainer task board progress

## Validation
- dotnet build WPF/VMagicMirrorConfig/VMagicMirrorConfig.csproj -c Debug -p:Platform=x86
- dotnet test WPF/VMagicMirrorTest/VMagicMirrorTest.csproj -c Debug -p:Platform=x86 --results-directory WPF/TestResults