### PR TITLE
顔トラッキングのロスト時にFace Switchに準ずる表情+アクセサリを適用できるようにする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -68,6 +68,20 @@ namespace Baku.VMagicMirror
             }
         }
 
+        private bool _visibleTrackingLost;
+        public bool VisibleByTrackingLost
+        {
+            get => _visibleTrackingLost;
+            set
+            {
+                if (_visibleTrackingLost != value)
+                {
+                    _visibleTrackingLost = value;
+                    SetVisibility(ShouldBeVisible);
+                }
+            }
+        }
+        
         private bool _visibleByBlinkTrigger;
         private bool VisibleByBlinkTrigger
         {
@@ -95,6 +109,7 @@ namespace Baku.VMagicMirror
                     ItemLayout.IsVisible ||
                     VisibleByWordToMotion ||
                     VisibleByFaceSwitch || 
+                    VisibleByTrackingLost ||
                     (VisibleByBlinkTrigger && ItemLayout.UseAsBlinkEffect);
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -38,7 +38,8 @@ namespace Baku.VMagicMirror
             FaceSwitchUpdater faceSwitchUpdater,
             DeviceTransformController deviceTransformController,
             WordToMotionAccessoryRequest accessoryRequest,
-            BlinkTriggerDetector blinkTriggerDetector
+            BlinkTriggerDetector blinkTriggerDetector,
+            TrackingLostBlendShapeSource trackingLostBlendShapeSource
             )
         {
             _cam = cam;
@@ -87,6 +88,10 @@ namespace Baku.VMagicMirror
                 .Subscribe(UpdateFaceSwitchStatus)
                 .AddTo(this);
 
+            trackingLostBlendShapeSource.AccessoryNameRequest
+                .Subscribe(UpdateTrackingLostStatus)
+                .AddTo(this);
+            
             deviceTransformController.ControlRequested
                 .Subscribe(ControlItemsTransform)
                 .AddTo(this);
@@ -108,6 +113,14 @@ namespace Baku.VMagicMirror
             }
         }
 
+        private void UpdateTrackingLostStatus(string fileId)
+        {
+            foreach (var item in _items)
+            {
+                item.VisibleByTrackingLost = item.FileId == fileId;
+            }
+        }
+        
         //NOTE: previewでも実際のモーションでも同じ所を叩かせる
         private void UpdateWordToMotionStatus(string fileId)
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -21,7 +21,7 @@ namespace Baku.VMagicMirror
         }
 
         private const int DefaultInterpolateFaceApplyCountMax = 8;
-        private const int SlowInterpolateFaceApplyCountMax = 30;
+        private const int SlowInterpolateFaceApplyCountMax = 16;
 
         private const int StatePriorityNone = 0;
         private const int StatePriorityFaceSwitch = 1;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -14,16 +14,23 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class BlendShapeInterpolator : MonoBehaviour
     {
-        private const int FaceApplyCountMax = 8;
+        private enum InterpolateType
+        {
+            Default,
+            SlowLerp,
+        }
+
+        private const int DefaultInterpolateFaceApplyCountMax = 8;
+        private const int SlowInterpolateFaceApplyCountMax = 30;
 
         private const int StatePriorityNone = 0;
         private const int StatePriorityFaceSwitch = 1;
         private const int StatePriorityTrackingLostBlendShape = 2;
         private const int StatePriorityWordToMotion = 3;
 
-        //補間する場合のフレーム単位で考慮するウェイト。メンドいのでdeltaTimeには依存させない。
-        //理想的には0.1secで表情が切り替わる
-        private static readonly float[] WeightCurve = {
+        // デフォルトで補間する場合のフレーム単位で考慮するウェイト。メンドいのでdeltaTimeには依存させない。
+        // 理想的には0.1secで表情が切り替わる
+        private static readonly float[] DefaultWeightCurve = {
             0f,
             0.1f,
             0.1f,
@@ -181,11 +188,11 @@ namespace Baku.VMagicMirror
             //遷移元か遷移先がIsBinary: 補間を完全にスキップ
             if (_toState.IsBinary || _fromState.IsBinary)
             {
-                _faceAppliedCount = FaceApplyCountMax;
+                _faceAppliedCount = DefaultInterpolateFaceApplyCountMax;
             }
 
             //補間が終了済み: 実態に沿うようにして終わり
-            if (_faceAppliedCount >= FaceApplyCountMax)
+            if (IsDone(_toState, _faceAppliedCount))
             {
                 NeedToInterpolate = false;
                 NonMouthWeight = _toState.NonMouthWeight;
@@ -197,8 +204,8 @@ namespace Baku.VMagicMirror
             
             //上記どれでもない: 補間が必要
             NeedToInterpolate = true;
-            
-            var weight = WeightCurve[_faceAppliedCount];
+
+            var weight = GetWeight(_toState, _faceAppliedCount);
             MouthWeight = Mathf.Lerp(_fromState.MouthWeight, _toState.MouthWeight, weight);
             NonMouthWeight = Mathf.Lerp(_fromState.NonMouthWeight, _toState.NonMouthWeight, weight);
             _fromState.Weight = 1 - weight;
@@ -209,6 +216,30 @@ namespace Baku.VMagicMirror
             if (fps < 60)
             {
                 _faceAppliedCount++;
+            }
+        }
+
+        private static bool IsDone(State toState, int faceAppliedCount)
+        {
+            if (toState.InterpolateType == InterpolateType.Default)
+            {
+                return faceAppliedCount >= DefaultInterpolateFaceApplyCountMax; 
+            }
+            else
+            {
+                return faceAppliedCount >= SlowInterpolateFaceApplyCountMax;
+            }
+        }
+
+        private static float GetWeight(State toState, int faceAppliedCount)
+        {
+            if (toState.InterpolateType == InterpolateType.Default)
+            {
+                return DefaultWeightCurve[faceAppliedCount];
+            }
+            else
+            {
+                return faceAppliedCount * 1f / SlowInterpolateFaceApplyCountMax;
             }
         }
 
@@ -249,6 +280,7 @@ namespace Baku.VMagicMirror
                 target.IsEmpty = false;
                 target.Weight = 0f;
                 target.Priority = StatePriorityTrackingLostBlendShape;
+                target.InterpolateType = InterpolateType.SlowLerp;
                 target.Keys.Clear();
                 target.Keys.Add((bsKey, 1f));
                 target.KeepLipSync = false;
@@ -276,6 +308,7 @@ namespace Baku.VMagicMirror
                 target.IsEmpty = false;
                 target.Weight = 0f;
                 target.Priority = StatePriorityFaceSwitch;
+                target.InterpolateType = InterpolateType.Default;
                 target.Keys.Clear();
                 target.Keys.Add((bsKey, 1f));
                 target.KeepLipSync = bsKeepLipSync;
@@ -291,6 +324,7 @@ namespace Baku.VMagicMirror
             _toState.IsEmpty = false;
             _toState.Weight = 0f;
             _toState.Priority = StatePriorityWordToMotion;
+            _toState.InterpolateType = InterpolateType.Default;
             _toState.Keys.Clear();
             _toState.Keys.AddRange(blendShapes);
             _toState.KeepLipSync = keepLipSync;
@@ -354,7 +388,8 @@ namespace Baku.VMagicMirror
             public bool IsBinary { get; set; }
             public float Weight { get; set; }
             public int Priority { get; set; }
-
+            public InterpolateType InterpolateType { get; set; } = InterpolateType.Default;
+            
             //このステートのときにMouth/それ以外が最終的にWeightいくらで動いてほしいか
             public float MouthWeight => IsEmpty || KeepLipSync ? 1f : 0f;
             public float NonMouthWeight => IsEmpty ? 1f : 0f;
@@ -368,6 +403,7 @@ namespace Baku.VMagicMirror
                 other.IsBinary = IsBinary;
                 other.Weight = Weight;
                 other.Priority = Priority;
+                other.InterpolateType = InterpolateType.Default;
             }
 
             public void OverwriteToEmpty()
@@ -377,6 +413,7 @@ namespace Baku.VMagicMirror
                 KeepLipSync = false;
                 IsBinary = false;
                 Priority = StatePriorityNone;
+                InterpolateType = InterpolateType.Default;
             }
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -21,7 +21,7 @@ namespace Baku.VMagicMirror
         }
 
         private const int DefaultInterpolateFaceApplyCountMax = 8;
-        private const int SlowInterpolateFaceApplyCountMax = 16;
+        private const int SlowInterpolateFaceApplyCountMax = 24;
 
         private const int StatePriorityNone = 0;
         private const int StatePriorityFaceSwitch = 1;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -18,7 +18,8 @@ namespace Baku.VMagicMirror
 
         private const int StatePriorityNone = 0;
         private const int StatePriorityFaceSwitch = 1;
-        private const int StatePriorityWordToMotion = 2;
+        private const int StatePriorityTrackingLostBlendShape = 2;
+        private const int StatePriorityWordToMotion = 3;
 
         //補間する場合のフレーム単位で考慮するウェイト。メンドいのでdeltaTimeには依存させない。
         //理想的には0.1secで表情が切り替わる
@@ -73,8 +74,9 @@ namespace Baku.VMagicMirror
         //NOTE: 何も適用してない状態はIsEmpty == trueになることで表現される
         private readonly State _fromState = new();
         private readonly State _toState = new();
-        //FaceSwitchはWtMより優先度が低く、「from/toどちらでも無いけど適用するかも」という状態になることがあるので、
-        //必要になったら使えるようにするために値をキャッシュするやつ
+        // トラッキングロス表情およびFaceSwitchはWtMより優先度が低く、「from/toどちらでも無いけど適用するかも」という状態になることがあるので、
+        // 必要になったら使えるようにするために値をキャッシュする
+        private readonly State _trackingLostBlendShapeState = new();
         private readonly State _faceSwitchState = new();
         
         //WtMかFace Switchが適用されると0からプラスの値に推移していく。
@@ -82,9 +84,13 @@ namespace Baku.VMagicMirror
         private int _faceAppliedCount;
 
         private readonly ReactiveProperty<bool> _hasWordToMotionOutput = new(false);
+        private readonly ReactiveProperty<bool> _hasTrackingLostBlendShapeOutput = new(false);
         private readonly ReactiveProperty<bool> _hasFaceSwitchOutput = new(false);
 
-        public void Setup(FaceSwitchUpdater faceSwitchUpdater, WordToMotionBlendShape wtmBlendShape)
+        public void Setup(
+            TrackingLostBlendShapeSource trackingLostBlendShapeSource,
+            FaceSwitchUpdater faceSwitchUpdater,
+            WordToMotionBlendShape wtmBlendShape)
         {
             faceSwitchUpdater.CurrentValue
                 .Subscribe(v =>
@@ -100,7 +106,24 @@ namespace Baku.VMagicMirror
                     }
                 })
                 .AddTo(this);
-            
+
+            trackingLostBlendShapeSource.ExpressionKey
+                .Subscribe(v =>
+                {
+                    _hasTrackingLostBlendShapeOutput.Value = v.HasValue;
+                    if (v.HasValue)
+                    {
+                        SetTrackingLost(v.Value);
+                    }
+                    else
+                    {
+                        _trackingLostBlendShapeState.OverwriteToEmpty();
+                        // NOTE: この処理が終わった瞬間にFaceSwitchのステートが入ってると効かないが許容するつもり
+                        // (FaceSwitchが常時適用しっぱなしということはないはずなので)
+                    }
+                })
+                .AddTo(this);
+
             // NOTE: コードのリファクタの関係でSkip(1)を入れてるが、別に必要ないかも
             wtmBlendShape.CurrentValue
                 .Skip(1)
@@ -111,9 +134,13 @@ namespace Baku.VMagicMirror
                     {
                         SetWordToMotion(v.Keys, v.KeepLipSync, v.IsPreview);
                     }
+                    //WtMが終わった瞬間に有効な別の遷移先がある場合はそれらを使う
+                    else if (!_trackingLostBlendShapeState.IsEmpty)
+                    {
+                        SetLowPriorTrackingLostBlendShapeToActive();
+                    }
                     else if (!_faceSwitchState.IsEmpty)
                     {
-                        //WtMが終わった瞬間に有効なFaceSwitchがあったらそれに遷移
                         SetLowPriorFaceSwitchToActive();
                     }
                 })
@@ -121,8 +148,9 @@ namespace Baku.VMagicMirror
 
             Observable.CombineLatest(
                     _hasWordToMotionOutput,
+                    _hasTrackingLostBlendShapeOutput,
                     _hasFaceSwitchOutput,
-                    (a, b) => a || b
+                    (a, b, c) => a || b || c
                 )
                 .Subscribe(hasOutput =>
                 {
@@ -184,7 +212,7 @@ namespace Baku.VMagicMirror
             }
         }
 
-        //NOTE: fromかtoにFaceSwitch / WtMいずれかの表情が入っている時だけ呼ぶ想定の関数。
+        //NOTE: fromかtoにFaceSwitch, TrackingLost, WtMいずれかの表情が入っている時に呼ぶ想定。
         //ただし、それ以外のケースで呼んでも破綻はしないはず
         public void Accumulate(ExpressionAccumulator accumulator)
         {
@@ -202,11 +230,38 @@ namespace Baku.VMagicMirror
             _eyeBoneAngleSetter.ReserveWeight = NonMouthWeight;
         }
 
+        private void SetTrackingLost(ExpressionKey key)
+        {
+            Write(_trackingLostBlendShapeState, key);
+
+            //NOTE: WtMが適用中の場合、優先度が低いので実際には何もしない
+            if (_toState.Priority > StatePriorityTrackingLostBlendShape)
+            {
+                return;
+            }
+            
+            _toState.CopyTo(_fromState);
+            Write(_toState, key);
+            _faceAppliedCount = 0;
+
+            void Write(State target, ExpressionKey bsKey)
+            {
+                target.IsEmpty = false;
+                target.Weight = 0f;
+                target.Priority = StatePriorityTrackingLostBlendShape;
+                target.Keys.Clear();
+                target.Keys.Add((bsKey, 1f));
+                target.KeepLipSync = false;
+                target.IsBinary =
+                    _hasModel && _expressionMap.TryGet(bsKey, out var clip) && clip.IsBinary;
+            }
+        }
+        
         private void SetFaceSwitch(ExpressionKey key, bool keepLipSync)
         {
             Write(_faceSwitchState, key, keepLipSync);
 
-            //NOTE: WtMが適用中の場合、優先度が低いので実際には何もしない
+            //NOTE: WtM or トラッキングロス表情が適用中の場合、優先度が低いので実際には何もしない
             if (_toState.Priority > StatePriorityFaceSwitch)
             {
                 return;
@@ -254,6 +309,15 @@ namespace Baku.VMagicMirror
             _faceAppliedCount = 0;
         }
 
+        private void SetLowPriorTrackingLostBlendShapeToActive()
+        {
+            _toState.CopyTo(_fromState);
+            //適用待ちの値が書き込み済みなのでそのまま使う
+            _trackingLostBlendShapeState.CopyTo(_toState);
+            _trackingLostBlendShapeState.OverwriteToEmpty();
+            _faceAppliedCount = 0;
+        }
+
         private void SetLowPriorFaceSwitchToActive()
         {
             _toState.CopyTo(_fromState);
@@ -281,11 +345,11 @@ namespace Baku.VMagicMirror
             }
         }
         
-        //NOTE: 「FaceSwitchもWtMも必要ない」という状態はIsEmpty == trueにすることで表現する
+        //NOTE: 「そもそも適用したい表情がない」という状態はIsEmpty == trueにすることで表現する
         class State
         {
             public bool IsEmpty { get; set; }
-            public List<(ExpressionKey, float)> Keys { get; } = new List<(ExpressionKey, float)>(8);
+            public List<(ExpressionKey, float)> Keys { get; } = new(8);
             public bool KeepLipSync { get; set; }
             public bool IsBinary { get; set; }
             public float Weight { get; set; }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeResultSetter.cs
@@ -19,6 +19,7 @@ namespace Baku.VMagicMirror
         private FaceSwitchUpdater _faceSwitchUpdater;
         private WordToMotionBlendShape _wtmBlendShape;
         private VMCPBlendShape _vmcpBlendShape;
+        private TrackingLostBlendShapeSource _trackingLostBlendShapeSource;
         private ExpressionAccumulator _accumulator;
         private UserOperationBlendShapeResultRepository _resultRepository;
         private bool _hasModel;
@@ -31,6 +32,7 @@ namespace Baku.VMagicMirror
             FaceSwitchUpdater faceSwitchUpdater,
             WordToMotionBlendShape wtmBlendShape,
             VMCPBlendShape vmcpBlendShape,
+            TrackingLostBlendShapeSource trackingLostBlendShapeSource,
             ExpressionAccumulator accumulator,
             UserOperationBlendShapeResultRepository resultRepository
             )
@@ -38,13 +40,14 @@ namespace Baku.VMagicMirror
             _faceSwitchUpdater = faceSwitchUpdater;
             _wtmBlendShape = wtmBlendShape;
             _vmcpBlendShape = vmcpBlendShape;
+            _trackingLostBlendShapeSource = trackingLostBlendShapeSource;
             _accumulator = accumulator;
             _resultRepository = resultRepository;
             
             vrmLoadable.VrmLoaded += info => _hasModel = true;
             vrmLoadable.VrmDisposing += () => _hasModel = false;
             
-            blendShapeInterpolator.Setup(faceSwitchUpdater, wtmBlendShape);
+            blendShapeInterpolator.Setup(trackingLostBlendShapeSource, faceSwitchUpdater, wtmBlendShape);
         }
 
         private void LateUpdate()
@@ -108,11 +111,21 @@ namespace Baku.VMagicMirror
                 neutralClipSettings.AccumulateOffsetClip(_accumulator);
                 return;
             }
+
+            // トラッキングロスによる表情が適用 > FaceSwitch以降を無視。
+            // このケースは他のブレンドシェイプを動かすモチベがないので、この状況で追加でAccumulateできるのはOffsetClipだけ
+            if (_trackingLostBlendShapeSource.HasRequest)
+            {
+                _trackingLostBlendShapeSource.Accumulate(_accumulator);
+                neutralClipSettings.AccumulateOffsetClip(_accumulator);
+                return;
+            }
             
             //FaceSwitchが適用 > PerfectSync、Blinkは確定で無視。
             //リップシンクは設定しだいで適用。
             if (_faceSwitchUpdater.HasClipToApply)
             {
+                
                 //NOTE: WtMと同じく、パーフェクトシンクの口と組み合わす場合のコストに多少配慮した書き方。
                 if (!_faceSwitchUpdater.KeepLipSync)
                 {
@@ -183,7 +196,7 @@ namespace Baku.VMagicMirror
         private void WriteClipsWithInterpolation()
         {
             // 補間があるバージョンのポイント:
-            // - FaceSwitch / WtMの現在値は(KeepLipSyncも含めて)使わず、Interpolatorが代行してくれる
+            // - FaceSwitch / FaceTrackingLost / WtMの現在値は(KeepLipSyncも含めて)使わず、Interpolatorが代行してくれる
             // - ゼロ埋めの冗長化回避は無理なので諦めて、全部ゼロ埋めしておく
             // - ふだんの動きを適用するが、そこでは必ずweightが入る
             blendShapeInterpolator.Accumulate(_accumulator);
@@ -243,6 +256,14 @@ namespace Baku.VMagicMirror
             if (_wtmBlendShape.HasBlendShapeToApply)
             {
                 _resultRepository.SetWordToMotionResult(_wtmBlendShape.CurrentValue.CurrentValue);
+            }
+            else if (_trackingLostBlendShapeSource.HasRequest)
+            {
+                var key = _trackingLostBlendShapeSource.ExpressionKey.CurrentValue;
+                if (key.HasValue)
+                {
+                    _resultRepository.SetTrackingLostBlendShapeResult(key.Value);
+                }
             }
             else if (_faceSwitchUpdater.HasClipToApply)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -11,7 +11,7 @@ namespace Baku.VMagicMirror
     /// <summary>
     /// 顔トラッキングを行う設定であり、かつそのトラッキングがロストしているときに適用したいブレンドシェイプ情報を出力するようなクラス
     /// </summary>
-    public class TrackingLostBlendShapeSource : IInitializable, ITickable, IDisposable
+    public class TrackingLostBlendShapeSource : PresenterBase, ITickable
     {
         private const float TrackingLostThreshold = 1.0f;
         private readonly IMessageReceiver _receiver;
@@ -20,13 +20,12 @@ namespace Baku.VMagicMirror
         private readonly MediaPipeKinematicSetter _mediaPipeKinematicSetter;
         private readonly ExternalTrackerDataSource _externalTrackerDataSource;
         
-        private readonly CompositeDisposable _disposable = new();
-
         // 「トラッキングロス時にブレンドシェイプを利かす」という処理自体が有効かどうかのフラグ
         private readonly ReactiveProperty<bool> _isFeatureEnabled = new(false);
         private readonly ReactiveProperty<string> _cameraDeviceName = new("");
 
         private bool _isActive;
+        private bool _trackingSucceedAtLeastOnce;
         private float _trackingLostTime;
         // とりあえずBlinkで決め打つが、GUIで選ばせるように拡張してもよいつもり
         // public ExpressionKey ExpressionKey { get; } = ExpressionKey.Blink;
@@ -56,11 +55,15 @@ namespace Baku.VMagicMirror
             }
         }
 
-        void IInitializable.Initialize()
+        public override void Initialize()
         {
             _receiver.BindBoolProperty(VmmCommands.EnableFaceTrackingLostBlendShape, _isFeatureEnabled);
             _receiver.BindStringProperty(VmmCommands.SetCameraDeviceName, _cameraDeviceName);
 
+            _config.HeadMotionControlMode
+                .Subscribe(_ => _trackingSucceedAtLeastOnce = false)
+                .AddTo(this);
+            
             _isFeatureEnabled.CombineLatest(
                 _config.HeadMotionControlMode,
                 _cameraDeviceName, 
@@ -79,7 +82,7 @@ namespace Baku.VMagicMirror
                     };
                     
                 })
-                .AddTo(_disposable);
+                .AddTo(this);
         }
 
         void ITickable.Tick()
@@ -87,6 +90,7 @@ namespace Baku.VMagicMirror
             if (!_isActive)
             {
                 _trackingLostTime = 0f;
+                _trackingSucceedAtLeastOnce = false;
                 _expressionKey.Value = null;
                 return;
             }
@@ -98,18 +102,25 @@ namespace Baku.VMagicMirror
             if (tracked)
             {
                 _trackingLostTime = 0f;
+                _trackingSucceedAtLeastOnce = true;
                 _expressionKey.Value = null;
                 return;
             }
 
+            // トラッキングに1回も成功してないうちは目は閉じないでおく (顔トラできててロスしたのと区別する)
+            if (!_trackingSucceedAtLeastOnce)
+            {
+                _trackingLostTime = 0f;
+                _expressionKey.Value = null;
+                return;
+            }
+            
             _trackingLostTime += Time.deltaTime;
             if (_trackingLostTime >= TrackingLostThreshold)
             {
                 _expressionKey.Value = UniVRM10.ExpressionKey.Blink;
             }
         }
-        
-        void IDisposable.Dispose() => _disposable.Dispose();
     }
 }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -53,7 +53,7 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class TrackingLostBlendShapeSource : PresenterBase, ITickable
     {
-        private const float TrackingLostThreshold = 1.0f;
+        private const float TrackingLostThreshold = 3.0f;
         
         // トラッキングがこの時間だけ成功し続けると _trackingSucceedAtLeastOnce を true にする。
         // なぜ1Fの判定じゃダメかというと、

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -1,0 +1,118 @@
+using System;
+using Baku.VMagicMirror.ExternalTracker;
+using Baku.VMagicMirror.MediaPipeTracker;
+using R3;
+using UnityEngine;
+using UniVRM10;
+using Zenject;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// 顔トラッキングを行う設定であり、かつそのトラッキングがロストしているときに適用したいブレンドシェイプ情報を出力するようなクラス
+    /// </summary>
+    public class TrackingLostBlendShapeSource : IInitializable, ITickable, IDisposable
+    {
+        // TODO:
+        // - このクラスをBlendShapeResultSetterから読み取り「FaceSwitchに準ずるがFaceSwitchよりは優先」という位置づけで適用する
+
+        private const float TrackingLostThreshold = 0.5f;
+        private readonly IMessageReceiver _receiver;
+        private readonly FaceControlConfiguration _config;
+
+        private readonly MediaPipeFacialValueRepository _mediaPipeFacialValueRepository;
+        private readonly ExternalTrackerDataSource _externalTrackerDataSource;
+        
+        private readonly CompositeDisposable _disposable = new();
+
+        // 「トラッキングロス時にブレンドシェイプを利かす」という処理自体が有効かどうかのフラグ
+        private readonly ReactiveProperty<bool> _isFeatureEnabled = new(false);
+        private readonly ReactiveProperty<string> _cameraDeviceName = new("");
+
+        private bool _isActive;
+        private float _trackingLostTime;
+        // とりあえずBlinkで決め打つが、GUIで選ばせるように拡張してもよいつもり
+        // public ExpressionKey ExpressionKey { get; } = ExpressionKey.Blink;
+        private readonly ReactiveProperty<ExpressionKey?> _expressionKey = new(null);
+        public ReadOnlyReactiveProperty<ExpressionKey?> ExpressionKey => _expressionKey;
+        
+        public TrackingLostBlendShapeSource(
+            IMessageReceiver receiver,
+            FaceControlConfiguration config,
+            MediaPipeFacialValueRepository mediaPipeFacialValueRepository,
+            ExternalTrackerDataSource externalTrackerDataSource)
+        {
+            _receiver = receiver;
+            _config = config;
+            _mediaPipeFacialValueRepository = mediaPipeFacialValueRepository;
+            _externalTrackerDataSource = externalTrackerDataSource;
+        }
+
+        public bool HasRequest => _expressionKey.CurrentValue.HasValue;
+
+        public void Accumulate(ExpressionAccumulator accumulator, float weight = 1f)
+        {
+            if (_expressionKey.CurrentValue.HasValue)
+            {
+                accumulator.Accumulate(_expressionKey.CurrentValue.Value, weight);
+            }
+        }
+
+        void IInitializable.Initialize()
+        {
+            _receiver.BindBoolProperty(VmmCommands.EnableFaceTrackingLostBlendShape, _isFeatureEnabled);
+            _receiver.BindStringProperty(VmmCommands.SetCameraDeviceName, _cameraDeviceName);
+
+            _isFeatureEnabled.CombineLatest(
+                _config.HeadMotionControlMode,
+                _cameraDeviceName, 
+                    (enabled, mode, cameraName) => (enabled, mode, cameraName)
+                )
+                .DistinctUntilChanged()
+                .Subscribe(value =>
+                {
+                    // NOTE: VMCProtocolの受信が絡むケースはトラッキングロスの概念が扱いにくいので考えないことにする
+                    _isActive = value.enabled && value.mode switch
+                    {
+                        FaceControlModes.ExternalTracker => true,
+                        FaceControlModes.WebCamHighPower or FaceControlModes.WebCamLowPower
+                            => !string.IsNullOrEmpty(value.cameraName),
+                        _ => false,
+                    };
+                    
+                })
+                .AddTo(_disposable);
+        }
+
+        void ITickable.Tick()
+        {
+            if (!_isActive)
+            {
+                _trackingLostTime = 0f;
+                _expressionKey.Value = null;
+                return;
+            }
+            
+            var tracked = _config.HeadMotionControlMode.CurrentValue is FaceControlModes.ExternalTracker
+                ? _externalTrackerDataSource.Connected 
+                : _mediaPipeFacialValueRepository.IsTracked;
+
+            if (tracked)
+            {
+                _trackingLostTime = 0f;
+                _expressionKey.Value = null;
+                return;
+            }
+
+            _trackingLostTime += Time.deltaTime;
+            if (_trackingLostTime >= TrackingLostThreshold)
+            {
+                _expressionKey.Value = UniVRM10.ExpressionKey.Blink;
+            }
+        }
+        
+        void IDisposable.Dispose() => _disposable.Dispose();
+    }
+}
+
+

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -8,6 +8,34 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
+    [Serializable]
+    public sealed class TrackingLostFaceSwitchSetting
+    {
+        [SerializeField] private string clipName = "";
+        [SerializeField] private string accessoryName = "";
+        
+        public string ClipName => clipName;
+        public string AccessoryName => accessoryName;
+        
+        public static TrackingLostFaceSwitchSetting Default { get; } = new();
+
+        public static TrackingLostFaceSwitchSetting FromJson(string json)
+        {
+            try
+            {
+                return JsonUtility.FromJson<TrackingLostFaceSwitchSetting>(json);
+            }
+            catch (Exception ex)
+            {
+                LogOutput.Instance.Write(ex);
+                return Default;
+            }
+        }
+     
+        public bool HasClipName => !string.IsNullOrEmpty(ClipName);
+        public bool HasValue => !string.IsNullOrEmpty(ClipName) || !string.IsNullOrEmpty(AccessoryName);
+    }
+    
     /// <summary>
     /// 顔トラッキングを行う設定であり、かつそのトラッキングがロストしているときに適用したいブレンドシェイプ情報を出力するようなクラス
     /// </summary>
@@ -26,7 +54,10 @@ namespace Baku.VMagicMirror
         private readonly MediaPipeKinematicSetter _mediaPipeKinematicSetter;
         private readonly ExternalTrackerDataSource _externalTrackerDataSource;
         
-        // 「トラッキングロス時にブレンドシェイプを利かす」という処理自体が有効かどうかのフラグ
+        private TrackingLostFaceSwitchSetting _trackingLostFaceSwitchSetting;
+        private ExpressionKey? _settingBasedKey;
+        
+        // 「トラッキングロス時にブレンドシェイプを利かす」という処理自体が有効かどうかのフラグはsettingの内容から定まる
         private readonly ReactiveProperty<bool> _isFeatureEnabled = new(false);
         private readonly ReactiveProperty<string> _cameraDeviceName = new("");
 
@@ -34,11 +65,6 @@ namespace Baku.VMagicMirror
         private bool _trackingSucceedAtLeastOnce;
         private float _trackedTime;
         private float _trackingLostTime;
-
-        // とりあえずBlinkで決め打つが、GUIで選ばせるように拡張してもよいつもり
-        // public ExpressionKey ExpressionKey { get; } = ExpressionKey.Blink;
-        private readonly ReactiveProperty<ExpressionKey?> _expressionKey = new(null);
-        public ReadOnlyReactiveProperty<ExpressionKey?> ExpressionKey => _expressionKey;
         
         [Inject]
         public TrackingLostBlendShapeSource(
@@ -55,17 +81,32 @@ namespace Baku.VMagicMirror
 
         public bool HasRequest => _expressionKey.CurrentValue.HasValue;
 
-        public void Accumulate(ExpressionAccumulator accumulator, float weight = 1f)
+        private readonly ReactiveProperty<ExpressionKey?> _expressionKey = new(null);
+        public ReadOnlyReactiveProperty<ExpressionKey?> ExpressionKey => _expressionKey;
+
+        private readonly ReactiveProperty<string> _accessoryNameRequest = new("");
+        public ReadOnlyReactiveProperty<string> AccessoryNameRequest => _accessoryNameRequest;
+
+        public void Accumulate(ExpressionAccumulator accumulator)
         {
             if (_expressionKey.CurrentValue.HasValue)
             {
-                accumulator.Accumulate(_expressionKey.CurrentValue.Value, weight);
+                accumulator.Accumulate(_expressionKey.CurrentValue.Value, 1f);
             }
         }
 
         public override void Initialize()
         {
-            _receiver.BindBoolProperty(VmmCommands.EnableFaceTrackingLostBlendShape, _isFeatureEnabled);
+            _receiver.AssignCommandHandler(
+                VmmCommands.SetTrackingLostFaceSwitchSetting, v =>
+                {
+                    _trackingLostFaceSwitchSetting = TrackingLostFaceSwitchSetting.FromJson(v.GetStringValue());
+                    _isFeatureEnabled.Value = _trackingLostFaceSwitchSetting.HasValue;
+                    
+                    _settingBasedKey = _trackingLostFaceSwitchSetting.HasClipName
+                        ? ExpressionKeyUtils.CreateKeyByName(_trackingLostFaceSwitchSetting.ClipName)
+                        : null;
+                });
             _receiver.BindStringProperty(VmmCommands.SetCameraDeviceName, _cameraDeviceName);
 
             _config.HeadMotionControlMode
@@ -100,6 +141,7 @@ namespace Baku.VMagicMirror
                 _trackingLostTime = 0f;
                 _trackingSucceedAtLeastOnce = false;
                 _expressionKey.Value = null;
+                _accessoryNameRequest.Value = "";
                 return;
             }
             
@@ -126,13 +168,15 @@ namespace Baku.VMagicMirror
             {
                 _trackingLostTime = 0f;
                 _expressionKey.Value = null;
+                _accessoryNameRequest.Value = "";
                 return;
             }
             
             _trackingLostTime += Time.deltaTime;
             if (_trackingLostTime >= TrackingLostThreshold)
             {
-                _expressionKey.Value = UniVRM10.ExpressionKey.Blink;
+                _expressionKey.Value = _settingBasedKey;
+                _accessoryNameRequest.Value = _trackingLostFaceSwitchSetting.AccessoryName;
             }
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -36,6 +36,7 @@ namespace Baku.VMagicMirror
         private readonly ReactiveProperty<ExpressionKey?> _expressionKey = new(null);
         public ReadOnlyReactiveProperty<ExpressionKey?> ExpressionKey => _expressionKey;
         
+        [Inject]
         public TrackingLostBlendShapeSource(
             IMessageReceiver receiver,
             FaceControlConfiguration config,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -14,7 +14,18 @@ namespace Baku.VMagicMirror
         [SerializeField] private string clipName = "";
         [SerializeField] private string accessoryName = "";
         
-        public string ClipName => clipName;
+        [NonSerialized] private string _filteredClipName = null;
+        public string ClipName
+        {
+            get
+            {
+                if (_filteredClipName == null)
+                {
+                    _filteredClipName = BlendShapeCompatUtil.GetVrm10ClipName(clipName);
+                }
+                return _filteredClipName;
+            }
+        }
         public string AccessoryName => accessoryName;
         
         public static TrackingLostFaceSwitchSetting Default { get; } = new();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -13,14 +13,11 @@ namespace Baku.VMagicMirror
     /// </summary>
     public class TrackingLostBlendShapeSource : IInitializable, ITickable, IDisposable
     {
-        // TODO:
-        // - このクラスをBlendShapeResultSetterから読み取り「FaceSwitchに準ずるがFaceSwitchよりは優先」という位置づけで適用する
-
-        private const float TrackingLostThreshold = 0.5f;
+        private const float TrackingLostThreshold = 1.0f;
         private readonly IMessageReceiver _receiver;
         private readonly FaceControlConfiguration _config;
 
-        private readonly MediaPipeFacialValueRepository _mediaPipeFacialValueRepository;
+        private readonly MediaPipeKinematicSetter _mediaPipeKinematicSetter;
         private readonly ExternalTrackerDataSource _externalTrackerDataSource;
         
         private readonly CompositeDisposable _disposable = new();
@@ -40,12 +37,12 @@ namespace Baku.VMagicMirror
         public TrackingLostBlendShapeSource(
             IMessageReceiver receiver,
             FaceControlConfiguration config,
-            MediaPipeFacialValueRepository mediaPipeFacialValueRepository,
+            MediaPipeKinematicSetter mediaPipeKinematicSetter,
             ExternalTrackerDataSource externalTrackerDataSource)
         {
             _receiver = receiver;
             _config = config;
-            _mediaPipeFacialValueRepository = mediaPipeFacialValueRepository;
+            _mediaPipeKinematicSetter = mediaPipeKinematicSetter;
             _externalTrackerDataSource = externalTrackerDataSource;
         }
 
@@ -96,7 +93,7 @@ namespace Baku.VMagicMirror
             
             var tracked = _config.HeadMotionControlMode.CurrentValue is FaceControlModes.ExternalTracker
                 ? _externalTrackerDataSource.Connected 
-                : _mediaPipeFacialValueRepository.IsTracked;
+                : _mediaPipeKinematicSetter.TryGetHeadPose(out _);
 
             if (tracked)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -38,6 +38,7 @@ namespace Baku.VMagicMirror
     
     /// <summary>
     /// 顔トラッキングを行う設定であり、かつそのトラッキングがロストしているときに適用したいブレンドシェイプ情報を出力するようなクラス
+    /// 名前に反するがBlendShapeに加えてAccessoryの表示リクエストも出力する
     /// </summary>
     public class TrackingLostBlendShapeSource : PresenterBase, ITickable
     {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs
@@ -14,6 +14,12 @@ namespace Baku.VMagicMirror
     public class TrackingLostBlendShapeSource : PresenterBase, ITickable
     {
         private const float TrackingLostThreshold = 1.0f;
+        
+        // トラッキングがこの時間だけ成功し続けると _trackingSucceedAtLeastOnce を true にする。
+        // なぜ1Fの判定じゃダメかというと、
+        // 「顔が検出できてない状態でiFacialMocapが送ってくるデータ」をトラッキングロスト扱いする判定に時間がかかるから
+        private const float TrackingFirstSucceedDuration = 1.0f;
+        
         private readonly IMessageReceiver _receiver;
         private readonly FaceControlConfiguration _config;
 
@@ -26,7 +32,9 @@ namespace Baku.VMagicMirror
 
         private bool _isActive;
         private bool _trackingSucceedAtLeastOnce;
+        private float _trackedTime;
         private float _trackingLostTime;
+
         // とりあえずBlinkで決め打つが、GUIで選ばせるように拡張してもよいつもり
         // public ExpressionKey ExpressionKey { get; } = ExpressionKey.Blink;
         private readonly ReactiveProperty<ExpressionKey?> _expressionKey = new(null);
@@ -99,16 +107,22 @@ namespace Baku.VMagicMirror
                 ? _externalTrackerDataSource.Connected 
                 : _mediaPipeKinematicSetter.TryGetHeadPose(out _);
 
-            if (tracked)
+            if (tracked && !_trackingSucceedAtLeastOnce)
             {
-                _trackingLostTime = 0f;
-                _trackingSucceedAtLeastOnce = true;
-                _expressionKey.Value = null;
-                return;
+                _trackedTime += Time.deltaTime;
+                if (_trackedTime >= TrackingFirstSucceedDuration)
+                {
+                    _trackingSucceedAtLeastOnce = true;
+                }
             }
 
-            // トラッキングに1回も成功してないうちは目は閉じないでおく (顔トラできててロスしたのと区別する)
-            if (!_trackingSucceedAtLeastOnce)
+            if (!tracked)
+            {
+                _trackedTime = 0f;
+            }
+            
+            // トラッキングに1回成功するまではトラッキングロストしててもBlendShapeが作動しない
+            if (tracked || !_trackingSucceedAtLeastOnce)
             {
                 _trackingLostTime = 0f;
                 _expressionKey.Value = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/TrackingLostBlendShapeSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09bed0735038da546a0e2da5cbb737e7

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/UserOperationBlendShapeResultRepository.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/UserOperationBlendShapeResultRepository.cs
@@ -73,6 +73,16 @@ namespace Baku.VMagicMirror
         }
 
         /// <summary>
+        /// トラッキングロス処理に由来したブレンドシェイプをアクティブな表情として扱う
+        /// </summary>
+        /// <param name="value"></param>
+        public void SetTrackingLostBlendShapeResult(ExpressionKey value)
+        {
+            HasActiveKey = true;
+            ActiveKey = value;
+        }
+        
+        /// <summary>
         /// FaceSwitchの適用状況を指定することで、そのExpressionKeyがアクティブな表情という扱いにする
         /// </summary>
         /// <param name="content"></param>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MonitoringInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MonitoringInstaller.cs
@@ -27,6 +27,7 @@ namespace Baku.VMagicMirror.Installer
             container.BindInterfacesAndSelfTo<FaceSwitchUpdater>().AsSingle();
             container.BindInstance(gamepadListener);
             container.BindInstance(midiInputObserver);
+            container.BindInterfacesAndSelfTo<TrackingLostBlendShapeSource>().AsSingle();
 
             //終了前に監視処理を安全にストップさせたいものは呼んでおく
             container.Bind<IReleaseBeforeQuit>()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -117,7 +117,7 @@
         FaceOffsetClip,
         EnableEyeMotionDuringClipApplied,
         DisableBlendShapeInterpolate,
-        EnableFaceTrackingLostBlendShape,
+        SetTrackingLostFaceSwitchSetting,
 
         // Motion, Face, WebCam high power mode
         EnableWebCamHighPowerMode,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -117,6 +117,7 @@
         FaceOffsetClip,
         EnableEyeMotionDuringClipApplied,
         DisableBlendShapeInterpolate,
+        EnableFaceTrackingLostBlendShape,
 
         // Motion, Face, WebCam high power mode
         EnableWebCamHighPowerMode,

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -41,6 +41,7 @@
         public bool EnableBlinkAdjust { get; set; } = true;
 
         public bool EnableVoiceBasedMotion { get; set; } = true;
+        public bool EnableTrackingLostBlendShape { get; set; } = false;
 
         public bool DisableFaceTrackingHorizontalFlip { get; set; } = false;
 
@@ -153,6 +154,7 @@
             EnableBodyLeanZ = false;
 
             EnableVoiceBasedMotion = true;
+            EnableTrackingLostBlendShape = false;
             DisableFaceTrackingHorizontalFlip = false;
             EnableImageBasedHandTracking = false;
             EnableImageBasedElbowTracking = false;

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -41,7 +41,7 @@
         public bool EnableBlinkAdjust { get; set; } = true;
 
         public bool EnableVoiceBasedMotion { get; set; } = true;
-        public bool EnableTrackingLostBlendShape { get; set; } = false;
+        public string SerializedTrackingLostFaceSwitchSetting { get; set; } = "";
 
         public bool DisableFaceTrackingHorizontalFlip { get; set; } = false;
 
@@ -154,7 +154,7 @@
             EnableBodyLeanZ = false;
 
             EnableVoiceBasedMotion = true;
-            EnableTrackingLostBlendShape = false;
+            SerializedTrackingLostFaceSwitchSetting = "";
             DisableFaceTrackingHorizontalFlip = false;
             EnableImageBasedHandTracking = false;
             EnableImageBasedElbowTracking = false;

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -123,6 +123,8 @@ namespace Baku.VMagicMirrorConfig
         public static Message EnableLipSyncBasedBlinkAdjust(bool enable) => BoolContent(VmmCommands.EnableLipSyncBasedBlinkAdjust, enable);
         public static Message EnableHeadRotationBasedBlinkAdjust(bool enable) => BoolContent(VmmCommands.EnableHeadRotationBasedBlinkAdjust, enable);
         public static Message EnableVoiceBasedMotion(bool enable) => BoolContent(VmmCommands.EnableVoiceBasedMotion, enable);
+        public static Message EnableTrackingLostBlendShape(bool enable) => BoolContent(VmmCommands.EnableFaceTrackingLostBlendShape, enable);
+
         //NOTE: falseのほうが普通だよ、という状態にするため、disable云々というやや面倒な言い方になってる事に注意
         public static Message DisableFaceTrackingHorizontalFlip(bool disable) => BoolContent(VmmCommands.DisableFaceTrackingHorizontalFlip, disable);
 

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -123,7 +123,7 @@ namespace Baku.VMagicMirrorConfig
         public static Message EnableLipSyncBasedBlinkAdjust(bool enable) => BoolContent(VmmCommands.EnableLipSyncBasedBlinkAdjust, enable);
         public static Message EnableHeadRotationBasedBlinkAdjust(bool enable) => BoolContent(VmmCommands.EnableHeadRotationBasedBlinkAdjust, enable);
         public static Message EnableVoiceBasedMotion(bool enable) => BoolContent(VmmCommands.EnableVoiceBasedMotion, enable);
-        public static Message EnableTrackingLostBlendShape(bool enable) => BoolContent(VmmCommands.EnableFaceTrackingLostBlendShape, enable);
+        public static Message SetTrackingLostFaceSwitchSetting(string v) => StringContent(VmmCommands.SetTrackingLostFaceSwitchSetting, v);
 
         //NOTE: falseのほうが普通だよ、という状態にするため、disable云々というやや面倒な言い方になってる事に注意
         public static Message DisableFaceTrackingHorizontalFlip(bool disable) => BoolContent(VmmCommands.DisableFaceTrackingHorizontalFlip, disable);

--- a/WPF/VMagicMirrorConfig/Model/MessageData/TrackingLostFaceSwitchSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/MessageData/TrackingLostFaceSwitchSetting.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Baku.VMagicMirrorConfig
+{
+    /// <summary>
+    /// トラッキングロストしたときの表情の設定に関するクラス。
+    /// <see cref="ExternalTrackerFaceSwitchItem"/> から不要なものを削ったような内容になっている
+    /// </summary>
+    public class TrackingLostFaceSwitchSetting
+    {
+        /// <summary> 条件に合致したとき動かすBlendShapeClipの名前 </summary>
+        [JsonProperty("clipName")]
+        public string ClipName { get; set; } = "";
+
+        /// <summary>
+        /// 条件を満たしているときのみ表示するアクセサリーがある場合、その名前。何もしない場合は空文字。
+        /// </summary>
+        [JsonProperty("accessoryName")]
+        public string AccessoryName { get; set; } = "";
+
+        public static TrackingLostFaceSwitchSetting FromJson(string json)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(json))
+                {
+                    return new();
+                }
+
+                return JsonConvert.DeserializeObject<TrackingLostFaceSwitchSetting>(json) ?? new();
+            }
+            catch (Exception ex)
+            {
+                LogOutput.Instance.Write(ex);
+                return new();
+            }
+        }
+
+        public string ToJson() => JsonConvert.SerializeObject(this);
+    }
+}

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -50,6 +50,7 @@ namespace Baku.VMagicMirrorConfig
                 SendMessage(MessageFactory.EnableLipSyncBasedBlinkAdjust(v));
             });
             EnableVoiceBasedMotion = new RProperty<bool>(setting.EnableVoiceBasedMotion, v => SendMessage(MessageFactory.EnableVoiceBasedMotion(v)));
+            EnableTrackingLostBlendShape = new RProperty<bool>(setting.EnableTrackingLostBlendShape, v => SendMessage(MessageFactory.EnableTrackingLostBlendShape(v)));
             DisableFaceTrackingHorizontalFlip = new RProperty<bool>(setting.DisableFaceTrackingHorizontalFlip, v => SendMessage(MessageFactory.DisableFaceTrackingHorizontalFlip(v)));
 
             EnableWebCamHighPowerMode = new RProperty<bool>(setting.EnableWebCamHighPowerMode, v => SendMessage(MessageFactory.EnableWebCamHighPowerMode(v)));
@@ -204,6 +205,7 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<bool> EnableBlinkAdjust { get; }
 
         public RProperty<bool> EnableVoiceBasedMotion { get; }
+        public RProperty<bool> EnableTrackingLostBlendShape { get; }
 
         public RProperty<bool> DisableFaceTrackingHorizontalFlip { get; }
 
@@ -315,6 +317,7 @@ namespace Baku.VMagicMirrorConfig
             AutoBlinkDuringFaceTracking.Value = setting.AutoBlinkDuringFaceTracking;
 
             EnableVoiceBasedMotion.Value = setting.EnableVoiceBasedMotion;
+            EnableTrackingLostBlendShape.Value = setting.EnableTrackingLostBlendShape;
             DisableFaceTrackingHorizontalFlip.Value = setting.DisableFaceTrackingHorizontalFlip;
             EnableImageBasedHandTracking.Value = setting.EnableImageBasedHandTracking;
             EnableImageBasedElbowTracking.Value = setting.EnableImageBasedElbowTracking;

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -50,7 +50,9 @@ namespace Baku.VMagicMirrorConfig
                 SendMessage(MessageFactory.EnableLipSyncBasedBlinkAdjust(v));
             });
             EnableVoiceBasedMotion = new RProperty<bool>(setting.EnableVoiceBasedMotion, v => SendMessage(MessageFactory.EnableVoiceBasedMotion(v)));
-            EnableTrackingLostBlendShape = new RProperty<bool>(setting.EnableTrackingLostBlendShape, v => SendMessage(MessageFactory.EnableTrackingLostBlendShape(v)));
+            SerializedTrackingLostFaceSwitchSetting = new RProperty<string>(
+                setting.SerializedTrackingLostFaceSwitchSetting,
+                v => SendMessage(MessageFactory.SetTrackingLostFaceSwitchSetting(v)));
             DisableFaceTrackingHorizontalFlip = new RProperty<bool>(setting.DisableFaceTrackingHorizontalFlip, v => SendMessage(MessageFactory.DisableFaceTrackingHorizontalFlip(v)));
 
             EnableWebCamHighPowerMode = new RProperty<bool>(setting.EnableWebCamHighPowerMode, v => SendMessage(MessageFactory.EnableWebCamHighPowerMode(v)));
@@ -205,7 +207,7 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<bool> EnableBlinkAdjust { get; }
 
         public RProperty<bool> EnableVoiceBasedMotion { get; }
-        public RProperty<bool> EnableTrackingLostBlendShape { get; }
+        public RProperty<string> SerializedTrackingLostFaceSwitchSetting { get; }
 
         public RProperty<bool> DisableFaceTrackingHorizontalFlip { get; }
 
@@ -317,7 +319,6 @@ namespace Baku.VMagicMirrorConfig
             AutoBlinkDuringFaceTracking.Value = setting.AutoBlinkDuringFaceTracking;
 
             EnableVoiceBasedMotion.Value = setting.EnableVoiceBasedMotion;
-            EnableTrackingLostBlendShape.Value = setting.EnableTrackingLostBlendShape;
             DisableFaceTrackingHorizontalFlip.Value = setting.DisableFaceTrackingHorizontalFlip;
             EnableImageBasedHandTracking.Value = setting.EnableImageBasedHandTracking;
             EnableImageBasedElbowTracking.Value = setting.EnableImageBasedElbowTracking;
@@ -397,6 +398,7 @@ namespace Baku.VMagicMirrorConfig
             ResetArmSetting();
             ResetHandSetting();
             ResetWaitMotionSetting();
+            ResetTrackingLostFaceSwitchSetting();
         }
 
         #endregion
@@ -443,6 +445,11 @@ namespace Baku.VMagicMirrorConfig
             DisableFaceTrackingHorizontalFlip.Value = setting.DisableFaceTrackingHorizontalFlip;
             EnableWebCameraHighPowerModeLipSync.Value = setting.EnableWebCameraHighPowerModeLipSync;
             EnableBodyLeanZ.Value = setting.EnableBodyLeanZ;
+        }
+
+        public void ResetTrackingLostFaceSwitchSetting()
+        {
+            SerializedTrackingLostFaceSwitchSetting.Value = MotionSetting.Default.SerializedTrackingLostFaceSwitchSetting;
         }
     }
 }

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -463,6 +463,7 @@ If the face tracking works correctly, please ignore this warning.
     
     <sys:String x:Key="Motion_Face_BlinkAdjust">Blink adjust by head motion and lip sync</sys:String>
     <sys:String x:Key="Motion_Face_NoCamMotion">Voice based motion when webcam not used</sys:String>
+    <sys:String x:Key="Motion_Face_EnableTrackingLostBlendShape">Close eyes when camera tracking is lost</sys:String>
 
     <!-- Face : Eye -->
     <sys:String x:Key="Motion_Eye">Eye</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -143,7 +143,9 @@
     <sys:String x:Key="FaceSwitch_Notice_WebCamHighPower">Web Camera (High Power) does not detect "Cheek puff" and "Tongue Out" conditions.</sys:String>
     
     <sys:String x:Key="ExTracker_FaceSwitch_Instruction" xml:space="preserve">Activates seleceted BlendShape by making specific face expression.
-Check "Keep LipSync" to make the lipsync continue.</sys:String>
+Check "Keep LipSync" to make the lipsync continue.
+
+Also expression can be applied when face tracking is lost.</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_ShowAccessoryOption">Show Accessory Option</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_AccessoryLabel">Accessory:</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_KeepLipSync">Keep LipSync</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -135,8 +135,10 @@
     
     <sys:String x:Key="ExTracker_FaceSwitch">Face Switch</sys:String>
 
-    <sys:String x:Key="FaceSwitch_Notice_WebCamLowPower" xml:space="preserve">Web Camera (Lite) does not detect facial data for this feature.
-If VMC Protocol is active and it receives perfect sync facial data, then Face Switch will work based on the data.</sys:String>
+    <sys:String x:Key="FaceSwitch_Notice_WebCamLowPower" xml:space="preserve">Web Camera (Lite) can only use following features:
+
+- Tracking lost detection
+- Face Switch input data receive via VMC Protocol</sys:String>
 
     <sys:String x:Key="FaceSwitch_Notice_WebCamHighPower">Web Camera (High Power) does not detect "Cheek puff" and "Tongue Out" conditions.</sys:String>
     
@@ -154,7 +156,9 @@ Check "Keep LipSync" to make the lipsync continue.</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_Trigger_browDown">Brow down</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_Trigger_tongueOut">Tongue out</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_Trigger_cheekPuff">Cheek puff</sys:String>
-    
+
+    <sys:String x:Key="ExTracker_FaceSwitch_SpecialTrigger_TrackingLost">Tracking is lost</sys:String>
+
     <!-- Face Tracker Eye Calibration -->
     <sys:String x:Key="EyeCalibration_Header">Blink Tracking Settings</sys:String>
     <sys:String x:Key="EyeCalibration_Instruction" xml:space="preserve">This window supports settings about blink tracking handling.

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -144,7 +144,10 @@
     <sys:String x:Key="FaceSwitch_Notice_WebCamHighPower">Webカメラ (高品質) の使用中は、「頬をふくらませる」と「舌を出す」の表情は検出されません。</sys:String>
     
     <sys:String x:Key="ExTracker_FaceSwitch_Instruction" xml:space="preserve">顔をはっきりと特定の表情にすることでアバターの表情を切り替えます。
-「リップシンクを続行」をオンにすると、表情を切り替えたままリップシンクを動かせます。</sys:String>
+「リップシンクを続行」をオンにすると、表情を切り替えたままリップシンクを動かせます。
+
+また、顔トラッキングが外れて一定時間が経過したときの表情も指定できます。
+</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_ShowAccessoryOption">アクセサリーオプションを表示</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_AccessoryLabel">アクセサリー:</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_KeepLipSync">リップシンクを続行</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -136,8 +136,10 @@
 
     <sys:String x:Key="ExTracker_FaceSwitch">表情スイッチ</sys:String>
     
-    <sys:String x:Key="FaceSwitch_Notice_WebCamLowPower" xml:space="preserve">Webカメラ (軽量) では表情を検出できないため、この機能は動作しません。
-ただし、VMC Protocolでパーフェクトシンク用の表情を受信している場合、その表情にもとづいて表情スイッチが適用されます。</sys:String>
+    <sys:String x:Key="FaceSwitch_Notice_WebCamLowPower" xml:space="preserve">Webカメラ (軽量) の使用中は本機能は制限され、下記のみが利用できます。
+
+- トラッキングロスト時の表情の切り替え
+- VMC Protocolで表情データを受信することによる表情の切り替え</sys:String>
 
     <sys:String x:Key="FaceSwitch_Notice_WebCamHighPower">Webカメラ (高品質) の使用中は、「頬をふくらませる」と「舌を出す」の表情は検出されません。</sys:String>
     
@@ -156,6 +158,8 @@
     <sys:String x:Key="ExTracker_FaceSwitch_Trigger_browDown">眉を下げると</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_Trigger_tongueOut">舌を出すと</sys:String>
     <sys:String x:Key="ExTracker_FaceSwitch_Trigger_cheekPuff">頬をふくらませると</sys:String>
+
+    <sys:String x:Key="ExTracker_FaceSwitch_SpecialTrigger_TrackingLost">顔トラッキングが外れたとき</sys:String>
 
     <!-- Face Tracker Eye Calibration -->
     <sys:String x:Key="EyeCalibration_Header">目のトラッキングの詳細設定</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -462,6 +462,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     
     <sys:String x:Key="Motion_Face_BlinkAdjust">顔の動きや声でまばたきを補正</sys:String>
     <sys:String x:Key="Motion_Face_NoCamMotion">カメラ非使用時、音声ベースでアバターを動かす</sys:String>
+    <sys:String x:Key="Motion_Face_EnableTrackingLostBlendShape">カメラでのトラッキングが途切れたら目を閉じる</sys:String>
             
     <!-- Face : Eye -->
     <sys:String x:Key="Motion_Eye">目・視線</sys:String>

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/FaceTrackerPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/FaceTrackerPanel.xaml
@@ -575,6 +575,10 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+                    <view:TrackingLostFaceSwitchSetting 
+                        Margin="15,5"
+                        DataContext="{Binding TrackingLostFaceSwitch}"
+                        />
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/WPF/VMagicMirrorConfig/View/FaceTracker/TrackingLostFaceSwitchSetting.xaml
+++ b/WPF/VMagicMirrorConfig/View/FaceTracker/TrackingLostFaceSwitchSetting.xaml
@@ -1,0 +1,70 @@
+﻿<UserControl x:Class="Baku.VMagicMirrorConfig.View.TrackingLostFaceSwitchSetting"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:md="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:view="clr-namespace:Baku.VMagicMirrorConfig.View"
+             xmlns:vm="clr-namespace:Baku.VMagicMirrorConfig.ViewModel"
+             xmlns:vmm="clr-namespace:Baku.VMagicMirrorConfig"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance Type={x:Type vm:TrackingLostFaceSwitchViewModel}}"             
+             d:DesignWidth="450">
+    <UserControl.Resources>
+        <view:Vrm1BlendShapeNameOrDoNothingConverter x:Key="Vrm1BlendShapeNameOrDoNothingConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <!-- FaceSwitchTemplateItemと暗黙にレイアウトを揃えたい都合で余計なColumnがある -->
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="80"/>
+            <ColumnDefinition Width="120"/>
+            <ColumnDefinition/>
+            <ColumnDefinition Width="100"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2"
+                   Margin="10,0"
+                   TextAlignment="Right"
+                    Text="{DynamicResource ExTracker_FaceSwitch_SpecialTrigger_TrackingLost}"/>
+
+        <ComboBox Grid.Column="2" 
+                  Margin="5,0"
+                  ItemsSource="{Binding BlendShapeNames}"
+                  SelectedItem="{Binding ClipName.Value}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Margin="0">
+                        <TextBlock.Text>
+                            <MultiBinding Converter="{StaticResource Vrm1BlendShapeNameOrDoNothingConverter}">
+                                <Binding Path=""/>
+                                <Binding Path="LanguageName" Source="{x:Static vmm:LanguageSelector.Instance}" />
+                            </MultiBinding>
+                        </TextBlock.Text>
+                    </TextBlock>
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+
+        <TextBlock Grid.Row="1"
+                   Grid.Column="1"
+                   Text="{DynamicResource ExTracker_FaceSwitch_AccessoryLabel}"
+                   Visibility="{Binding ShowAccessoryOption.Value, 
+                                        Converter={StaticResource BooleanToVisibilityConverter}}"
+                   />
+        <ComboBox Grid.Row="1"
+                  Grid.Column="2" 
+                  Margin="5,0"
+                  ItemsSource="{Binding AvailableAccessoryNames}"
+                  DisplayMemberPath="DisplayName.Value"
+                  SelectedValuePath="FileId"
+                  SelectedValue="{Binding AccessoryName.Value}"
+                  Visibility="{Binding ShowAccessoryOption.Value, 
+                                       Converter={StaticResource BooleanToVisibilityConverter}}"
+                  >
+        </ComboBox>
+    </Grid>
+</UserControl>

--- a/WPF/VMagicMirrorConfig/View/FaceTracker/TrackingLostFaceSwitchSetting.xaml.cs
+++ b/WPF/VMagicMirrorConfig/View/FaceTracker/TrackingLostFaceSwitchSetting.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Controls;
+
+namespace Baku.VMagicMirrorConfig.View
+{
+    public partial class TrackingLostFaceSwitchSetting : UserControl
+    {
+        public TrackingLostFaceSwitchSetting()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
@@ -242,16 +242,6 @@
                             <TextBlock Text="{DynamicResource Motion_Face_NoCamMotion}"/>
                         </CheckBox.Content>
                     </CheckBox>
-
-                    <CheckBox Margin="15,0,0,5"
-                              IsChecked="{Binding EnableTrackingLostBlendShape.Value}"
-                              >
-                        <CheckBox.Content>
-                            <TextBlock Text="{DynamicResource Motion_Face_EnableTrackingLostBlendShape}"/>
-                        </CheckBox.Content>
-                    </CheckBox>
-
-
                 </StackPanel>
             </Border>
 

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/FaceSettingPanel.xaml
@@ -243,6 +243,15 @@
                         </CheckBox.Content>
                     </CheckBox>
 
+                    <CheckBox Margin="15,0,0,5"
+                              IsChecked="{Binding EnableTrackingLostBlendShape.Value}"
+                              >
+                        <CheckBox.Content>
+                            <TextBlock Text="{DynamicResource Motion_Face_EnableTrackingLostBlendShape}"/>
+                        </CheckBox.Content>
+                    </CheckBox>
+
+
                 </StackPanel>
             </Border>
 

--- a/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/FaceTrackerViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/ControlPanel/FaceTrackerViewModel.cs
@@ -57,6 +57,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 () => MachineIpAddress.Value = NetworkEnvironmentUtils.GetLocalIpv4AddressAsString()
                 );
 
+            TrackingLostFaceSwitch = new TrackingLostFaceSwitchViewModel(this);
+
             if (IsInDesignMode)
             {
                 // NOTE: 視認性のためにプレビュー上ではUIがだいたい展開した状態にする。
@@ -348,8 +350,15 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public void SaveFaceSwitchSetting() => _exTrackerModel.SaveFaceSwitchSetting();
 
         /// <summary> UIで個別設定として表示する、表情スイッチの要素です。 </summary>
-        public ObservableCollection<FaceSwitchItemViewModel> FaceSwitchItems { get; }
-            = new ObservableCollection<FaceSwitchItemViewModel>();
+        public ObservableCollection<FaceSwitchItemViewModel> FaceSwitchItems { get; } = [];
+
+        /// <summary>
+        /// トラッキングロストに関する表情スイッチの設定です。
+        /// UI上はFaceSwitchItemと並ぶものの、データの構造が違うので注意
+        /// </summary>
+        public RProperty<string> SerializedTrackingLostFaceSwitchSetting => _motionModel.SerializedTrackingLostFaceSwitchSetting;
+
+        public TrackingLostFaceSwitchViewModel TrackingLostFaceSwitch{ get; }
 
         /// <summary> Face Switch機能で表示可能なブレンドシェイプ名の一覧です。 </summary>
         public ReadOnlyObservableCollection<string> BlendShapeNames => _runtimeConfig.BlendShapeNames;
@@ -367,7 +376,11 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand ResetFaceSwitchSettingCommand
             => _resetFaceSwitchSettingCommand ??= new ActionCommand(ResetFaceSwitchSetting);
         private void ResetFaceSwitchSetting() 
-            => SettingResetUtils.ResetSingleCategoryAsync(() => _exTrackerModel.ResetFaceSwitchSetting());
+            => SettingResetUtils.ResetSingleCategoryAsync(() =>
+            {
+                _exTrackerModel.ResetFaceSwitchSetting();
+                _motionModel.ResetTrackingLostFaceSwitchSetting();
+            });
 
         #endregion
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/FaceSwitchViewModels.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/FaceSwitchViewModels.cs
@@ -104,7 +104,6 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             {
                 if (_model.AccessoryName != value)
                 {
-                    LogOutput.Instance.Write($"Accessory Name Updated, from={_model.AccessoryName}, to={value}");
                     _model.AccessoryName = value;
                     RaisePropertyChanged();
                     _parent.SaveFaceSwitchSetting();

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/TrackingLostFaceSwitchViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/TrackingLostFaceSwitchViewModel.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace Baku.VMagicMirrorConfig.ViewModel
+{
+    /// <summary>
+    /// トラッキングロスト時の表情操作の設定に関するビューモデル。
+    /// <see cref="FaceSwitchItemViewModel"/> と似てるがThreshold設定やKeepLipSyncがなく、Localizeも決め打ちでいい点が異なる
+    /// </summary>
+    public class TrackingLostFaceSwitchViewModel : ViewModelBase
+    {
+        public TrackingLostFaceSwitchViewModel(FaceTrackerViewModel parent)
+        {
+            _parent = parent;
+
+            if (!IsInDesignMode)
+            {
+                Setup();
+                parent.SerializedTrackingLostFaceSwitchSetting.AddWeakEventHandler(
+                    OnTrackingLostFaceSwitchSettingChanged
+                    );
+
+                // TODO: ほんとはClipNameが変わったらBlendShapeStoreにも反映したい
+                ClipName.PropertyChanged += (s, e) => ApplyToModel();
+                AccessoryName.PropertyChanged += (s, e) => ApplyToModel();
+            }
+        }
+
+        private readonly FaceTrackerViewModel _parent;
+
+        private void OnTrackingLostFaceSwitchSettingChanged(object? sender, PropertyChangedEventArgs e) => Setup();
+
+        private void Setup()
+        {
+            var setting = TrackingLostFaceSwitchSetting.FromJson(_parent.SerializedTrackingLostFaceSwitchSetting.Value);
+            ClipName.Value = setting.ClipName;
+            AccessoryName.Value = setting.AccessoryName;
+        }
+
+        private void ApplyToModel()
+        {
+            _parent.SerializedTrackingLostFaceSwitchSetting.Value = new TrackingLostFaceSwitchSetting()
+            {
+                ClipName = ClipName.Value,
+                AccessoryName = AccessoryName.Value,
+            }.ToJson();
+        }
+
+
+        public RProperty<bool> ShowAccessoryOption => _parent.ShowAccessoryOption;
+
+        public ReadOnlyObservableCollection<string> BlendShapeNames => _parent.BlendShapeNames;
+
+        public ReadOnlyObservableCollection<AccessoryItemNameViewModel> AvailableAccessoryNames 
+            => _parent.AvailableAccessoryNames.Items;
+
+        public RProperty<string> ClipName { get; } = new("");
+        public RProperty<string> AccessoryName { get; } = new("");
+    }
+}

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingItem/TrackingLostFaceSwitchViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingItem/TrackingLostFaceSwitchViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 
 namespace Baku.VMagicMirrorConfig.ViewModel
@@ -23,6 +24,12 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 // TODO: ほんとはClipNameが変わったらBlendShapeStoreにも反映したい
                 ClipName.PropertyChanged += (s, e) => ApplyToModel();
                 AccessoryName.PropertyChanged += (s, e) => ApplyToModel();
+
+                // NOTE: これをやらないと「保存されたアクセサリー名」→「利用可能アクセサリー一覧」の順に取得したときにUIにうまく反映されない
+                ((INotifyCollectionChanged)AvailableAccessoryNames).CollectionChanged += (s, e) =>
+                {
+                    RaisePropertyChanged(nameof(AccessoryName));
+                };
             }
         }
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
@@ -104,7 +104,6 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<bool> EnableBodyLeanZ => _model.EnableBodyLeanZ;
         public RProperty<bool> EnableBlinkAdjust => _model.EnableBlinkAdjust;
         public RProperty<bool> EnableVoiceBasedMotion => _model.EnableVoiceBasedMotion;
-        public RProperty<bool> EnableTrackingLostBlendShape => _model.EnableTrackingLostBlendShape;
         public RProperty<bool> DisableFaceTrackingHorizontalFlip => _model.DisableFaceTrackingHorizontalFlip;
         
         public RProperty<string> CameraDeviceName { get; }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/FaceSettingViewModel.cs
@@ -104,6 +104,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<bool> EnableBodyLeanZ => _model.EnableBodyLeanZ;
         public RProperty<bool> EnableBlinkAdjust => _model.EnableBlinkAdjust;
         public RProperty<bool> EnableVoiceBasedMotion => _model.EnableVoiceBasedMotion;
+        public RProperty<bool> EnableTrackingLostBlendShape => _model.EnableTrackingLostBlendShape;
         public RProperty<bool> DisableFaceTrackingHorizontalFlip => _model.DisableFaceTrackingHorizontalFlip;
         
         public RProperty<string> CameraDeviceName { get; }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature
- [x] Improve existing feature

## What the PR does

fixes #1226 

- キー/マウス入力まではケアしないで、あくまで顔トラッキングのロストだけケアする
- GUI上ではFace Switchの一種かのように提示するが、内部的には別のデータとして保持する(発動条件も全く異なるので)

## How to confirm

WPF Build + Editorで下記を確認

- 顔トラッキングの種類別に、トラッキングが一度も成功してないとき(非適用)、トラッキング中(非適用)、トラッキングロストして数秒後(適用)、がそれぞれ期待通りになること
- オプションがオプトインになってること
- 補間が効いており、通常のFace Switchよりは低速に表情が切り替わること
- 表情のみ、アクセサリのみ、表情+アクセサリ、のいずれも動作すること
- 指定した表情やアクセサリの設定がVMMの再起動時も持ち越されていること
