### PR TITLE
セルフ落影をopt-inするオプションを追加 / 脚IKの影響でhipsボーンが不自然に回転することがあるのを対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
@@ -1,5 +1,6 @@
 using Baku.VMagicMirror.FK;
 using R3;
+using RootMotion.FinalIK;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -7,20 +8,26 @@ namespace Baku.VMagicMirror
     public sealed class LateUpdateAfterFinalIKRunner : PresenterBase
     {
         private readonly LateUpdateSourceAfterFinalIK _source;
+        private readonly IVRMLoadable _vrmLoadable;
 
         private readonly MediaPipeHandLocalRotLimiter _mediaPipeHandLocalRotLimiter;
         private readonly VrmaMotionSetter _vrmaMotionSetter;
         private readonly ArmMuscleInterpolator _armMuscleInterpolator;
+        private LimbIK _leftLegIk;
+        private LimbIK _rightLegIk;
+        private bool _hasModel;
 
         [Inject]
         public LateUpdateAfterFinalIKRunner(
             LateUpdateSourceAfterFinalIK source,
+            IVRMLoadable vrmLoadable,
             MediaPipeHandLocalRotLimiter mediaPipeHandLocalRotLimiter,
             VrmaMotionSetter vrmaMotionSetter,
             ArmMuscleInterpolator armMuscleInterpolator
             )
         {
             _source = source;
+            _vrmLoadable = vrmLoadable;
             _mediaPipeHandLocalRotLimiter = mediaPipeHandLocalRotLimiter;
             _vrmaMotionSetter = vrmaMotionSetter;
             _armMuscleInterpolator = armMuscleInterpolator;
@@ -28,6 +35,9 @@ namespace Baku.VMagicMirror
         
         public override void Initialize()
         {
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+            _vrmLoadable.VrmDisposing += OnVrmDisposing;
+
             _source.OnLateUpdate
                 .Subscribe(_ => OnLateUpdate())
                 .AddTo(this);
@@ -35,9 +45,30 @@ namespace Baku.VMagicMirror
 
         private void OnLateUpdate()
         {
+            // FBBIK -> LimbIK をこの順で呼ぶのをスクリプト上で担保したいのでここに書いてる
+            if (_hasModel)
+            {
+                _leftLegIk.solver.Update();
+                _rightLegIk.solver.Update();
+            }
+
             _mediaPipeHandLocalRotLimiter.LateUpdate();
             _vrmaMotionSetter.ApplyUpdate();
             _armMuscleInterpolator.Update();
+        }
+
+        private void OnVrmLoaded(VrmLoadedInfo info)
+        {
+            _leftLegIk = info.leftLegIk;
+            _rightLegIk = info.rightLegIk;
+            _hasModel = true;
+        }
+
+        private void OnVrmDisposing()
+        {
+            _hasModel = false;
+            _leftLegIk = null;
+            _rightLegIk = null;
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/TaskBasedIkWeightFader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/TaskBasedIkWeightFader.cs
@@ -9,7 +9,7 @@ namespace Baku.VMagicMirror
 {
     public class TaskBasedIkWeightFader : IInitializable, ITickable, IDisposable
     {
-        //ロード時点で設定されたFBBIKのウェイトを一覧で保持するやつ
+        //ロード時点で設定されたIKのウェイトを一覧で保持するやつ
         readonly struct Weights
         {
             public Weights(
@@ -22,8 +22,8 @@ namespace Baku.VMagicMirror
                 float rightHandRot,
                 float bodyPos,
 
-                float leftFootPos,
-                float rightFootPos,
+                float leftLegIkPos,
+                float rightLegIkPos,
                 
                 float leftWristTwist,
                 float rightWristTwist
@@ -38,8 +38,8 @@ namespace Baku.VMagicMirror
                 RightHandRot = rightHandRot;
 
                 BodyPos = bodyPos;
-                LeftFootPos = leftFootPos;
-                RightFootPos = rightFootPos;
+                LeftLegIkPos = leftLegIkPos;
+                RightLegIkPos = rightLegIkPos;
                 
                 LeftWristTwist = leftWristTwist;
                 RightWristTwist = rightWristTwist;
@@ -55,8 +55,8 @@ namespace Baku.VMagicMirror
             
             public float BodyPos { get; }
             
-            public float LeftFootPos { get; }
-            public float RightFootPos { get; }
+            public float LeftLegIkPos { get; }
+            public float RightLegIkPos { get; }
 
             public float LeftWristTwist { get; }
             public float RightWristTwist { get; }
@@ -81,6 +81,8 @@ namespace Baku.VMagicMirror
         
         //モデルに関連する数値
         private FullBodyBipedIK _ik;
+        private LimbIK _leftLegIk;
+        private LimbIK _rightLegIk;
         private TwistRelaxer _leftTwistRelaxer;
         private TwistRelaxer _rightTwistRelaxer;
         private SimpleAnimation _simpleAnimation;
@@ -146,6 +148,8 @@ namespace Baku.VMagicMirror
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
             _ik = info.fbbIk;
+            _leftLegIk = info.leftLegIk;
+            _rightLegIk = info.rightLegIk;
             _leftTwistRelaxer = info.leftArmTwistRelaxer;
             _rightTwistRelaxer = info.rightArmTwistRelaxer;
 
@@ -158,8 +162,8 @@ namespace Baku.VMagicMirror
                 s.rightHandEffector.positionWeight,
                 s.rightHandEffector.rotationWeight,
                 s.bodyEffector.positionWeight,
-                s.leftFootEffector.positionWeight,
-                s.rightFootEffector.positionWeight,
+                _leftLegIk.solver.IKPositionWeight,
+                _rightLegIk.solver.IKPositionWeight,
                 LeftTwistRelaxerWeight,
                 RightTwistRelaxerWeight
             );
@@ -178,6 +182,8 @@ namespace Baku.VMagicMirror
         {
             _hasModel = false;
             _ik = null;
+            _leftLegIk = null;
+            _rightLegIk = null;
             _simpleAnimation = null;
         }
 
@@ -292,8 +298,8 @@ namespace Baku.VMagicMirror
             
             //下半身
             s.bodyEffector.positionWeight = _originWeight.BodyPos * lowerFactor;
-            s.leftFootEffector.positionWeight = _originWeight.LeftFootPos * lowerFactor;
-            s.rightFootEffector.positionWeight = _originWeight.RightFootPos * lowerFactor;
+            _leftLegIk.solver.IKPositionWeight = _originWeight.LeftLegIkPos * lowerFactor;
+            _rightLegIk.solver.IKPositionWeight = _originWeight.RightLegIkPos * lowerFactor;
 
             _weightIsDirty = false;
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -21,6 +21,8 @@ namespace Baku.VMagicMirror
         [SerializeField] private VmmAvatarDropShadowController avatarDropShadowController = null;
         [SerializeField] private DesktopLightEstimator desktopLightEstimator = null;
 
+        private readonly ReactiveProperty<bool> _selfShadowEnabled = new();
+
         private Color _color = Color.white;
         private Volume _globalVolume;
         private Bloom _bloom;
@@ -79,17 +81,21 @@ namespace Baku.VMagicMirror
                 message=> SetLightPitch(message.ToInt())
                 );
 
-            // 固定シャドウが有効になると固定シャドウが勝つ…という優先度があるので注意。同時に作用させてはいけない
             var shadowEnabled = new ReactiveProperty<bool>(true);
             receiver.BindBoolProperty(VmmCommands.ShadowEnable, shadowEnabled);
+            receiver.BindBoolProperty(VmmCommands.SelfShadowEnable, _selfShadowEnabled);
+            
+            // - 背面シャドウと固定シャドウは原則として排他になる
+            // - ただしセルフ落影を有効にしている場合、背面シャドウと使っていてもlightのshadowを有効にする
             shadowEnabled.CombineLatest(
                 fixedShadowController.FixedShadowEnabled,
-                (dropShadowEnabled, fixedShadowEnabled) => (
+                _selfShadowEnabled,
+                (dropShadowEnabled, fixedShadowEnabled, selfShadowEnabled) => (
                     dropShadowEnabled: dropShadowEnabled && !fixedShadowEnabled,
-                    fixedShadowEnabled: fixedShadowEnabled
+                    lightingShadowEnabled: fixedShadowEnabled || selfShadowEnabled
                 ))
                 .DistinctUntilChanged()
-                .Subscribe(SetEnableShadow)
+                .Subscribe(v => SetEnableShadow(v.dropShadowEnabled, v.lightingShadowEnabled))
                 .AddTo(this);
 
             receiver.AssignCommandHandler(
@@ -242,13 +248,11 @@ namespace Baku.VMagicMirror
             mainLight.transform.localEulerAngles = mainLightLocalEulerAngle;
         }
 
-        private void SetEnableShadow((bool dropShadowEnabled, bool fixedShadowEnabled) value)
+        private void SetEnableShadow(bool dropShadowEnabled, bool lightingShadowEnabled)
         {
-            var (dropShadowEnabled, fixedShadowEnabled) = value;
-
             avatarDropShadowController.SetEnabled(dropShadowEnabled);
             // NOTE: セルフ落影のオンオフを動的に変えられるようにする場合、セルフ影がオンの場合にもSoftに倒す必要がある
-            mainLight.shadows = fixedShadowEnabled ? LightShadows.Soft : LightShadows.None;
+            mainLight.shadows = lightingShadowEnabled ? LightShadows.Soft : LightShadows.None;
         }
 
         private void SetShadowIntensity(float shadowStrength)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -222,6 +222,7 @@
         ShadowDepthOffset,
         FixedShadowAlwaysEnable,
         FixedShadowWhenLocomotionActiveEnable,
+        SelfShadowEnable,
 
         BloomIntensity,
         BloomThreshold,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -323,6 +323,8 @@ namespace Baku.VMagicMirror
                 animator = animator,
                 instance = instance,
                 fbbIk = setupResult.Fbbik,
+                leftLegIk = setupResult.LeftLegIk,
+                rightLegIk = setupResult.RightLegIk,
                 leftArmTwistRelaxer = setupResult.LeftArmTwistRelaxer,
                 rightArmTwistRelaxer = setupResult.RightArmTwistRelaxer,
                 //NOTE: このbsがないことでエラーが起こるのはイベント購読側が悪い。

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadControllerHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadControllerHelper.cs
@@ -13,14 +13,24 @@ namespace Baku.VMagicMirror
     {
         public readonly struct SetupResult
         {
-            public SetupResult(FullBodyBipedIK fbbik, TwistRelaxer leftArmTwistRelaxer, TwistRelaxer rightArmTwistRelaxer)
+            public SetupResult(
+                FullBodyBipedIK fbbik,
+                LimbIK leftLegIk,
+                LimbIK rightLegIk,
+                TwistRelaxer leftArmTwistRelaxer,
+                TwistRelaxer rightArmTwistRelaxer
+                )
             {
                 Fbbik = fbbik;
+                LeftLegIk = leftLegIk;
+                RightLegIk = rightLegIk;
                 LeftArmTwistRelaxer = leftArmTwistRelaxer;
                 RightArmTwistRelaxer = rightArmTwistRelaxer;
             }
 
             public FullBodyBipedIK Fbbik { get; }
+            public LimbIK LeftLegIk { get; }
+            public LimbIK RightLegIk { get; }
             public TwistRelaxer LeftArmTwistRelaxer { get; }
             public TwistRelaxer RightArmTwistRelaxer { get; }
         }
@@ -35,6 +45,7 @@ namespace Baku.VMagicMirror
             var controlRigRoot = controlRig.GetBoneTransform(HumanBodyBones.Hips).parent;
             var bipedReferences = LoadReferencesFromVrm(controlRig, controlRigRoot);
             var fbbik = AddFBBIK(controlRig.GetBoneTransform(HumanBodyBones.Hips).parent.gameObject, ikTargets, bipedReferences);
+            var (leftLegIk, rightLegIk) = AddLegIK(controlRigRoot.gameObject, ikTargets, bipedReferences);
             
             var (leftTwistRelaxer, rightTwistRelaxer) = AddTwistRelaxer(animator, fbbik);
 
@@ -46,7 +57,7 @@ namespace Baku.VMagicMirror
             AddLookAtIK(controlRigRoot.gameObject, ikTargets.LookAt, controlRig, bipedReferences.root);
             AddFingerRigToRightIndex(controlRig, ikTargets);
             
-            return new SetupResult(fbbik, leftTwistRelaxer, rightTwistRelaxer);
+            return new SetupResult(fbbik, leftLegIk, rightLegIk, leftTwistRelaxer, rightTwistRelaxer);
         }
 
         private static FullBodyBipedIK AddFBBIK(GameObject go, IKTargetTransforms ikTargets, BipedReferences reference)
@@ -76,15 +87,12 @@ namespace Baku.VMagicMirror
             fbbik.solver.rightArmChain.pull = 0.1f;
             fbbik.solver.leftArmChain.pull = 0.1f;
 
-            //NOTE: 足についてはSimpleAnimationを使うとO脚みたくなっちゃうので、それを防ぐために入れる。
-            //(pull = 0相当にしたいんだけどそういうの無い…？)
-            fbbik.solver.leftFootEffector.target = ikTargets.LeftFoot;
-            fbbik.solver.leftFootEffector.positionWeight = 1f;
+            //NOTE: 足はHipsを巻き込まないように、FBBIKではなくLimbIKで処理する。
+            fbbik.solver.leftFootEffector.positionWeight = 0f;
             fbbik.solver.leftFootEffector.rotationWeight = 0f;
             fbbik.solver.leftLegChain.pull = 0f;
             
-            fbbik.solver.rightFootEffector.target = ikTargets.RightFoot;
-            fbbik.solver.rightFootEffector.positionWeight = 1f;
+            fbbik.solver.rightFootEffector.positionWeight = 0f;
             fbbik.solver.rightFootEffector.rotationWeight = 0f;
             fbbik.solver.rightLegChain.pull = 0f;
 
@@ -96,6 +104,57 @@ namespace Baku.VMagicMirror
             ));
 
             return fbbik;
+        }
+
+        private static (LimbIK left, LimbIK right) AddLegIK(
+            GameObject go,
+            IKTargetTransforms ikTargets,
+            BipedReferences reference
+            )
+        {
+            var left = AddLegIK(
+                go,
+                AvatarIKGoal.LeftFoot,
+                reference.leftThigh,
+                reference.leftCalf,
+                reference.leftFoot,
+                ikTargets.LeftFoot,
+                reference.root
+                );
+
+            var right = AddLegIK(
+                go,
+                AvatarIKGoal.RightFoot,
+                reference.rightThigh,
+                reference.rightCalf,
+                reference.rightFoot,
+                ikTargets.RightFoot,
+                reference.root
+                );
+
+            return (left, right);
+        }
+
+        private static LimbIK AddLegIK(
+            GameObject go,
+            AvatarIKGoal goal,
+            Transform thigh,
+            Transform calf,
+            Transform foot,
+            Transform target,
+            Transform root
+            )
+        {
+            var limbIk = go.AddComponent<LimbIK>();
+            limbIk.solver.goal = goal;
+            limbIk.solver.target = target;
+            limbIk.solver.IKPositionWeight = 1f;
+            limbIk.solver.IKRotationWeight = 0f;
+            limbIk.solver.maintainRotationWeight = 1f;
+            limbIk.solver.bendModifier = IKSolverLimb.BendModifier.Animation;
+            limbIk.solver.SetChain(thigh, calf, foot, root);
+
+            return limbIk;
         }
 
         private static void AddLookAtIK(GameObject go, Transform headTarget, Vrm10RuntimeControlRig controlRig, Transform referenceRoot)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadControllerHelper.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadControllerHelper.cs
@@ -153,6 +153,7 @@ namespace Baku.VMagicMirror
             limbIk.solver.maintainRotationWeight = 1f;
             limbIk.solver.bendModifier = IKSolverLimb.BendModifier.Animation;
             limbIk.solver.SetChain(thigh, calf, foot, root);
+            limbIk.enabled = false;
 
             return limbIk;
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
@@ -16,6 +16,8 @@ namespace Baku.VMagicMirror
         public Vrm10Instance instance;
         public Vrm10RuntimeExpression RuntimeFacialExpression => instance.Runtime.Expression;
         public FullBodyBipedIK fbbIk;
+        public LimbIK leftLegIk;
+        public LimbIK rightLegIk;
 
         public TwistRelaxer leftArmTwistRelaxer;
         public TwistRelaxer rightArmTwistRelaxer;

--- a/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
@@ -44,6 +44,8 @@
         public bool EnableFixedShadowAlways { get; set; } = false;
         public bool EnableFixedShadowWhenLocomotionActive { get; set; } = true;
 
+        public bool EnableSelfShadow { get; set; } = false;
+
         #endregion
 
         #region Ambient Occlusion

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -310,6 +310,8 @@ namespace Baku.VMagicMirrorConfig
         public static Message FixedShadowWhenLocomotionActiveEnable(bool enable) 
             => BoolContent(VmmCommands.FixedShadowWhenLocomotionActiveEnable, enable);
 
+        public static Message EnableSelfShadow(bool enable) => BoolContent(VmmCommands.SelfShadowEnable, enable);
+
         public static Message BloomColor(int r, int g, int b) => IntArrayContent(VmmCommands.BloomColor, [r, g, b]);
         public static Message BloomIntensity(int intensityPercent) => IntContent(VmmCommands.BloomIntensity, intensityPercent);
         public static Message BloomThreshold(int thresholdPercent) => IntContent(VmmCommands.BloomThreshold, thresholdPercent);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -53,6 +53,9 @@ namespace Baku.VMagicMirrorConfig
                 v => SendMessage(MessageFactory.FixedShadowWhenLocomotionActiveEnable(v))
                 );
 
+            EnableSelfShadow = new RProperty<bool>(s.EnableSelfShadow, b => SendMessage(MessageFactory.EnableSelfShadow(b)));
+
+
             BloomIntensity = new RProperty<int>(s.BloomIntensity, i => SendMessage(MessageFactory.BloomIntensity(i)));
             BloomThreshold = new RProperty<int>(s.BloomThreshold, i => SendMessage(MessageFactory.BloomThreshold(i)));
             Action sendBloomColor = () =>
@@ -126,6 +129,8 @@ namespace Baku.VMagicMirrorConfig
 
         public RProperty<bool> EnableFixedShadowAlways { get; }
         public RProperty<bool> EnableFixedShadowWhenLocomotionActive { get; }
+
+        public RProperty<bool> EnableSelfShadow { get; }
 
         #endregion
 

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -55,7 +55,6 @@ namespace Baku.VMagicMirrorConfig
 
             EnableSelfShadow = new RProperty<bool>(s.EnableSelfShadow, b => SendMessage(MessageFactory.EnableSelfShadow(b)));
 
-
             BloomIntensity = new RProperty<int>(s.BloomIntensity, i => SendMessage(MessageFactory.BloomIntensity(i)));
             BloomThreshold = new RProperty<int>(s.BloomThreshold, i => SendMessage(MessageFactory.BloomThreshold(i)));
             Action sendBloomColor = () =>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -600,6 +600,7 @@ Translate (2 way):
     <sys:String x:Key="Shadow_Yaw">Yaw Angle [deg]</sys:String>
     <sys:String x:Key="Shadow_Pitch">Pitch Angle [deg]</sys:String>
     <sys:String x:Key="Shadow_DepthOffset">Depth Offset [cm]</sys:String>
+    <sys:String x:Key="Shadow_EnableSelfShadow">Enable Self Shadow</sys:String>
     <sys:String x:Key="Shadow_FixedShadow_Header">Full Body Shadow Settings (Click to Expand)</sys:String>
     <sys:String x:Key="Shadow_FixedShadow_UseAlways">Always Apply Full Body Shadow</sys:String>
     <sys:String x:Key="Shadow_FixedShadow_UseOnLocomotion">Apply When Locomotion is Active</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -601,6 +601,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Shadow_Yaw">向き(横)[deg]</sys:String>
     <sys:String x:Key="Shadow_Pitch">向き(上下)[deg]</sys:String>
     <sys:String x:Key="Shadow_DepthOffset">奥行きの調整 [cm]</sys:String>
+    <sys:String x:Key="Shadow_EnableSelfShadow">アバター自身にも落ち影を適用</sys:String>
     <sys:String x:Key="Shadow_FixedShadow_Header">全身表示用シャドウの設定 (クリックで展開)</sys:String>
     <sys:String x:Key="Shadow_FixedShadow_UseAlways">つねに全身表示用シャドウを適用</sys:String>
     <sys:String x:Key="Shadow_FixedShadow_UseOnLocomotion">下半身モーションの適用時には適用</sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -371,6 +371,11 @@
 
                     </Grid>
 
+                    <CheckBox Margin="10,5,10,10"
+                              Content="{DynamicResource Shadow_EnableSelfShadow}"
+                              IsChecked="{Binding EnableSelfShadow.Value}"
+                              />
+
                     <md:Card md:ShadowAssist.ShadowDepth="Depth1" 
                              Margin="5,10" 
                              Padding="0">

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -185,6 +185,8 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<bool> EnableFixedShadowAlways => _model.EnableFixedShadowAlways;
         public RProperty<bool> EnableFixedShadowWhenLocomotionActive => _model.EnableFixedShadowWhenLocomotionActive;
 
+        public RProperty<bool> EnableSelfShadow => _model.EnableSelfShadow;
+
         #endregion
 
         #region Ambient Occlusion


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix
- [x] Improve existing feature

## What the PR does

fixes #1239 
fixes #1254 

横着だが、独立な2つの対応を一気に入れる。

- セルフ落影: `mainLight.shadowMode`の制御だけで十分なのでそのようにした
- #1254 : issue側に書いてある通り、LimbIKを後乗せで適用することでケアできるようだったので、IK Targetのポーズ制御方法はそのままにしたうえで後乗せ実行する処理を入れた

## How to confirm

Unity Editor + WPFで双方の動作改善が見られること
