### PR TITLE
fix: register seam dependencies in model installer

### DIFF
--- a/WPF/VMagicMirrorConfig/Depdency/ModelInstaller.cs
+++ b/WPF/VMagicMirrorConfig/Depdency/ModelInstaller.cs
@@ -1,4 +1,4 @@
-﻿namespace Baku.VMagicMirrorConfig
+namespace Baku.VMagicMirrorConfig
 {
     static class ModelInstaller
     {
@@ -48,6 +48,7 @@
             //NOTE: 設定ファイル系の処理のモデルも必要なら入れてよい
             resolver.Add(new SettingFileIo());
             resolver.Add(new SaveFileManager());
+            resolver.Add(new PreferenceFileManager());
 
             resolver.Add(new AvatarLoader());
 
@@ -61,7 +62,14 @@
             resolver.Add(new FaceSettingReceiver());
             resolver.Add(new BuddySettingsReceiver());
 
-            resolver.Add(new PreferenceFileManager());
+            // ViewModel seams: add boundaries to resolver and consume via Resolve in default constructors.
+            resolver.Add<ViewModel.ISaveLoadDataInteraction>(new ViewModel.SaveLoadDataInteraction());
+            resolver.Add<ViewModel.ISettingIoDialogInteraction>(new ViewModel.SettingIoDialogInteraction());
+            resolver.Add<ViewModel.IVMCPDialogInteraction>(new ViewModel.VMCPDialogInteraction());
+            resolver.Add<ViewModel.IHomeResetInteraction>(new ViewModel.HomeResetInteraction());
+            resolver.Add<ViewModel.IHomeResetStorage>(new ViewModel.HomeResetStorage(
+                resolver.Resolve<SaveFileManager>(),
+                resolver.Resolve<PreferenceFileManager>()));
 
             resolver.Add(new HotKeySetter());
             resolver.Add(new HotKeyActionRunner());

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/HomeViewModel.cs
@@ -27,11 +27,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             ModelResolver.Instance.Resolve<ScreenshotTaker>(),
             ModelResolver.Instance.Resolve<AppQuitSetting>(),
             ModelResolver.Instance.Resolve<PreferenceSettingModel>(),
-            new HomeResetStorage(
-                ModelResolver.Instance.Resolve<SaveFileManager>(),
-                ModelResolver.Instance.Resolve<PreferenceFileManager>()
-            ),
-            new HomeResetInteraction()
+            ModelResolver.Instance.Resolve<IHomeResetStorage>(),
+            ModelResolver.Instance.Resolve<IHomeResetInteraction>()
             )
         {
         }

--- a/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SaveFileManage/SaveLoadDataViewModel.cs
@@ -12,10 +12,20 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         //NOTE: セーブとロードで必要な素材が微妙に違うのでファクトリで作ります
 
         internal static SaveLoadDataViewModel CreateForSave(SaveFileManager model, Action actToClose)
-            => new SaveLoadDataViewModel(null, model, false, actToClose, new SaveLoadDataInteraction());
+            => new SaveLoadDataViewModel(
+                null,
+                model,
+                false,
+                actToClose,
+                ModelResolver.Instance.Resolve<ISaveLoadDataInteraction>());
 
         internal static SaveLoadDataViewModel CreateForLoad(RootSettingModel rootModel, SaveFileManager model, Action actToClose)
-            => new SaveLoadDataViewModel(rootModel, model, true, actToClose, new SaveLoadDataInteraction());
+            => new SaveLoadDataViewModel(
+                rootModel,
+                model,
+                true,
+                actToClose,
+                ModelResolver.Instance.Resolve<ISaveLoadDataInteraction>());
 
 
         private SaveLoadDataViewModel(

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/SettingIoViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/SettingIoViewModel.cs
@@ -7,7 +7,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public SettingIoViewModel() : this(
             ModelResolver.Instance.Resolve<AutomationSettingModel>(),
             ModelResolver.Instance.Resolve<PreferenceSettingModel>(),
-            new SettingIoDialogInteraction()
+            ModelResolver.Instance.Resolve<ISettingIoDialogInteraction>()
             )
         {
         }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/VMCPSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/VMCPSettingViewModel.cs
@@ -6,7 +6,7 @@
         public VMCPSettingViewModel() : this(
             ModelResolver.Instance.Resolve<VMCPSettingModel>(),
             ModelResolver.Instance.Resolve<PreferenceSettingModel>(),
-            new VMCPDialogInteraction())
+            ModelResolver.Instance.Resolve<IVMCPDialogInteraction>())
         {
         }
 

--- a/maintainer/decision-log.md
+++ b/maintainer/decision-log.md
@@ -81,3 +81,9 @@
 - Decision: `HomeViewModel` の初手分割は `ResetToDefault` 経路を対象にする
 - Decision: 確認ダイアログ/終了操作とファイル削除処理を境界化し、UseCaseで統合する
 - Reason: 影響範囲を限定して、既存挙動を維持したままテスト可能な単位を先に作るため
+
+### D-015: seam追加時のDIセットアップ必須化
+
+- Decision: `*Interaction` / `*Storage` / `*Service` などのseamを追加したら、`ModelInstaller` に登録する
+- Decision: ViewModelの既定コンストラクタでは `new` ではなく `ModelResolver.Resolve<...>()` を使う
+- Reason: 起動時の依存解決失敗と、構成の散逸を防ぐため

--- a/maintainer/index.md
+++ b/maintainer/index.md
@@ -45,3 +45,11 @@
 - WPF build: `dotnet build WPF/VMagicMirrorConfig/VMagicMirrorConfig.csproj -c Debug -p:Platform=x86`
 - WPF test: `dotnet test WPF/VMagicMirrorTest/VMagicMirrorTest.csproj -c Debug -p:Platform=x86 --results-directory WPF/TestResults`
 - 前提: NuGet への到達性（`https://api.nuget.org/v3/index.json`）
+
+## Implementation Memo
+
+- ViewModelに `*Interaction` / `*Storage` / `*Service` などの seam を追加した場合は、
+  既定コンストラクタで `new` せず、`ModelResolver.Instance.Resolve<...>()` で取得する
+- 同時に `Depdency/ModelInstaller.cs` へ `resolver.Add<Interface>(new Impl(...))` を追加する
+- 追加後は `dotnet test WPF/VMagicMirrorTest/VMagicMirrorTest.csproj -c Debug -p:Platform=x86 --results-directory WPF/TestResults`
+  で回帰確認する

--- a/maintainer/task-board.md
+++ b/maintainer/task-board.md
@@ -44,6 +44,7 @@
 - [x] 2026-03-08 SettingIoViewModel の確認ダイアログ境界を抽象化しテスト追加（合計41件成功）
 - [x] 2026-03-08 次候補比較（Home vs VMCP）を実施し、VMCPを小PR対象として選定
 - [x] 2026-03-08 HomeViewModelのResetToDefault経路をUseCase化しテスト追加
+- [x] 2026-03-08 seam追加分のDI登録漏れを修正（ModelInstaller + Resolve方針に統一）
 
 ## Update Rule
 


### PR DESCRIPTION
## Summary
- register newly introduced seam interfaces in ModelInstaller
- switch default constructors to resolve seams via ModelResolver
- align DI usage across SaveLoadData / SettingIo / VMCP / Home reset flows
- add persistent implementation memo and decision log for DI checklist

## Validation
- dotnet test WPF/VMagicMirrorTest/VMagicMirrorTest.csproj -c Debug -p:Platform=x86 --results-directory WPF/TestResults