### PR TITLE
FaceSwitchでアクセサリーのみ表示しようとしたときエラーになるのを直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Windows 10/11環境でお使いいただけます。
 
 適当なフォルダに本レポジトリを配置します。配置先について、空白文字を含むようなフォルダパスは避けて下さい。
 
-Unity 6.0系でUnityプロジェクト(本レポジトリの`VMagicMirror`フォルダ)を開き、Visual Studio 2022でWPFプロジェクトを開きます。
+Unity 6.3系でUnityプロジェクト(本レポジトリの`VMagicMirror`フォルダ)を開き、Visual Studio 2022でWPFプロジェクトを開きます。
 
 メンテナの開発環境は以下の通りです。
 
-* Unity 6.0.58f2 Personal
-* Visual Studio Community 2022 (17.14.19)
+* Unity 6.3.13f1 Personal
+* Visual Studio Community 2022 (17.14.29)
     * 「.NET Desktop」コンポーネントがインストール済みであること
     * 「C++によるデスクトップ開発」コンポーネントがインストール済みであること
         - UnityのBurstコンパイラ向けに必要なセットアップです。

--- a/README_en.md
+++ b/README_en.md
@@ -54,12 +54,12 @@ note: Contact in English or Japanese is very helpful for the author.
 
 Put the repository on your local folder. folder path should not include space character.
 
-Open Unity project with Unity 6.0.x, and open WPF project with Visual Studio 2022.
+Open Unity project with Unity 6.3.x, and open WPF project with Visual Studio 2022.
 
 Maintainer's environment is as following.
 
-* Unity 6.0.58f2 Personal
-* Visual Studio Community 2022 (17.14.19)
+* Unity 6.0.13f1 Personal
+* Visual Studio Community 2022 (17.14.29)
     * Component ".NET Desktop Development" is required.
     * Also Component "C++ Desktop Development" is required, for Unity Burst compiler.
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -103,9 +103,9 @@ namespace Baku.VMagicMirror
                 .Subscribe(v =>
                 {
                     _hasFaceSwitchOutput.Value = v.HasValue;
-                    if (v.HasValue)
+                    if (v is { HasValue: true, Key: not null })
                     {
-                        SetFaceSwitch(v.Key, v.KeepLipSync);
+                        SetFaceSwitch(v.Key.Value, v.KeepLipSync);
                     }
                     else
                     {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
@@ -9,7 +9,7 @@ namespace Baku.VMagicMirror
 {
     public readonly struct FaceSwitchKeyApplyContent : IEquatable<FaceSwitchKeyApplyContent>
     {
-        private FaceSwitchKeyApplyContent(bool hasValue, bool keepLipSync, ExpressionKey key, string accessoryName)
+        private FaceSwitchKeyApplyContent(bool hasValue, bool keepLipSync, ExpressionKey? key, string accessoryName)
         {
             HasValue = hasValue;
             KeepLipSync = keepLipSync;
@@ -19,14 +19,19 @@ namespace Baku.VMagicMirror
 
         //NOTE: default指定してName == nullになってると怒られる事があるので便宜的にneutralで代用している
         public static FaceSwitchKeyApplyContent Empty { get; } 
-            = new(false, false, ExpressionKey.Neutral, "");
+            = new(false, false, null, "");
 
-        public static FaceSwitchKeyApplyContent Create(ExpressionKey key, bool keepLipSync, string accessoryName) =>
+        public static FaceSwitchKeyApplyContent Create(ExpressionKey? key, bool keepLipSync, string accessoryName) =>
             new(true, keepLipSync, key, accessoryName);
         
+        /// <summary> 表情またはアクセサリーのいずれかが有効な値ならtrue </summary>
         public bool HasValue { get; }
         public bool KeepLipSync { get; }
-        public ExpressionKey Key { get; }
+
+        /// <summary> 適用しない場合はnull </summary>
+        public ExpressionKey? Key { get; }
+        
+        /// <summary> 適用しない場合は空文字 </summary>
         public string AccessoryName { get; }
 
         public bool Equals(FaceSwitchKeyApplyContent other) => 
@@ -80,7 +85,7 @@ namespace Baku.VMagicMirror
             = new(FaceSwitchKeyApplyContent.Empty);
         public ReadOnlyReactiveProperty<FaceSwitchKeyApplyContent> CurrentValue => _currentValue;
         
-        public bool HasClipToApply => _currentValue.Value.HasValue;
+        public bool HasClipToApply => _currentValue.Value is { HasValue: true, Key: not null };
         // NOTE: `HasValue &&` もチェックしたほうがロバストだが、冗長なはずなのでやってない
         public bool KeepLipSync => _currentValue.Value.KeepLipSync;
 
@@ -143,8 +148,14 @@ namespace Baku.VMagicMirror
                 return;
             }
 
+            var key = _currentValue.CurrentValue.Key;
+            if (!key.HasValue)
+            {
+                return;
+            }
+
             //ターゲットのキーだけいじり、他のクリップ状態については呼び出し元に責任を持ってもらう
-            accumulator.Accumulate(_currentValue.Value.Key, 1f);
+            accumulator.Accumulate(key.Value, 1f);
             //表情を適用した = 目ボーンは正面向きになってほしい
             _eyeBoneSetter.ReserveReset = true;
         }
@@ -181,8 +192,13 @@ namespace Baku.VMagicMirror
             // その場合も何も適用しない
             if (_faceSwitch.UpdateCalled && !_faceSwitchItem.IsEmpty)
             {
+                var clipName = _faceSwitchItem.ClipName;
+                var key = string.IsNullOrEmpty(clipName)
+                    ? (ExpressionKey?)null
+                    : ExpressionKeyUtils.CreateKeyByName(clipName);
+
                 _currentValue.Value = FaceSwitchKeyApplyContent.Create(
-                    ExpressionKeyUtils.CreateKeyByName(_faceSwitchItem.ClipName),
+                    key,
                     _faceSwitchItem.KeepLipSync,
                     _faceSwitchItem.AccessoryName
                 );

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/UserOperationBlendShapeResultRepository.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/UserOperationBlendShapeResultRepository.cs
@@ -88,8 +88,11 @@ namespace Baku.VMagicMirror
         /// <param name="content"></param>
         public void SetFaceSwitchResult(FaceSwitchKeyApplyContent content)
         {
-            HasActiveKey = true;
-            ActiveKey = content.Key;
+            if (content.Key.HasValue)
+            {
+                HasActiveKey = true;
+                ActiveKey = content.Key.Value;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

タイトルの通り。

FaceSwitchの設定としてアクセサリー表示のみ設定しているとClipNameが空になってExpressionKeyの生成時に怒られることがあったので、それを対策した。

※ [d7d257e](https://github.com/malaybaku/VMagicMirror/pull/1235/commits/d7d257e40d2a5d604e1e97b0463cc90debdbb7a1) は #1234 の入れ忘れの反映

## How to confirm

Editor上で3種類のFace Switchが期待動作するのを確認

- 表情のみ
- 表情+アクセサリー
- アクセサリーのみ
