### PR TITLE
Word to Motionタブのmarginを調整

### DIFF
--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/WordToMotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/WordToMotionSettingPanel.xaml
@@ -36,10 +36,11 @@
                 Text="{DynamicResource WordToMotion_Header}"                 
                 Style="{StaticResource SectionHeaderText}"
                 />
-            <Border Style="{StaticResource SideMarginSectionBorder}">
+            <Border Style="{StaticResource SideMarginSectionBorder}"
+                    Margin="10,5">
                 <StackPanel>
 
-                    <Grid Margin="25,0,25,50">
+                    <Grid Margin="5,0,5,50">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

#1257 でUIのマージンやpaddingを大きく取る方向にシフトしたことでUIが隠れてしまってたため、marginを削る方向で調整します。

## How to confirm

ビルドで詳細設定ウィンドウ > word to motionを開いたときword to motionのitemのUIが右に見切れてしまわずに表示されること
