### PR TITLE
refactor: add dialog seam to setting io viewmodel

### DIFF
--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/ISettingIoDialogInteraction.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/ISettingIoDialogInteraction.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal interface ISettingIoDialogInteraction
+    {
+        Task<bool> ConfirmEnableAutomationAsync();
+        Task<bool> ConfirmDisableAutomationAsync();
+        Task<bool> ConfirmToggleSkipLocalVrmLicenseCheckAsync(bool currentValue);
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/SettingIoDialogInteraction.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/SettingIoDialogInteraction.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal sealed class SettingIoDialogInteraction : ISettingIoDialogInteraction
+    {
+        public async Task<bool> ConfirmEnableAutomationAsync()
+        {
+            var indication = MessageIndication.EnableAutomation();
+            return await MessageBoxWrapper.Instance.ShowAsync(
+                indication.Title, indication.Content, MessageBoxWrapper.MessageBoxStyle.OKCancel
+            );
+        }
+
+        public async Task<bool> ConfirmDisableAutomationAsync()
+        {
+            var indication = MessageIndication.DisableAutomation();
+            return await MessageBoxWrapper.Instance.ShowAsync(
+                indication.Title, indication.Content, MessageBoxWrapper.MessageBoxStyle.OKCancel
+            );
+        }
+
+        public async Task<bool> ConfirmToggleSkipLocalVrmLicenseCheckAsync(bool currentValue)
+        {
+            var indication = currentValue
+                ? MessageIndication.DisableSkipLocalVrmLicenseCheck()
+                : MessageIndication.SkipLocalVrmLicenseCheck();
+
+            return await MessageBoxWrapper.Instance.ShowAsync(
+                indication.Title, indication.Content, MessageBoxWrapper.MessageBoxStyle.OKCancel
+            );
+        }
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/SettingIoViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/SettingIoViewModel.cs
@@ -6,15 +6,20 @@ namespace Baku.VMagicMirrorConfig.ViewModel
     {
         public SettingIoViewModel() : this(
             ModelResolver.Instance.Resolve<AutomationSettingModel>(),
-            ModelResolver.Instance.Resolve<PreferenceSettingModel>()
+            ModelResolver.Instance.Resolve<PreferenceSettingModel>(),
+            new SettingIoDialogInteraction()
             )
         {
         }
 
-        internal SettingIoViewModel(AutomationSettingModel model, PreferenceSettingModel preferenceSettingModel)
+        internal SettingIoViewModel(
+            AutomationSettingModel model,
+            PreferenceSettingModel preferenceSettingModel,
+            ISettingIoDialogInteraction dialogInteraction)
         {
             _model = model;
             _preferenceSettingModel = preferenceSettingModel;
+            _dialogInteraction = dialogInteraction;
 
             OpenInstructionUrlCommand = new ActionCommand(OpenInstructionUrl);
             RequestEnableAutomationCommand = new ActionCommand(OnEnableAutomationRequested);
@@ -40,6 +45,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private readonly AutomationSettingModel _model;
         private readonly PreferenceSettingModel _preferenceSettingModel;
+        private readonly ISettingIoDialogInteraction _dialogInteraction;
 
         public RProperty<bool> IsAutomationEnabled => _model.IsAutomationEnabled;
 
@@ -56,10 +62,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private async void OnEnableAutomationRequested()
         {
-            var indication = MessageIndication.EnableAutomation();
-            var result = await MessageBoxWrapper.Instance.ShowAsync(
-                indication.Title, indication.Content, MessageBoxWrapper.MessageBoxStyle.OKCancel
-                );
+            var result = await _dialogInteraction.ConfirmEnableAutomationAsync();
 
             if (result)
             {
@@ -69,10 +72,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private async void OnDisableAutomationRequested()
         {
-            var indication = MessageIndication.DisableAutomation();
-            var result = await MessageBoxWrapper.Instance.ShowAsync(
-                indication.Title, indication.Content, MessageBoxWrapper.MessageBoxStyle.OKCancel
-                );
+            var result = await _dialogInteraction.ConfirmDisableAutomationAsync();
 
             if (result)
             {
@@ -100,13 +100,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private async void ToggleSkipLocalVrmLicenseCheck()
         {
-            var indication = SkipLocalVrmLicenseCheck.Value
-                ? MessageIndication.DisableSkipLocalVrmLicenseCheck()
-                : MessageIndication.SkipLocalVrmLicenseCheck();
-
-            var result = await MessageBoxWrapper.Instance.ShowAsync(
-                indication.Title, indication.Content, MessageBoxWrapper.MessageBoxStyle.OKCancel
-                );
+            var result = await _dialogInteraction
+                .ConfirmToggleSkipLocalVrmLicenseCheckAsync(SkipLocalVrmLicenseCheck.Value);
 
             if (result)
             {

--- a/WPF/VMagicMirrorTest/ViewModel/SettingWindowTab/SettingIoViewModelTests.cs
+++ b/WPF/VMagicMirrorTest/ViewModel/SettingWindowTab/SettingIoViewModelTests.cs
@@ -1,0 +1,93 @@
+using Baku.VMagicMirrorConfig.ViewModel;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Baku.VMagicMirrorConfig.Test.ViewModel.SettingWindowTab
+{
+    public class SettingIoViewModelTests
+    {
+        [Test]
+        public void RequestEnableAutomationCommand_確認ダイアログを呼ぶ()
+        {
+            using var model = new AutomationSettingModel(new FakeMessageSender());
+            var preference = new PreferenceSettingModel();
+            var dialog = new FakeDialogInteraction { EnableResult = false };
+            var vm = new SettingIoViewModel(model, preference, dialog);
+
+            vm.RequestEnableAutomationCommand.Execute(null);
+
+            Assert.That(dialog.EnableRequestedCount, Is.EqualTo(1));
+            Assert.That(model.IsAutomationEnabled.Value, Is.False);
+        }
+
+        [Test]
+        public void RequestDisableAutomationCommand_確認ダイアログを呼ぶ()
+        {
+            using var model = new AutomationSettingModel(new FakeMessageSender());
+            var preference = new PreferenceSettingModel();
+            var dialog = new FakeDialogInteraction { DisableResult = true };
+            var vm = new SettingIoViewModel(model, preference, dialog);
+
+            vm.RequestDisableAutomationCommand.Execute(null);
+
+            Assert.That(dialog.DisableRequestedCount, Is.EqualTo(1));
+            Assert.That(model.IsAutomationEnabled.Value, Is.False);
+        }
+
+        [Test]
+        public void ToggleSkipLocalVrmLicenseCheckCommand_確認OKなら値がトグルされる()
+        {
+            using var model = new AutomationSettingModel(new FakeMessageSender());
+            var preference = new PreferenceSettingModel();
+            var dialog = new FakeDialogInteraction { ToggleResult = true };
+            var vm = new SettingIoViewModel(model, preference, dialog);
+
+            Assert.That(preference.SkipLocalVrmLicenseCheck.Value, Is.False);
+            vm.ToggleSkipLocalVrmLicenseCheckCommand.Execute(null);
+
+            Assert.That(dialog.ToggleRequestedCount, Is.EqualTo(1));
+            Assert.That(dialog.LastToggleCurrentValue, Is.False);
+            Assert.That(preference.SkipLocalVrmLicenseCheck.Value, Is.True);
+        }
+
+        private sealed class FakeDialogInteraction : ISettingIoDialogInteraction
+        {
+            public bool EnableResult { get; set; } = true;
+            public bool DisableResult { get; set; } = true;
+            public bool ToggleResult { get; set; } = true;
+
+            public int EnableRequestedCount { get; private set; }
+            public int DisableRequestedCount { get; private set; }
+            public int ToggleRequestedCount { get; private set; }
+            public bool LastToggleCurrentValue { get; private set; }
+
+            public Task<bool> ConfirmEnableAutomationAsync()
+            {
+                EnableRequestedCount++;
+                return Task.FromResult(EnableResult);
+            }
+
+            public Task<bool> ConfirmDisableAutomationAsync()
+            {
+                DisableRequestedCount++;
+                return Task.FromResult(DisableResult);
+            }
+
+            public Task<bool> ConfirmToggleSkipLocalVrmLicenseCheckAsync(bool currentValue)
+            {
+                ToggleRequestedCount++;
+                LastToggleCurrentValue = currentValue;
+                return Task.FromResult(ToggleResult);
+            }
+        }
+
+        private sealed class FakeMessageSender : IMessageSender
+        {
+            public void SendMessage(Message message)
+            {
+            }
+
+            public Task<string> QueryMessageAsync(Message message) => Task.FromResult(string.Empty);
+        }
+    }
+}

--- a/maintainer/task-board.md
+++ b/maintainer/task-board.md
@@ -24,6 +24,7 @@
 - [x] 2026-03-08 WPFテスト性改善タスクを Phase 単位に分解
 - [x] 2026-03-08 WPF ViewModel のUI直接依存ホットスポットを棚卸し
 - [x] 2026-03-08 SaveLoadDataUseCase のユニットテスト追加（6件、合計38件成功）
+- [x] 2026-03-08 SettingIoViewModel の確認ダイアログ境界を抽象化しテスト追加（合計41件成功）
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- add ISettingIoDialogInteraction abstraction
- add SettingIoDialogInteraction default implementation
- make SettingIoViewModel use injected dialog interaction
- add SettingIoViewModel unit tests (3 cases)
- update maintainer task board progress

## Validation
- dotnet test WPF/VMagicMirrorTest/VMagicMirrorTest.csproj -c Debug -p:Platform=x86 --results-directory WPF/TestResults