### PR TITLE
MediaPipeUnityPluginの想定バージョンを引き上げる

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Unity 6.0系でUnityプロジェクト(本レポジトリの`VMagicMirror`フォ
     * [RawInput.Sharp](https://www.nuget.org/packages/RawInput.Sharp/) 0.0.3
     * [Fly,Baby. ver1.2](https://nanakorobi-hi.booth.pm/items/1629266)
     * [LaserLightShader](https://noriben.booth.pm/items/2141514)
-    * [MediaPipeUnityPlugin](https://github.com/homuler/MediaPipeUnityPlugin), [v1.16.1](https://github.com/homuler/MediaPipeUnityPlugin/releases/tag/v0.16.1) or later
+    * [MediaPipeUnityPlugin](https://github.com/homuler/MediaPipeUnityPlugin), [v0.16.3](https://github.com/homuler/MediaPipeUnityPlugin/releases/tag/v0.16.3) or later
     * Roslyn Scripting (後述)
 
 FinalIKは有償アセットであることに注意してください。

--- a/README_en.md
+++ b/README_en.md
@@ -77,7 +77,7 @@ Maintainer's environment is as following.
     * [RawInput.Sharp](https://www.nuget.org/packages/RawInput.Sharp/) 0.0.3
     * [Fly,Baby. ver1.2](https://nanakorobi-hi.booth.pm/items/1629266)
     * [LaserLightShader](https://noriben.booth.pm/items/2141514)
-    * [MediaPipeUnityPlugin](https://github.com/homuler/MediaPipeUnityPlugin), [v1.16.1](https://github.com/homuler/MediaPipeUnityPlugin/releases/tag/v0.16.1) or later
+    * [MediaPipeUnityPlugin](https://github.com/homuler/MediaPipeUnityPlugin), [v0.16.3](https://github.com/homuler/MediaPipeUnityPlugin/releases/tag/v0.16.3) or later
     * Roslyn Scripting (see the last part of this section for detail)
 
 Note that `FinalIK` is paid asset.


### PR DESCRIPTION
## PR category

PR type: 

- [x] Documentation fix / update

## What the PR does

#1222 をcloseしたものの、リリースされているbug fix内容を踏まえるとMediaPipeUnityPluginのバージョンを上げない理由が特になく、実際にローカルプロジェクト上でv0.16.3を導入した状態になったため、実態に合うようにREADMEを更新します。
