### PR TITLE
ハンドトラッキングロスト時に手が下がりすぎるのを防ぐ

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/TrackingLostHandCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/TrackingLostHandCalculator.cs
@@ -131,6 +131,10 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 var position = MathUtil.GetCubicBezierWithStartTangent(
                     _leftLastTrackedPose.position, endPose.position, HandDownStartTangent, positionRate
                 );
+                
+                // positionが下がりすぎると腰を曲げてでも下に手を持ってくような動きになって不自然なので下限をつける
+                // StartTangent自体をアバターの身長とかに比例させるほうが無難かもだが、そこまではしない
+                position.y = Mathf.Max(position.y, endPose.position.y);
 
                 var rotationRate =
                     Mathf.SmoothStep(0, 1, (time - TrackingLostRotationDelay) / TrackingLostMotionDuration);
@@ -172,6 +176,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 var position = MathUtil.GetCubicBezierWithStartTangent(
                     _rightLastTrackedPose.position, endPose.position, HandDownStartTangent, positionRate
                 );
+                position.y = Mathf.Max(position.y, endPose.position.y);
 
                 var rotationRate =
                     Mathf.SmoothStep(0, 1, (time - TrackingLostRotationDelay) / TrackingLostMotionDuration);


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix

## What the PR does

fixes #1247 

ベジエ曲線を使ってハンドトラッキングがロストしたときの手の動きの計算をしているが、単なるベジエ曲線の補間だとIKのy座標が保証されないので、下限を明示的につけるようにした

## How to confirm

Editor実行で、 #1247 に書いたようなトラッキングロストをさせたときにアバターの手が下に行きすぎないこと
