### PR TITLE
背面シャドウの配置計算を改善

### DIFF
--- a/VMagicMirror/.gitignore
+++ b/VMagicMirror/.gitignore
@@ -1,0 +1,2 @@
+.codex/
+.uloop/

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Camera/Main Camera.prefab
@@ -399,16 +399,10 @@ MonoBehaviour:
   backgroundImageBoard: {fileID: 1537561560760104036}
   shadowQuadRenderer: {fileID: 3358616490393661295}
   shadowDepthOffset: 0.4
-  minShadowDepth: 2
   backgroundDepthMargin: 0.5
   shadowIntensity: 0.65
   shadowYawDeg: -20
   shadowPitchDeg: 8
-  yawFactor: 0.004
-  pitchFactor: -0.004
-  shadowScale: 0.85
-  maskOverscanFactor: 1.5
-  referenceDepth: 2.5
 --- !u!114 &8150168015613584728
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
@@ -13,23 +13,16 @@ namespace Baku.VMagicMirror
         private static readonly int AlphaThreshold = Shader.PropertyToID("_AlphaThreshold");
         private static readonly int MaskOverscanInv = Shader.PropertyToID("_MaskOverscanInv");
         private const float AlphaThresholdValue = 0.001f;
+        private const float MinShadowDepth = 0.01f;
 
         [SerializeField] private Camera targetCamera = null;
         [SerializeField] private BackgroundImageBoard backgroundImageBoard = null;
         [SerializeField] private Renderer shadowQuadRenderer = null;
         [SerializeField] private float shadowDepthOffset = 0.4f;
-        [SerializeField] private float minShadowDepth = 2.0f;
         [SerializeField] private float backgroundDepthMargin = 0.5f;
         [SerializeField] private float shadowIntensity = 0.65f;
         [SerializeField] private float shadowYawDeg = -20f;
         [SerializeField] private float shadowPitchDeg = 8f;
-
-        [SerializeField, Range(-0.01f, 0.01f)] private float yawFactor = 0.003f;
-        [SerializeField, Range(-0.01f, 0.01f)] private float pitchFactor = -0.003f;
-        [SerializeField] private float shadowScale = 0.85f;
-        [SerializeField, Range(1.0f, 2.0f)] private float maskOverscanFactor = 1.5f;
-
-        [SerializeField, Range(1f, 5f)] private float referenceDepth = 3.0f;
 
         private Material _shadowQuadMaterial;
         // NOTE: componentのenabledではない形でon/offを制御しとく
@@ -117,29 +110,30 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            var depth = ComputeShadowDepth();
+            var avatarBackDepth = GetAvatarBackDepth();
+            var depth = ComputeShadowDepth(avatarBackDepth);
             UpdateShadowQuadTransform(depth);
-            UpdateShadowQuadMaterial(depth);
+            UpdateShadowQuadMaterial(depth, avatarBackDepth);
         }
 
-        private float ComputeShadowDepth()
+        private float ComputeShadowDepth(float avatarBackDepth)
         {
-            var farLimit = Mathf.Max(minShadowDepth, targetCamera.farClipPlane - backgroundDepthMargin);
-            var avatarDepth = GetAvatarBackDepth() + shadowDepthOffset;
-            var depth = Mathf.Max(minShadowDepth, avatarDepth);
+            var farLimit = Mathf.Max(MinShadowDepth, targetCamera.farClipPlane - backgroundDepthMargin);
+            var avatarDepth = avatarBackDepth + shadowDepthOffset;
+            var depth = Mathf.Max(MinShadowDepth, avatarDepth);
 
             if (HasBackgroundImage)
             {
                 depth = Mathf.Min(depth, BackgroundEyeDepth - backgroundDepthMargin);
             }
 
-            return Mathf.Clamp(depth, minShadowDepth, farLimit);
+            return Mathf.Clamp(depth, MinShadowDepth, farLimit);
         }
 
         private float GetAvatarBackDepth()
         {
             var hasBounds = false;
-            var maxDepth = minShadowDepth;
+            var maxDepth = float.NegativeInfinity;
             foreach (var r in _avatarMaskTextureController.AvatarRenderers)
             {
                 if (!r.enabled || !r.gameObject.activeInHierarchy)
@@ -156,7 +150,7 @@ namespace Baku.VMagicMirror
                 }
             }
 
-            return hasBounds ? maxDepth : minShadowDepth;
+            return hasBounds ? maxDepth : MinShadowDepth;
         }
 
         private void UpdateShadowQuadTransform(float depth)
@@ -169,32 +163,41 @@ namespace Baku.VMagicMirror
             transformRef.localScale = new Vector3(xScale, yScale, 1f);
         }
 
-        private void UpdateShadowQuadMaterial(float depth)
+        private void UpdateShadowQuadMaterial(float depth, float avatarBackDepth)
         {
             _shadowQuadMaterial.SetTexture(AvatarMaskTex, _avatarMaskTextureController.AvatarMaskHandle.rt);
             _shadowQuadMaterial.SetFloat(MaskOverscanInv, 1.0f / _avatarMaskTextureController.AvatarMaskOverscanFactor);
 
-            // スケールの根拠:
-            // - ユーザーが指定した影のdepthOffsetが大きい: 影が見かけ奥まったように見せるためにoffsetを大きくする
-            // - カメラがアバターから遠い: offsetを縮めたほうが距離がそれっぽいのでそうする。ただし近いときのオフセットは据え置き
-            var offsetScaleByDepth =
-                (shadowDepthOffset / 0.4f) *
-                Mathf.Min(1.0f, referenceDepth / depth);
-            
-            var offset = new Vector2(
-                shadowYawDeg * yawFactor * offsetScaleByDepth,
-                shadowPitchDeg * pitchFactor * offsetScaleByDepth
-            );
-
-            // NOTE: scaleは実は固定で良くて、depthのコントロールだけで良い、というのはある？あるかも。
-            //var scale = Vector2.one;
+            var offset = CalculateShadowOffset(depth, avatarBackDepth);
+            var scale = CalculateShadowScale(depth, avatarBackDepth);
             var color = new Color(0f, 0f, 0f, shadowIntensity);
-            
+
             _shadowQuadMaterial.SetVector(ShadowOffset, offset);
-            _shadowQuadMaterial.SetVector(ShadowScale, 
-                Vector2.one * (shadowScale * CalculateShadowScale(shadowDepthOffset)));
+            _shadowQuadMaterial.SetVector(ShadowScale, Vector2.one * scale);
             _shadowQuadMaterial.SetColor(ShadowColor, color);
             _shadowQuadMaterial.SetFloat(AlphaThreshold, AlphaThresholdValue);
+        }
+
+        private Vector2 CalculateShadowOffset(float shadowDepth, float avatarBackDepth)
+        {
+            var safeShadowDepth = Mathf.Max(0.0001f, shadowDepth);
+            var depthRate = Mathf.Max(0f, shadowDepth - avatarBackDepth) / safeShadowDepth;
+            var tanHalfVerticalFov = Mathf.Max(
+                0.0001f,
+                Mathf.Tan(targetCamera.fieldOfView * Mathf.Deg2Rad * 0.5f));
+            var tanHalfHorizontalFov = Mathf.Max(0.0001f, tanHalfVerticalFov * targetCamera.aspect);
+
+            return new Vector2(
+                0.5f * depthRate * Mathf.Tan(shadowYawDeg * Mathf.Deg2Rad) / tanHalfHorizontalFov,
+                -0.5f * depthRate * Mathf.Tan(shadowPitchDeg * Mathf.Deg2Rad) / tanHalfVerticalFov
+            );
+        }
+
+        private static float CalculateShadowScale(float shadowDepth, float avatarBackDepth)
+        {
+            var safeShadowDepth = Mathf.Max(0.0001f, shadowDepth);
+            var casterDepth = Mathf.Clamp(avatarBackDepth, 0.0001f, safeShadowDepth);
+            return casterDepth / safeShadowDepth;
         }
 
         private static Vector3 GetBoundsCorner(Bounds bounds, int index)
@@ -205,14 +208,6 @@ namespace Baku.VMagicMirror
                 (index & 1) == 0 ? -extents.x : extents.x,
                 (index & 2) == 0 ? -extents.y : extents.y,
                 (index & 4) == 0 ? -extents.z : extents.z);
-        }
-
-        private static float CalculateShadowScale(float depth)
-        {
-            // depth = 0m のとき scale = 1.0
-            // depth = 2.5m = 250cm (GUI側の最大値) のとき scale = 0.6
-            // くらいになるように線形にやってる
-            return Mathf.Lerp(1.0f, 0.6f, depth / 2.5f);
         }
     }
 }

--- a/VMagicMirror/Packages/manifest.json
+++ b/VMagicMirror/Packages/manifest.json
@@ -28,6 +28,7 @@
     "com.vrmc.gltf": "https://github.com/vrm-c/UniVRM.git?path=/Packages/UniGLTF#v0.131.0",
     "com.vrmc.univrm": "https://github.com/vrm-c/UniVRM.git?path=/Packages/VRM#v0.131.0",
     "com.vrmc.vrm": "https://github.com/vrm-c/UniVRM.git?path=/Packages/VRM10#v0.131.0",
+    "io.github.hatayama.uloopmcp": "https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src",
     "jp.keijiro.klak.spout": "2.0.6",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.adaptiveperformance": "1.0.0",

--- a/VMagicMirror/Packages/packages-lock.json
+++ b/VMagicMirror/Packages/packages-lock.json
@@ -147,6 +147,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "3.2.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.probuilder": {
       "version": "6.0.9",
       "depth": 0,
@@ -287,6 +294,16 @@
         "com.vrmc.gltf": "0.131.0"
       },
       "hash": "3b99078d26b362733ad9bf463f98c83b8a1b4c9f"
+    },
+    "io.github.hatayama.uloopmcp": {
+      "version": "https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.2.1"
+      },
+      "hash": "f2f983ade57a33de7650f504671bb24c70bc6e1a"
     },
     "jp.keijiro.klak.spout": {
       "version": "2.0.6",


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

#1241 で背面シャドウ実装を「真の影の投影」から「アバター部分のmaskをoffset + scaleしたものを描く」に変えたとき、そのoffsetとscaleの計算がヒューリスティック過ぎたのを修正するPRです。

- maskを作ること自体はそのままで、角度とカメラの距離、FoVから幾何的な計算をする方向に調整しています。

## How to confirm

Buildで現行のリリース版(4.4.3)と比べてカメラの寄り引き、角度の変更、奥行きの調整などを条件をそろえて比べたとき、概ね同じ位置にシャドウが配置されること

## Note

Packages以下の差分があるのは作業の一環でUnity CLI Loopを導入してみたため