### PR TITLE
ハンドトラッキング中のmuscle補間時に肩だけカクついた動きになってたのを対策

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/ArmMuscleInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/ArmMuscleInterpolator.cs
@@ -23,12 +23,18 @@ namespace Baku.VMagicMirror.FK
 
         private static readonly HashSet<HumanBodyBones> LeftBones = new()
         {
-            HumanBodyBones.LeftUpperArm, HumanBodyBones.LeftLowerArm, HumanBodyBones.LeftHand,
+            HumanBodyBones.LeftShoulder,
+            HumanBodyBones.LeftUpperArm,
+            HumanBodyBones.LeftLowerArm,
+            HumanBodyBones.LeftHand,
         };
 
         private static readonly HashSet<HumanBodyBones> RightBones = new()
         {
-            HumanBodyBones.RightUpperArm, HumanBodyBones.RightLowerArm, HumanBodyBones.RightHand,
+            HumanBodyBones.RightShoulder,
+            HumanBodyBones.RightUpperArm, 
+            HumanBodyBones.RightLowerArm,
+            HumanBodyBones.RightHand,
         };
 
         private static readonly int[] LeftArmMuscleIndices = { 37, 38, 39, 40, 41, 42, 43, 44, 45 };


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix
- [x] Improve existing feature

## What the PR does

- #1252 の副作用と見られる事象で、ハンドトラッキング中に肩ボーンだけ動きが不連続になることがあったのを修正します。

## How to confirm

Editor上でハンドトラッキングと他のIKを切り替えたり、ハンドトラッキング中のロストおよび復帰動作をするときにボーンが非連続に動いてしまわないこと
