### PR TITLE
refactor: extract home reset-to-default flow

### DIFF
--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeResetInteraction.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeResetInteraction.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal sealed class HomeResetInteraction : IHomeResetInteraction
+    {
+        public async Task<bool> ConfirmResetToDefaultAsync()
+        {
+            var indication = MessageIndication.ResetSettingConfirmation();
+            return await MessageBoxWrapper.Instance.ShowAsync(
+                indication.Title,
+                indication.Content,
+                MessageBoxWrapper.MessageBoxStyle.OKCancel
+            );
+        }
+
+        public void CloseMainWindow() => Application.Current.MainWindow?.Close();
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeResetStorage.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeResetStorage.cs
@@ -1,0 +1,20 @@
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal sealed class HomeResetStorage : IHomeResetStorage
+    {
+        private readonly SaveFileManager _saveFileManager;
+        private readonly PreferenceFileManager _preferenceFileManager;
+
+        public HomeResetStorage(SaveFileManager saveFileManager, PreferenceFileManager preferenceFileManager)
+        {
+            _saveFileManager = saveFileManager;
+            _preferenceFileManager = preferenceFileManager;
+        }
+
+        public void DeleteAutoSaveFile()
+            => _saveFileManager.SettingFileIo.DeleteSetting(SpecialFilePath.AutoSaveSettingFilePath);
+
+        public void DeletePreferenceSaveFile()
+            => _preferenceFileManager.DeleteSaveFile();
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeResetUseCase.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeResetUseCase.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal sealed class HomeResetUseCase
+    {
+        private readonly AppQuitSetting _appQuitSetting;
+        private readonly IHomeResetStorage _storage;
+        private readonly IHomeResetInteraction _interaction;
+
+        public HomeResetUseCase(
+            AppQuitSetting appQuitSetting,
+            IHomeResetStorage storage,
+            IHomeResetInteraction interaction)
+        {
+            _appQuitSetting = appQuitSetting;
+            _storage = storage;
+            _interaction = interaction;
+        }
+
+        public async Task ExecuteAsync()
+        {
+            if (!await _interaction.ConfirmResetToDefaultAsync())
+            {
+                return;
+            }
+
+            // 「設定のデフォルト化 == 設定ファイルを消してオートセーブ無効で再起動」として扱う。
+            _appQuitSetting.SkipAutoSaveAndRestart = true;
+            _storage.DeleteAutoSaveFile();
+            // オートセーブ以外の設定ファイルも削除する。
+            _storage.DeletePreferenceSaveFile();
+            _interaction.CloseMainWindow();
+        }
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeViewModel.cs
@@ -5,7 +5,6 @@ using Microsoft.Win32;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
-using System.Windows;
 
 namespace Baku.VMagicMirrorConfig.ViewModel
 {
@@ -19,6 +18,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         private readonly AvatarLoader _avatarLoader;
         private readonly AppQuitSetting _appQuitSetting;
         private readonly PreferenceSettingModel _preferenceSetting;
+        private readonly HomeResetUseCase _resetUseCase;
 
         public HomeViewModel() : this(
             ModelResolver.Instance.Resolve<RootSettingModel>(),
@@ -26,7 +26,12 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             ModelResolver.Instance.Resolve<AvatarLoader>(),
             ModelResolver.Instance.Resolve<ScreenshotTaker>(),
             ModelResolver.Instance.Resolve<AppQuitSetting>(),
-            ModelResolver.Instance.Resolve<PreferenceSettingModel>()
+            ModelResolver.Instance.Resolve<PreferenceSettingModel>(),
+            new HomeResetStorage(
+                ModelResolver.Instance.Resolve<SaveFileManager>(),
+                ModelResolver.Instance.Resolve<PreferenceFileManager>()
+            ),
+            new HomeResetInteraction()
             )
         {
         }
@@ -37,7 +42,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             AvatarLoader avatarLoader,
             ScreenshotTaker screenshotTaker,
             AppQuitSetting appQuitSetting,
-            PreferenceSettingModel preferenceSetting
+            PreferenceSettingModel preferenceSetting,
+            IHomeResetStorage resetStorage,
+            IHomeResetInteraction resetInteraction
             )
         {
             _setting = rootSetting;
@@ -45,6 +52,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             _avatarLoader = avatarLoader;
             _appQuitSetting = appQuitSetting;
             _preferenceSetting = preferenceSetting;
+            _resetUseCase = new HomeResetUseCase(_appQuitSetting, resetStorage, resetInteraction);
             
             LoadVrmCommand = new ActionCommand(LoadVrmByFileOpenDialog);
             LoadVrmByFilePathCommand = new ActionCommand<string>(LoadVrmByFilePath);
@@ -154,25 +162,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private async void ResetToDefault()
         {
-            var indication = MessageIndication.ResetSettingConfirmation();
-            bool res = await MessageBoxWrapper.Instance.ShowAsync(
-                indication.Title,
-                indication.Content,
-                MessageBoxWrapper.MessageBoxStyle.OKCancel
-                );
-
-            if (!res)
-            {
-                return;
-            }
-
-            //書いてる通りだが、「設定のデフォルト化 == 設定ファイルを消してオートセーブが無効な状態で再起動」とすることで
-            //クリーンに再起動しようとしている
-            _appQuitSetting.SkipAutoSaveAndRestart = true;
-            _saveFileManager.SettingFileIo.DeleteSetting(SpecialFilePath.AutoSaveSettingFilePath);
-            //オートセーブじゃないほうの設定ファイルも消してしまう
-            ModelResolver.Instance.Resolve<PreferenceFileManager>().DeleteSaveFile();
-            Application.Current.MainWindow?.Close();
+            await _resetUseCase.ExecuteAsync();
         }
 
         #region セーブ/ロード
@@ -182,7 +172,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private async void ShowSaveModal()
         {
-            if (Application.Current.MainWindow is not MetroWindow window)
+            if (System.Windows.Application.Current.MainWindow is not MetroWindow window)
             {
                 return;
             }
@@ -211,7 +201,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         private async void ShowLoadModal()
         {
-            if (Application.Current.MainWindow is not MetroWindow window)
+            if (System.Windows.Application.Current.MainWindow is not MetroWindow window)
             {
                 return;
             }

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/IHomeResetInteraction.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/IHomeResetInteraction.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal interface IHomeResetInteraction
+    {
+        Task<bool> ConfirmResetToDefaultAsync();
+        void CloseMainWindow();
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/IHomeResetStorage.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/IHomeResetStorage.cs
@@ -1,0 +1,8 @@
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    internal interface IHomeResetStorage
+    {
+        void DeleteAutoSaveFile();
+        void DeletePreferenceSaveFile();
+    }
+}

--- a/WPF/VMagicMirrorTest/ViewModel/ControlPanel/HomeResetUseCaseTests.cs
+++ b/WPF/VMagicMirrorTest/ViewModel/ControlPanel/HomeResetUseCaseTests.cs
@@ -1,0 +1,59 @@
+using Baku.VMagicMirrorConfig.ViewModel;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Baku.VMagicMirrorConfig.Test.ViewModel.ControlPanel
+{
+    public class HomeResetUseCaseTests
+    {
+        [Test]
+        public async Task ExecuteAsync_確認キャンセル時は何もしない()
+        {
+            var appQuitSetting = new AppQuitSetting();
+            var storage = new FakeHomeResetStorage();
+            var interaction = new FakeHomeResetInteraction { ConfirmResult = false };
+            var useCase = new HomeResetUseCase(appQuitSetting, storage, interaction);
+
+            await useCase.ExecuteAsync();
+
+            Assert.That(appQuitSetting.SkipAutoSaveAndRestart, Is.False);
+            Assert.That(storage.DeleteAutoSaveCalled, Is.False);
+            Assert.That(storage.DeletePreferenceCalled, Is.False);
+            Assert.That(interaction.CloseMainWindowCalled, Is.False);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_確認OK時は設定削除して終了する()
+        {
+            var appQuitSetting = new AppQuitSetting();
+            var storage = new FakeHomeResetStorage();
+            var interaction = new FakeHomeResetInteraction { ConfirmResult = true };
+            var useCase = new HomeResetUseCase(appQuitSetting, storage, interaction);
+
+            await useCase.ExecuteAsync();
+
+            Assert.That(appQuitSetting.SkipAutoSaveAndRestart, Is.True);
+            Assert.That(storage.DeleteAutoSaveCalled, Is.True);
+            Assert.That(storage.DeletePreferenceCalled, Is.True);
+            Assert.That(interaction.CloseMainWindowCalled, Is.True);
+        }
+
+        private sealed class FakeHomeResetStorage : IHomeResetStorage
+        {
+            public bool DeleteAutoSaveCalled { get; private set; }
+            public bool DeletePreferenceCalled { get; private set; }
+
+            public void DeleteAutoSaveFile() => DeleteAutoSaveCalled = true;
+            public void DeletePreferenceSaveFile() => DeletePreferenceCalled = true;
+        }
+
+        private sealed class FakeHomeResetInteraction : IHomeResetInteraction
+        {
+            public bool ConfirmResult { get; set; }
+            public bool CloseMainWindowCalled { get; private set; }
+
+            public Task<bool> ConfirmResetToDefaultAsync() => Task.FromResult(ConfirmResult);
+            public void CloseMainWindow() => CloseMainWindowCalled = true;
+        }
+    }
+}

--- a/maintainer/decision-log.md
+++ b/maintainer/decision-log.md
@@ -75,3 +75,9 @@
 - Decision: `HomeViewModel` は依存点が多いため、次の小PR対象は `VMCPSettingViewModel` とする
 - Decision: `HomeViewModel` はさらに小さい責務単位へ分割してから着手する
 - Reason: 1PRのサイズとレビュー負荷を抑え、既存の分離パターンを再利用しやすくするため
+
+### D-014: HomeViewModel分割の初手
+
+- Decision: `HomeViewModel` の初手分割は `ResetToDefault` 経路を対象にする
+- Decision: 確認ダイアログ/終了操作とファイル削除処理を境界化し、UseCaseで統合する
+- Reason: 影響範囲を限定して、既存挙動を維持したままテスト可能な単位を先に作るため

--- a/maintainer/task-board.md
+++ b/maintainer/task-board.md
@@ -27,7 +27,7 @@
 
 ## Doing
 
-- [ ] WPF: HomeViewModelの分離対象をさらに小さく分割（Reset/Export/Import/Modal表示の分離）
+- [ ] WPF: HomeViewModelの分離対象をさらに小さく分割（Export/Import/Modal表示の分離）
 
 ## Review
 
@@ -43,6 +43,7 @@
 - [x] 2026-03-08 SaveLoadDataUseCase のユニットテスト追加（6件、合計38件成功）
 - [x] 2026-03-08 SettingIoViewModel の確認ダイアログ境界を抽象化しテスト追加（合計41件成功）
 - [x] 2026-03-08 次候補比較（Home vs VMCP）を実施し、VMCPを小PR対象として選定
+- [x] 2026-03-08 HomeViewModelのResetToDefault経路をUseCase化しテスト追加
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- extract HomeViewModel reset-to-default flow into HomeResetUseCase
- add interaction/storage seams for reset flow
- keep HomeViewModel as coordinator for reset command
- add HomeResetUseCase unit tests
- update maintainer task board and decision log

## Validation
- dotnet test WPF/VMagicMirrorTest/VMagicMirrorTest.csproj -c Debug -p:Platform=x86 --results-directory WPF/TestResults