### PR TITLE
シャドウについて影色の設定を追加 + 背面影にぼかしのサイズ設定を追加

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/FixedShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/FixedShadowController.cs
@@ -14,7 +14,7 @@ namespace Baku.VMagicMirror
         private readonly VMCPReceiver _vmcpReceiver;
         private readonly Renderer _fixedShadowBoardRenderer;
 
-        // NOTE: この5つはGUIから直接降ってくるやつ
+        // NOTE: これらはGUIから直接降ってくるやつ
         private readonly ReactiveProperty<bool> _shadowEnabled = new(true);
         private readonly ReactiveProperty<bool> _fixedShadowEnabledAlways = new(false);
         private readonly ReactiveProperty<bool> _fixedShadowEnabledWhenLocomotionActive = new(true);
@@ -23,8 +23,8 @@ namespace Baku.VMagicMirror
         public ReactiveProperty<bool> FixedShadowEnabled => _fixedShadowEnabled;
 
         private readonly MaterialPropertyBlock _propertyBlock = new();
-        private Color _shadowColor = new(0f, 0f, 0f, 0.6f);
-        private float _shadowIntensity = 1.0f;
+        private Color _shadowColor = new(0f, 0f, 0f);
+        private float _shadowIntensity = .65f;
         
         [Inject]
         public FixedShadowController(
@@ -51,6 +51,13 @@ namespace Baku.VMagicMirror
                 VmmCommands.FixedShadowWhenLocomotionActiveEnable,
                 _fixedShadowEnabledWhenLocomotionActive);
 
+            _receiver.AssignCommandHandler(
+                VmmCommands.ShadowColor,
+                c =>
+                {
+                    var rgb = c.ToColorFloats();
+                    SetShadowColor(rgb[0], rgb[1], rgb[2]);
+                });
             _receiver.AssignCommandHandler(
                 VmmCommands.ShadowIntensity,
                 c => SetShadowIntensity(c.ParseAsPercentage())
@@ -106,6 +113,12 @@ namespace Baku.VMagicMirror
             ApplyBoardShadowColor();
         }
 
+        private void SetShadowColor(float r, float g, float b)
+        {
+            _shadowColor = new Color(r, g, b, _shadowColor.a);
+            ApplyBoardShadowColor();
+        }
+
         private void SetShadowIntensity(float intensity)
         {
             _shadowIntensity = Mathf.Max(0f, intensity);
@@ -119,8 +132,11 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            var color = _shadowColor;
-            color.a *= _shadowIntensity;
+            var color = new Color(
+                _shadowColor.r,
+                _shadowColor.g,
+                _shadowColor.b,
+                _shadowIntensity);
 
             _fixedShadowBoardRenderer.GetPropertyBlock(_propertyBlock);
             _propertyBlock.SetColor(ColorId, color);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -102,6 +102,10 @@ namespace Baku.VMagicMirror
                     SetShadowColor(shadowRgb[0], shadowRgb[1], shadowRgb[2]);
                 });
             receiver.AssignCommandHandler(
+                VmmCommands.ShadowBlur,
+                message => SetShadowBlur(message.ToInt())
+            );
+            receiver.AssignCommandHandler(
                 VmmCommands.ShadowIntensity,
                 message => SetShadowIntensity(message.ParseAsPercentage())
             );
@@ -260,6 +264,9 @@ namespace Baku.VMagicMirror
 
         private void SetShadowColor(float r, float g, float b)
             => avatarDropShadowController.SetShadowColor(r, g, b);
+
+        private void SetShadowBlur(int blur)
+            => avatarDropShadowController.SetShadowBlur(blur);
 
         private void SetShadowIntensity(float shadowStrength)
             => avatarDropShadowController.SetShadowIntensity(shadowStrength);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -95,6 +95,13 @@ namespace Baku.VMagicMirror
                 .AddTo(this);
 
             receiver.AssignCommandHandler(
+                VmmCommands.ShadowColor,
+                message =>
+                {
+                    var shadowRgb = message.ToColorFloats();
+                    SetShadowColor(shadowRgb[0], shadowRgb[1], shadowRgb[2]);
+                });
+            receiver.AssignCommandHandler(
                 VmmCommands.ShadowIntensity,
                 message => SetShadowIntensity(message.ParseAsPercentage())
             );
@@ -250,6 +257,9 @@ namespace Baku.VMagicMirror
             // NOTE: セルフ落影のオンオフを動的に変えられるようにする場合、セルフ影がオンの場合にもSoftに倒す必要がある
             mainLight.shadows = lightingShadowEnabled ? LightShadows.Soft : LightShadows.None;
         }
+
+        private void SetShadowColor(float r, float g, float b)
+            => avatarDropShadowController.SetShadowColor(r, g, b);
 
         private void SetShadowIntensity(float shadowStrength)
             => avatarDropShadowController.SetShadowIntensity(shadowStrength);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
@@ -20,11 +20,16 @@ namespace Baku.VMagicMirror
         private const string ShadowBlurKeyword = "_VMM_SHADOW_BLUR";
         private const string ShadowGaussianBlurKeyword = "_VMM_SHADOW_GAUSSIAN_BLUR";
         private const float AlphaThresholdValue = 0.001f;
+        
+        private const float MinShadowDepth = 0.01f;
+
+        // シャドウのぼかし具合をカメラの寄り引きで調整するためのファクター
         private const float ShadowBlurWorldUnit = 0.001f;
         private const float ShadowBlurFactor = 0.3f;
         private const float BlurSizePowerFactor = 1.5f;
+        // ぼかしのサイズが大きいときが2-passのガウシアンブラーで処理する + その切替時にぼかしサイズが不連続に変わった印象を抑えるためのファクター
+        private const float GaussianBlurStepFactor = 0.3f;
         private const int GaussianBlurThreshold = 30;
-        private const float MinShadowDepth = 0.01f;
 
         [SerializeField] private Camera targetCamera = null;
         [SerializeField] private BackgroundImageBoard backgroundImageBoard = null;
@@ -220,17 +225,18 @@ namespace Baku.VMagicMirror
             var scale = CalculateShadowScale(depth, avatarBackDepth);
             var color = new Color(shadowColor.r, shadowColor.g, shadowColor.b, shadowIntensity);
             var blurStep = CalculateShadowBlurStep(depth);
+            var materialBlurStep = UseGaussianBlur ? blurStep * GaussianBlurStepFactor : blurStep;
 
             if (UseGaussianBlur)
             {
-                UpdateGaussianHorizontalBlurTexture(avatarMaskTexture, offset, scale, blurStep);
+                UpdateGaussianHorizontalBlurTexture(avatarMaskTexture, offset, scale, materialBlurStep);
                 _shadowQuadMaterial.SetTexture(ShadowBlurTex, _shadowGaussianHorizontalTexture);
             }
 
             _shadowQuadMaterial.SetVector(ShadowOffset, offset);
             _shadowQuadMaterial.SetVector(ShadowScale, Vector2.one * scale);
             _shadowQuadMaterial.SetColor(ShadowColor, color);
-            _shadowQuadMaterial.SetVector(ShadowBlurStep, blurStep);
+            _shadowQuadMaterial.SetVector(ShadowBlurStep, materialBlurStep);
             _shadowQuadMaterial.SetFloat(AlphaThreshold, AlphaThresholdValue);
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
@@ -16,6 +16,8 @@ namespace Baku.VMagicMirror
         private const string ShadowBlurKeyword = "_VMM_SHADOW_BLUR";
         private const float AlphaThresholdValue = 0.001f;
         private const float ShadowBlurWorldUnit = 0.001f;
+        private const float ShadowBlurFactor = 0.3f;
+        private const float BlurSizePowerFactor = 1.5f;
         private const float MinShadowDepth = 0.01f;
 
         [SerializeField] private Camera targetCamera = null;
@@ -220,7 +222,8 @@ namespace Baku.VMagicMirror
                 0.0001f,
                 Mathf.Tan(targetCamera.fieldOfView * Mathf.Deg2Rad * 0.5f));
             var tanHalfHorizontalFov = Mathf.Max(0.0001f, tanHalfVerticalFov * targetCamera.aspect);
-            var worldRadius = shadowBlur * ShadowBlurWorldUnit;
+            var adjustedBlur = 10f * ShadowBlurFactor * Mathf.Pow(shadowBlur / 10f, BlurSizePowerFactor);
+            var worldRadius = adjustedBlur * ShadowBlurWorldUnit;
 
             return new Vector2(
                 worldRadius / (2f * safeDepth * tanHalfHorizontalFov),

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
@@ -20,6 +20,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private Renderer shadowQuadRenderer = null;
         [SerializeField] private float shadowDepthOffset = 0.4f;
         [SerializeField] private float backgroundDepthMargin = 0.5f;
+        [SerializeField] private Color shadowColor = Color.black;
         [SerializeField] private float shadowIntensity = 0.65f;
         [SerializeField] private float shadowYawDeg = -20f;
         [SerializeField] private float shadowPitchDeg = 8f;
@@ -60,6 +61,7 @@ namespace Baku.VMagicMirror
         }
 
         public void SetDepthOffset(float offset) => shadowDepthOffset = offset;
+        public void SetShadowColor(float r, float g, float b) => shadowColor = new Color(r, g, b);
         public void SetShadowIntensity(float intensity) => shadowIntensity = intensity;
         public void SetShadowYaw(int yawDeg) => shadowYawDeg = yawDeg;
         public void SetShadowPitch(int pitchDeg) => shadowPitchDeg = pitchDeg;
@@ -170,7 +172,7 @@ namespace Baku.VMagicMirror
 
             var offset = CalculateShadowOffset(depth, avatarBackDepth);
             var scale = CalculateShadowScale(depth, avatarBackDepth);
-            var color = new Color(0f, 0f, 0f, shadowIntensity);
+            var color = new Color(shadowColor.r, shadowColor.g, shadowColor.b, shadowIntensity);
 
             _shadowQuadMaterial.SetVector(ShadowOffset, offset);
             _shadowQuadMaterial.SetVector(ShadowScale, Vector2.one * scale);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
@@ -10,9 +10,12 @@ namespace Baku.VMagicMirror
         private static readonly int ShadowOffset = Shader.PropertyToID("_ShadowOffset");
         private static readonly int ShadowScale = Shader.PropertyToID("_ShadowScale");
         private static readonly int ShadowColor = Shader.PropertyToID("_ShadowColor");
+        private static readonly int ShadowBlurStep = Shader.PropertyToID("_ShadowBlurStep");
         private static readonly int AlphaThreshold = Shader.PropertyToID("_AlphaThreshold");
         private static readonly int MaskOverscanInv = Shader.PropertyToID("_MaskOverscanInv");
+        private const string ShadowBlurKeyword = "_VMM_SHADOW_BLUR";
         private const float AlphaThresholdValue = 0.001f;
+        private const float ShadowBlurWorldUnit = 0.001f;
         private const float MinShadowDepth = 0.01f;
 
         [SerializeField] private Camera targetCamera = null;
@@ -22,6 +25,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private float backgroundDepthMargin = 0.5f;
         [SerializeField] private Color shadowColor = Color.black;
         [SerializeField] private float shadowIntensity = 0.65f;
+        [SerializeField] private int shadowBlur = 10;
         [SerializeField] private float shadowYawDeg = -20f;
         [SerializeField] private float shadowPitchDeg = 8f;
 
@@ -62,6 +66,11 @@ namespace Baku.VMagicMirror
 
         public void SetDepthOffset(float offset) => shadowDepthOffset = offset;
         public void SetShadowColor(float r, float g, float b) => shadowColor = new Color(r, g, b);
+        public void SetShadowBlur(int blur)
+        {
+            shadowBlur = Mathf.Clamp(blur, 0, 100);
+            ApplyShadowBlurKeyword();
+        }
         public void SetShadowIntensity(float intensity) => shadowIntensity = intensity;
         public void SetShadowYaw(int yawDeg) => shadowYawDeg = yawDeg;
         public void SetShadowPitch(int pitchDeg) => shadowPitchDeg = pitchDeg;
@@ -100,6 +109,7 @@ namespace Baku.VMagicMirror
                 name = "VmmAvatarDropShadowQuad (Runtime)"
             };
             shadowQuadRenderer.material = _shadowQuadMaterial;
+            ApplyShadowBlurKeyword();
         }
 
         private void UpdateShadowQuad()
@@ -177,7 +187,45 @@ namespace Baku.VMagicMirror
             _shadowQuadMaterial.SetVector(ShadowOffset, offset);
             _shadowQuadMaterial.SetVector(ShadowScale, Vector2.one * scale);
             _shadowQuadMaterial.SetColor(ShadowColor, color);
+            _shadowQuadMaterial.SetVector(ShadowBlurStep, CalculateShadowBlurStep(depth));
             _shadowQuadMaterial.SetFloat(AlphaThreshold, AlphaThresholdValue);
+        }
+
+        private void ApplyShadowBlurKeyword()
+        {
+            if (_shadowQuadMaterial == null)
+            {
+                return;
+            }
+
+            if (shadowBlur > 0)
+            {
+                _shadowQuadMaterial.EnableKeyword(ShadowBlurKeyword);
+            }
+            else
+            {
+                _shadowQuadMaterial.DisableKeyword(ShadowBlurKeyword);
+            }
+        }
+
+        private Vector2 CalculateShadowBlurStep(float shadowDepth)
+        {
+            if (shadowBlur <= 0)
+            {
+                return Vector2.zero;
+            }
+
+            var safeDepth = Mathf.Max(0.0001f, shadowDepth);
+            var tanHalfVerticalFov = Mathf.Max(
+                0.0001f,
+                Mathf.Tan(targetCamera.fieldOfView * Mathf.Deg2Rad * 0.5f));
+            var tanHalfHorizontalFov = Mathf.Max(0.0001f, tanHalfVerticalFov * targetCamera.aspect);
+            var worldRadius = shadowBlur * ShadowBlurWorldUnit;
+
+            return new Vector2(
+                worldRadius / (2f * safeDepth * tanHalfHorizontalFov),
+                worldRadius / (2f * safeDepth * tanHalfVerticalFov)
+            );
         }
 
         private Vector2 CalculateShadowOffset(float shadowDepth, float avatarBackDepth)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmAvatarDropShadowController.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Rendering;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -6,7 +8,9 @@ namespace Baku.VMagicMirror
     public sealed class VmmAvatarDropShadowController : MonoBehaviour
     {
         private const string ShadowQuadShaderName = "Hidden/Vmm/AvatarDropShadowQuad";
+        private const string ShadowGaussianHorizontalShaderName = "Hidden/Vmm/AvatarDropShadowGaussianHorizontal";
         private static readonly int AvatarMaskTex = Shader.PropertyToID("_AvatarMaskTex");
+        private static readonly int ShadowBlurTex = Shader.PropertyToID("_ShadowBlurTex");
         private static readonly int ShadowOffset = Shader.PropertyToID("_ShadowOffset");
         private static readonly int ShadowScale = Shader.PropertyToID("_ShadowScale");
         private static readonly int ShadowColor = Shader.PropertyToID("_ShadowColor");
@@ -14,10 +18,12 @@ namespace Baku.VMagicMirror
         private static readonly int AlphaThreshold = Shader.PropertyToID("_AlphaThreshold");
         private static readonly int MaskOverscanInv = Shader.PropertyToID("_MaskOverscanInv");
         private const string ShadowBlurKeyword = "_VMM_SHADOW_BLUR";
+        private const string ShadowGaussianBlurKeyword = "_VMM_SHADOW_GAUSSIAN_BLUR";
         private const float AlphaThresholdValue = 0.001f;
         private const float ShadowBlurWorldUnit = 0.001f;
         private const float ShadowBlurFactor = 0.3f;
         private const float BlurSizePowerFactor = 1.5f;
+        private const int GaussianBlurThreshold = 30;
         private const float MinShadowDepth = 0.01f;
 
         [SerializeField] private Camera targetCamera = null;
@@ -32,8 +38,13 @@ namespace Baku.VMagicMirror
         [SerializeField] private float shadowPitchDeg = 8f;
 
         private Material _shadowQuadMaterial;
+        private Material _shadowGaussianHorizontalMaterial;
+        private RenderTexture _shadowGaussianHorizontalTexture;
         // NOTE: componentのenabledではない形でon/offを制御しとく
         private bool _enabled = true;
+
+        private bool UseGaussianBlur => shadowBlur >= GaussianBlurThreshold && _shadowGaussianHorizontalMaterial != null;
+        private bool UseSmallBlur => shadowBlur > 0 && !UseGaussianBlur;
 
         private bool HasBackgroundImage => 
             backgroundImageBoard != null &&
@@ -72,6 +83,10 @@ namespace Baku.VMagicMirror
         {
             shadowBlur = Mathf.Clamp(blur, 0, 100);
             ApplyShadowBlurKeyword();
+            if (!UseGaussianBlur)
+            {
+                ReleaseGaussianBlurTexture();
+            }
         }
         public void SetShadowIntensity(float intensity) => shadowIntensity = intensity;
         public void SetShadowYaw(int yawDeg) => shadowYawDeg = yawDeg;
@@ -96,6 +111,14 @@ namespace Baku.VMagicMirror
                 Destroy(_shadowQuadMaterial);
                 _shadowQuadMaterial = null;
             }
+
+            if (_shadowGaussianHorizontalMaterial != null)
+            {
+                Destroy(_shadowGaussianHorizontalMaterial);
+                _shadowGaussianHorizontalMaterial = null;
+            }
+
+            ReleaseGaussianBlurTexture();
         }
 
         private void EnsureShadowQuadMaterial()
@@ -111,6 +134,16 @@ namespace Baku.VMagicMirror
                 name = "VmmAvatarDropShadowQuad (Runtime)"
             };
             shadowQuadRenderer.material = _shadowQuadMaterial;
+
+            var gaussianHorizontalShader = Shader.Find(ShadowGaussianHorizontalShaderName);
+            if (gaussianHorizontalShader != null)
+            {
+                _shadowGaussianHorizontalMaterial = new Material(gaussianHorizontalShader)
+                {
+                    name = "VmmAvatarDropShadowGaussianHorizontal (Runtime)"
+                };
+            }
+
             ApplyShadowBlurKeyword();
         }
 
@@ -179,17 +212,25 @@ namespace Baku.VMagicMirror
 
         private void UpdateShadowQuadMaterial(float depth, float avatarBackDepth)
         {
-            _shadowQuadMaterial.SetTexture(AvatarMaskTex, _avatarMaskTextureController.AvatarMaskHandle.rt);
+            var avatarMaskTexture = _avatarMaskTextureController.AvatarMaskHandle.rt;
+            _shadowQuadMaterial.SetTexture(AvatarMaskTex, avatarMaskTexture);
             _shadowQuadMaterial.SetFloat(MaskOverscanInv, 1.0f / _avatarMaskTextureController.AvatarMaskOverscanFactor);
 
             var offset = CalculateShadowOffset(depth, avatarBackDepth);
             var scale = CalculateShadowScale(depth, avatarBackDepth);
             var color = new Color(shadowColor.r, shadowColor.g, shadowColor.b, shadowIntensity);
+            var blurStep = CalculateShadowBlurStep(depth);
+
+            if (UseGaussianBlur)
+            {
+                UpdateGaussianHorizontalBlurTexture(avatarMaskTexture, offset, scale, blurStep);
+                _shadowQuadMaterial.SetTexture(ShadowBlurTex, _shadowGaussianHorizontalTexture);
+            }
 
             _shadowQuadMaterial.SetVector(ShadowOffset, offset);
             _shadowQuadMaterial.SetVector(ShadowScale, Vector2.one * scale);
             _shadowQuadMaterial.SetColor(ShadowColor, color);
-            _shadowQuadMaterial.SetVector(ShadowBlurStep, CalculateShadowBlurStep(depth));
+            _shadowQuadMaterial.SetVector(ShadowBlurStep, blurStep);
             _shadowQuadMaterial.SetFloat(AlphaThreshold, AlphaThresholdValue);
         }
 
@@ -200,14 +241,88 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            if (shadowBlur > 0)
+            if (UseGaussianBlur)
+            {
+                _shadowQuadMaterial.DisableKeyword(ShadowBlurKeyword);
+                _shadowQuadMaterial.EnableKeyword(ShadowGaussianBlurKeyword);
+            }
+            else if (UseSmallBlur)
             {
                 _shadowQuadMaterial.EnableKeyword(ShadowBlurKeyword);
+                _shadowQuadMaterial.DisableKeyword(ShadowGaussianBlurKeyword);
             }
             else
             {
                 _shadowQuadMaterial.DisableKeyword(ShadowBlurKeyword);
+                _shadowQuadMaterial.DisableKeyword(ShadowGaussianBlurKeyword);
             }
+        }
+
+        private void UpdateGaussianHorizontalBlurTexture(RenderTexture avatarMaskTexture, Vector2 offset, float scale, Vector2 blurStep)
+        {
+            EnsureGaussianBlurTexture(avatarMaskTexture);
+            if (_shadowGaussianHorizontalTexture == null)
+            {
+                return;
+            }
+
+            _shadowGaussianHorizontalMaterial.SetTexture(AvatarMaskTex, avatarMaskTexture);
+            _shadowGaussianHorizontalMaterial.SetVector(ShadowOffset, offset);
+            _shadowGaussianHorizontalMaterial.SetVector(ShadowScale, Vector2.one * scale);
+            _shadowGaussianHorizontalMaterial.SetVector(ShadowBlurStep, blurStep);
+            _shadowGaussianHorizontalMaterial.SetFloat(AlphaThreshold, AlphaThresholdValue);
+            _shadowGaussianHorizontalMaterial.SetFloat(
+                MaskOverscanInv,
+                1.0f / _avatarMaskTextureController.AvatarMaskOverscanFactor);
+
+            Graphics.Blit(avatarMaskTexture, _shadowGaussianHorizontalTexture, _shadowGaussianHorizontalMaterial);
+        }
+
+        private void EnsureGaussianBlurTexture(RenderTexture source)
+        {
+            if (_shadowGaussianHorizontalTexture != null &&
+                _shadowGaussianHorizontalTexture.width == source.width &&
+                _shadowGaussianHorizontalTexture.height == source.height)
+            {
+                return;
+            }
+
+            ReleaseGaussianBlurTexture();
+
+            var descriptor = new RenderTextureDescriptor(source.width, source.height)
+            {
+                graphicsFormat = GraphicsFormat.R8_UNorm,
+                depthStencilFormat = GraphicsFormat.None,
+                msaaSamples = 1,
+                mipCount = 1,
+                volumeDepth = 1,
+                dimension = TextureDimension.Tex2D,
+                sRGB = false,
+                useMipMap = false,
+                autoGenerateMips = false
+            };
+            _shadowGaussianHorizontalTexture = new RenderTexture(descriptor)
+            {
+                name = "VmmAvatarDropShadowGaussianHorizontal",
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp
+            };
+            _shadowGaussianHorizontalTexture.Create();
+        }
+
+        private void ReleaseGaussianBlurTexture()
+        {
+            if (_shadowGaussianHorizontalTexture == null)
+            {
+                return;
+            }
+
+            if (_shadowGaussianHorizontalTexture.IsCreated())
+            {
+                _shadowGaussianHorizontalTexture.Release();
+            }
+            Destroy(_shadowGaussianHorizontalTexture);
+            _shadowGaussianHorizontalTexture = null;
         }
 
         private Vector2 CalculateShadowBlurStep(float shadowDepth)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -216,6 +216,7 @@
         UseDesktopLightAdjust,
 
         ShadowEnable,
+        ShadowColor,
         ShadowIntensity,
         ShadowYaw,
         ShadowPitch,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -217,6 +217,7 @@
 
         ShadowEnable,
         ShadowColor,
+        ShadowBlur,
         ShadowIntensity,
         ShadowYaw,
         ShadowPitch,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowGaussianHorizontal.shader
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowGaussianHorizontal.shader
@@ -1,0 +1,94 @@
+Shader "Hidden/Vmm/AvatarDropShadowGaussianHorizontal"
+{
+    HLSLINCLUDE
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+        TEXTURE2D(_AvatarMaskTex);
+        SAMPLER(sampler_AvatarMaskTex);
+
+        float2 _ShadowOffset;
+        float2 _ShadowScale;
+        float2 _ShadowBlurStep;
+        float _AlphaThreshold;
+        float _MaskOverscanInv;
+
+        struct Attributes
+        {
+            float4 positionOS : POSITION;
+            float2 uv : TEXCOORD0;
+        };
+
+        struct Varyings
+        {
+            float4 positionCS : SV_POSITION;
+            float2 uv : TEXCOORD0;
+        };
+
+        Varyings Vert(Attributes input)
+        {
+            Varyings output;
+            VertexPositionInputs positionInputs = GetVertexPositionInputs(input.positionOS.xyz);
+            output.positionCS = positionInputs.positionCS;
+            output.uv = input.uv;
+            return output;
+        }
+
+        float SampleShadowMask(float2 uv)
+        {
+            const float2 pivot = float2(0.5, 0.5);
+            float2 safeScale = max(_ShadowScale, float2(0.0001, 0.0001));
+            float2 sourceUv = (((uv - pivot) - _ShadowOffset) / safeScale) * _MaskOverscanInv + pivot;
+            float sourceInRange =
+                step(0.0, sourceUv.x) *
+                step(0.0, sourceUv.y) *
+                step(sourceUv.x, 1.0) *
+                step(sourceUv.y, 1.0);
+
+            float mask = SAMPLE_TEXTURE2D(_AvatarMaskTex, sampler_AvatarMaskTex, sourceUv).r;
+            float alphaRange = max(1e-5, 1.0 - _AlphaThreshold);
+            float shadowMask = saturate((mask - _AlphaThreshold) / alphaRange);
+            return shadowMask * sourceInRange;
+        }
+
+        float SampleGaussianHorizontalMask(float2 uv)
+        {
+            float2 blurStep = float2(_ShadowBlurStep.x, 0.0);
+            float mask = SampleShadowMask(uv) * 0.1370;
+
+            mask += SampleShadowMask(uv + blurStep * 1.0) * 0.1296;
+            mask += SampleShadowMask(uv - blurStep * 1.0) * 0.1296;
+            mask += SampleShadowMask(uv + blurStep * 2.0) * 0.1098;
+            mask += SampleShadowMask(uv - blurStep * 2.0) * 0.1098;
+            mask += SampleShadowMask(uv + blurStep * 3.0) * 0.0832;
+            mask += SampleShadowMask(uv - blurStep * 3.0) * 0.0832;
+            mask += SampleShadowMask(uv + blurStep * 4.0) * 0.0563;
+            mask += SampleShadowMask(uv - blurStep * 4.0) * 0.0563;
+            mask += SampleShadowMask(uv + blurStep * 5.0) * 0.0341;
+            mask += SampleShadowMask(uv - blurStep * 5.0) * 0.0341;
+            mask += SampleShadowMask(uv + blurStep * 6.0) * 0.0185;
+            mask += SampleShadowMask(uv - blurStep * 6.0) * 0.0185;
+
+            return mask;
+        }
+
+        float4 Frag(Varyings input) : SV_Target
+        {
+            float mask = SampleGaussianHorizontalMask(input.uv);
+            return float4(mask, mask, mask, mask);
+        }
+    ENDHLSL
+
+    SubShader
+    {
+        Tags { "RenderPipeline" = "UniversalPipeline" }
+        Cull Off ZWrite Off ZTest Always
+
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex Vert
+            #pragma fragment Frag
+            ENDHLSL
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowGaussianHorizontal.shader.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowGaussianHorizontal.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9e2c3e123a5348f58e2db6c076a0db8d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowQuad.shader
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowQuad.shader
@@ -9,6 +9,7 @@ Shader "Hidden/Vmm/AvatarDropShadowQuad"
         float4 _ShadowColor;
         float2 _ShadowOffset;
         float2 _ShadowScale;
+        float2 _ShadowBlurStep;
         float _AlphaThreshold;
         float _MaskOverscanInv;
 
@@ -50,9 +51,36 @@ Shader "Hidden/Vmm/AvatarDropShadowQuad"
             return shadowMask * sourceInRange;
         }
 
+        float SampleBlurredShadowMask(float2 uv)
+        {
+            float2 blurStep = _ShadowBlurStep;
+            float mask = SampleShadowMask(uv) * 0.24;
+
+            mask += SampleShadowMask(uv + float2(blurStep.x, 0.0)) * 0.1;
+            mask += SampleShadowMask(uv - float2(blurStep.x, 0.0)) * 0.1;
+            mask += SampleShadowMask(uv + float2(0.0, blurStep.y)) * 0.1;
+            mask += SampleShadowMask(uv - float2(0.0, blurStep.y)) * 0.1;
+
+            mask += SampleShadowMask(uv + float2(blurStep.x, blurStep.y)) * 0.06;
+            mask += SampleShadowMask(uv + float2(-blurStep.x, blurStep.y)) * 0.06;
+            mask += SampleShadowMask(uv + float2(blurStep.x, -blurStep.y)) * 0.06;
+            mask += SampleShadowMask(uv - float2(blurStep.x, blurStep.y)) * 0.06;
+
+            mask += SampleShadowMask(uv + float2(2.0 * blurStep.x, 0.0)) * 0.03;
+            mask += SampleShadowMask(uv - float2(2.0 * blurStep.x, 0.0)) * 0.03;
+            mask += SampleShadowMask(uv + float2(0.0, 2.0 * blurStep.y)) * 0.03;
+            mask += SampleShadowMask(uv - float2(0.0, 2.0 * blurStep.y)) * 0.03;
+
+            return mask;
+        }
+
         float4 Frag(Varyings input) : SV_Target
         {
+            #if defined(_VMM_SHADOW_BLUR)
+            float shadowAlpha = SampleBlurredShadowMask(input.uv) * _ShadowColor.a;
+            #else
             float shadowAlpha = SampleShadowMask(input.uv) * _ShadowColor.a;
+            #endif
             return float4(_ShadowColor.rgb, shadowAlpha);
         }
     ENDHLSL
@@ -76,6 +104,7 @@ Shader "Hidden/Vmm/AvatarDropShadowQuad"
             HLSLPROGRAM
             #pragma vertex Vert
             #pragma fragment Frag
+            #pragma multi_compile_local _ _VMM_SHADOW_BLUR
             ENDHLSL
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowQuad.shader
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmAvatarDropShadowQuad.shader
@@ -5,6 +5,8 @@ Shader "Hidden/Vmm/AvatarDropShadowQuad"
 
         TEXTURE2D(_AvatarMaskTex);
         SAMPLER(sampler_AvatarMaskTex);
+        TEXTURE2D(_ShadowBlurTex);
+        SAMPLER(sampler_ShadowBlurTex);
 
         float4 _ShadowColor;
         float2 _ShadowOffset;
@@ -74,9 +76,32 @@ Shader "Hidden/Vmm/AvatarDropShadowQuad"
             return mask;
         }
 
+        float SampleGaussianBlurredShadowMask(float2 uv)
+        {
+            float2 blurStep = float2(0.0, _ShadowBlurStep.y);
+            float mask = SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv).r * 0.1370;
+
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv + blurStep * 1.0).r * 0.1296;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv - blurStep * 1.0).r * 0.1296;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv + blurStep * 2.0).r * 0.1098;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv - blurStep * 2.0).r * 0.1098;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv + blurStep * 3.0).r * 0.0832;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv - blurStep * 3.0).r * 0.0832;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv + blurStep * 4.0).r * 0.0563;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv - blurStep * 4.0).r * 0.0563;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv + blurStep * 5.0).r * 0.0341;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv - blurStep * 5.0).r * 0.0341;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv + blurStep * 6.0).r * 0.0185;
+            mask += SAMPLE_TEXTURE2D(_ShadowBlurTex, sampler_ShadowBlurTex, uv - blurStep * 6.0).r * 0.0185;
+
+            return mask;
+        }
+
         float4 Frag(Varyings input) : SV_Target
         {
-            #if defined(_VMM_SHADOW_BLUR)
+            #if defined(_VMM_SHADOW_GAUSSIAN_BLUR)
+            float shadowAlpha = SampleGaussianBlurredShadowMask(input.uv) * _ShadowColor.a;
+            #elif defined(_VMM_SHADOW_BLUR)
             float shadowAlpha = SampleBlurredShadowMask(input.uv) * _ShadowColor.a;
             #else
             float shadowAlpha = SampleShadowMask(input.uv) * _ShadowColor.a;
@@ -104,7 +129,7 @@ Shader "Hidden/Vmm/AvatarDropShadowQuad"
             HLSLPROGRAM
             #pragma vertex Vert
             #pragma fragment Frag
-            #pragma multi_compile_local _ _VMM_SHADOW_BLUR
+            #pragma multi_compile_local _ _VMM_SHADOW_BLUR _VMM_SHADOW_GAUSSIAN_BLUR
             ENDHLSL
         }
     }

--- a/VMagicMirror/ProjectSettings/GraphicsSettings.asset
+++ b/VMagicMirror/ProjectSettings/GraphicsSettings.asset
@@ -50,6 +50,7 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   - {fileID: 4800000, guid: 8c17b56f4bf084c47872edcb95237e4a, type: 3}
   - {fileID: 4800000, guid: 1a60714b3f0ce4147a009855466aceda, type: 3}
+  - {fileID: 4800000, guid: 9e2c3e123a5348f58e2db6c076a0db8d, type: 3}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,

--- a/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
@@ -39,6 +39,7 @@
         public int ShadowR { get; set; } = 0;
         public int ShadowG { get; set; } = 0;
         public int ShadowB { get; set; } = 0;
+        public int ShadowBlur { get; set; } = 10;
         public int ShadowIntensity { get; set; } = 65;
         public int ShadowYaw { get; set; } = -20;
         public int ShadowPitch { get; set; } = 8;

--- a/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
@@ -36,6 +36,9 @@
         #region Shadow
 
         public bool EnableShadow { get; set; } = true;
+        public int ShadowR { get; set; } = 0;
+        public int ShadowG { get; set; } = 0;
+        public int ShadowB { get; set; } = 0;
         public int ShadowIntensity { get; set; } = 65;
         public int ShadowYaw { get; set; } = -20;
         public int ShadowPitch { get; set; } = 8;

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -301,6 +301,7 @@ namespace Baku.VMagicMirrorConfig
         public static Message UseDesktopLightAdjust(bool use) => BoolContent(VmmCommands.UseDesktopLightAdjust, use);
 
         public static Message ShadowEnable(bool enable) => BoolContent(VmmCommands.ShadowEnable, enable);
+        public static Message ShadowColor(int r, int g, int b) => IntArrayContent(VmmCommands.ShadowColor, [r, g, b]);
         public static Message ShadowIntensity(int intensityPercent) => IntContent(VmmCommands.ShadowIntensity, intensityPercent);
         public static Message ShadowYaw(int angleDeg) => IntContent(VmmCommands.ShadowYaw, angleDeg);
         public static Message ShadowPitch(int angleDeg) => IntContent(VmmCommands.ShadowPitch, angleDeg);

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -302,6 +302,7 @@ namespace Baku.VMagicMirrorConfig
 
         public static Message ShadowEnable(bool enable) => BoolContent(VmmCommands.ShadowEnable, enable);
         public static Message ShadowColor(int r, int g, int b) => IntArrayContent(VmmCommands.ShadowColor, [r, g, b]);
+        public static Message ShadowBlur(int blur) => IntContent(VmmCommands.ShadowBlur, blur);
         public static Message ShadowIntensity(int intensityPercent) => IntContent(VmmCommands.ShadowIntensity, intensityPercent);
         public static Message ShadowYaw(int angleDeg) => IntContent(VmmCommands.ShadowYaw, angleDeg);
         public static Message ShadowPitch(int angleDeg) => IntContent(VmmCommands.ShadowPitch, angleDeg);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -44,6 +44,7 @@ namespace Baku.VMagicMirrorConfig
             ShadowR = new RProperty<int>(s.ShadowR, _ => sendShadowColor());
             ShadowG = new RProperty<int>(s.ShadowG, _ => sendShadowColor());
             ShadowB = new RProperty<int>(s.ShadowB, _ => sendShadowColor());
+            ShadowBlur = new RProperty<int>(s.ShadowBlur, i => SendMessage(MessageFactory.ShadowBlur(i)));
             ShadowIntensity = new RProperty<int>(s.ShadowIntensity, i => SendMessage(MessageFactory.ShadowIntensity(i)));
             ShadowYaw = new RProperty<int>(s.ShadowYaw, i => SendMessage(MessageFactory.ShadowYaw(i)));
             ShadowPitch = new RProperty<int>(s.ShadowPitch, i => SendMessage(MessageFactory.ShadowPitch(i)));
@@ -127,6 +128,7 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<int> ShadowR { get; }
         public RProperty<int> ShadowG { get; }
         public RProperty<int> ShadowB { get; }
+        public RProperty<int> ShadowBlur { get; }
         public RProperty<int> ShadowIntensity { get; }
         public RProperty<int> ShadowYaw { get; }
         public RProperty<int> ShadowPitch { get; }
@@ -222,6 +224,7 @@ namespace Baku.VMagicMirrorConfig
             ShadowR.Value = setting.ShadowR;
             ShadowG.Value = setting.ShadowG;
             ShadowB.Value = setting.ShadowB;
+            ShadowBlur.Value = setting.ShadowBlur;
             ShadowIntensity.Value = setting.ShadowIntensity;
             ShadowYaw.Value = setting.ShadowYaw;
             ShadowPitch.Value = setting.ShadowPitch;

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -39,6 +39,11 @@ namespace Baku.VMagicMirrorConfig
             UseDesktopLightAdjust = new RProperty<bool>(s.UseDesktopLightAdjust, b => SendMessage(MessageFactory.UseDesktopLightAdjust(b)));
 
             EnableShadow = new RProperty<bool>(s.EnableShadow, b => SendMessage(MessageFactory.ShadowEnable(b)));
+            Action sendShadowColor = () =>
+                SendMessage(MessageFactory.ShadowColor(ShadowR?.Value ?? 0, ShadowG?.Value ?? 0, ShadowB?.Value ?? 0));
+            ShadowR = new RProperty<int>(s.ShadowR, _ => sendShadowColor());
+            ShadowG = new RProperty<int>(s.ShadowG, _ => sendShadowColor());
+            ShadowB = new RProperty<int>(s.ShadowB, _ => sendShadowColor());
             ShadowIntensity = new RProperty<int>(s.ShadowIntensity, i => SendMessage(MessageFactory.ShadowIntensity(i)));
             ShadowYaw = new RProperty<int>(s.ShadowYaw, i => SendMessage(MessageFactory.ShadowYaw(i)));
             ShadowPitch = new RProperty<int>(s.ShadowPitch, i => SendMessage(MessageFactory.ShadowPitch(i)));
@@ -119,6 +124,9 @@ namespace Baku.VMagicMirrorConfig
         #region Shadow
 
         public RProperty<bool> EnableShadow { get; }
+        public RProperty<int> ShadowR { get; }
+        public RProperty<int> ShadowG { get; }
+        public RProperty<int> ShadowB { get; }
         public RProperty<int> ShadowIntensity { get; }
         public RProperty<int> ShadowYaw { get; }
         public RProperty<int> ShadowPitch { get; }
@@ -211,6 +219,9 @@ namespace Baku.VMagicMirrorConfig
         {
             var setting = LightSetting.Default;
             EnableShadow.Value = setting.EnableShadow;
+            ShadowR.Value = setting.ShadowR;
+            ShadowG.Value = setting.ShadowG;
+            ShadowB.Value = setting.ShadowB;
             ShadowIntensity.Value = setting.ShadowIntensity;
             ShadowYaw.Value = setting.ShadowYaw;
             ShadowPitch.Value = setting.ShadowPitch;

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -599,6 +599,7 @@ Translate (2 way):
     <sys:String x:Key="Shadow">Shadow</sys:String>
     <sys:String x:Key="Shadow_Enable">Enable Shadow</sys:String>
     <sys:String x:Key="Shadow_Enable_Streaming">Avatar's Shadow</sys:String>
+    <sys:String x:Key="Shadow_Color">Shadow Color</sys:String>
     <sys:String x:Key="Shadow_Intensity">Intensity [%]</sys:String>
     <sys:String x:Key="Shadow_Yaw">Yaw Angle [deg]</sys:String>
     <sys:String x:Key="Shadow_Pitch">Pitch Angle [deg]</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -600,6 +600,7 @@ Translate (2 way):
     <sys:String x:Key="Shadow_Enable">Enable Shadow</sys:String>
     <sys:String x:Key="Shadow_Enable_Streaming">Avatar's Shadow</sys:String>
     <sys:String x:Key="Shadow_Color">Shadow Color</sys:String>
+    <sys:String x:Key="Shadow_Blur">Blur Size</sys:String>
     <sys:String x:Key="Shadow_Intensity">Intensity [%]</sys:String>
     <sys:String x:Key="Shadow_Yaw">Yaw Angle [deg]</sys:String>
     <sys:String x:Key="Shadow_Pitch">Pitch Angle [deg]</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -599,6 +599,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Shadow">影</sys:String>
     <sys:String x:Key="Shadow_Enable">影を有効化</sys:String>
     <sys:String x:Key="Shadow_Enable_Streaming">アバターの影</sys:String>
+    <sys:String x:Key="Shadow_Color">影の色</sys:String>
     <sys:String x:Key="Shadow_Intensity">濃さ[%]</sys:String>
     <sys:String x:Key="Shadow_Yaw">向き(横)[deg]</sys:String>
     <sys:String x:Key="Shadow_Pitch">向き(上下)[deg]</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -600,6 +600,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Shadow_Enable">影を有効化</sys:String>
     <sys:String x:Key="Shadow_Enable_Streaming">アバターの影</sys:String>
     <sys:String x:Key="Shadow_Color">影の色</sys:String>
+    <sys:String x:Key="Shadow_Blur">ぼかしの大きさ</sys:String>
     <sys:String x:Key="Shadow_Intensity">濃さ[%]</sys:String>
     <sys:String x:Key="Shadow_Yaw">向き(横)[deg]</sys:String>
     <sys:String x:Key="Shadow_Pitch">向き(上下)[deg]</sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -258,6 +258,7 @@
                             </Style>
                         </Grid.Resources>
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="32"/>
                             <RowDefinition/>
                             <RowDefinition/>
                             <RowDefinition/>
@@ -270,50 +271,69 @@
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Row="0" Grid.Column="0"
+                                   Text="{DynamicResource Shadow_Color}" />
+                        <StackPanel Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
+                                    Orientation="Horizontal">
+                            <Rectangle Style="{StaticResource ColorSampleRectangle}">
+                                <Rectangle.Fill>
+                                    <SolidColorBrush Color="{Binding ShadowColor}"/>
+                                </Rectangle.Fill>
+                            </Rectangle>
+                            <Button Style="{DynamicResource ColorEditButton}"
+                                    Command="{Binding EditShadowColorCommand}">
+                                <StackPanel Orientation="Horizontal">
+                                    <md:PackIcon Style="{StaticResource ColorEditButtonIcon}"/>
+                                    <TextBlock Style="{StaticResource ColorEditButtonText}"
+                                               Text="{DynamicResource Setting_EditColor}"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+
+                        <TextBlock Grid.Row="1" Grid.Column="0"
                                    Text="{DynamicResource Shadow_Intensity}" />
-                        <Slider Grid.Row="0" Grid.Column="1"
+                        <Slider Grid.Row="1" Grid.Column="1"
                                 x:Name="sliderShadowIntensity"
                                 Minimum="0"
                                 Maximum="100"
                                 Value="{Binding ShadowIntensity.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="0" Grid.Column="2"
+                        <TextBox Grid.Row="1" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderShadowIntensity}"
                                  />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0"
+                        <TextBlock Grid.Row="2" Grid.Column="0"
                                    Text="{DynamicResource Shadow_Yaw}" />
-                        <Slider Grid.Row="1" Grid.Column="1"
+                        <Slider Grid.Row="2" Grid.Column="1"
                                 x:Name="sliderShadowYaw"
                                 Minimum="-180"
                                 Maximum="180"
                                 Value="{Binding ShadowYaw.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="1" Grid.Column="2"
+                        <TextBox Grid.Row="2" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderShadowYaw}"
                                  />
 
-                        <TextBlock Grid.Row="2" Grid.Column="0"
+                        <TextBlock Grid.Row="3" Grid.Column="0"
                                    Text="{DynamicResource Shadow_Pitch}" />
-                        <Slider Grid.Row="2" Grid.Column="1"
+                        <Slider Grid.Row="3" Grid.Column="1"
                                 x:Name="sliderShadowPitch"
                                 Minimum="-90"
                                 Maximum="90"
                                 Value="{Binding ShadowPitch.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="2" Grid.Column="2"
+                        <TextBox Grid.Row="3" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderShadowPitch}"
                                  />
 
-                        <TextBlock Grid.Row="3" Grid.Column="0"
+                        <TextBlock Grid.Row="4" Grid.Column="0"
                                    Text="{DynamicResource Shadow_DepthOffset}" />
-                        <Slider Grid.Row="3" Grid.Column="1"
+                        <Slider Grid.Row="4" Grid.Column="1"
                                 x:Name="sliderShadowDepthOffset"
                                 Minimum="1"
                                 Maximum="250"
                                 Value="{Binding ShadowDepthOffset.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="3" Grid.Column="2"
+                        <TextBox Grid.Row="4" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderShadowDepthOffset}"
                                  />
 

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -263,6 +263,7 @@
                             <RowDefinition/>
                             <RowDefinition/>
                             <RowDefinition/>
+                            <RowDefinition/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -302,38 +303,50 @@
                                  />
 
                         <TextBlock Grid.Row="2" Grid.Column="0"
-                                   Text="{DynamicResource Shadow_Yaw}" />
+                                   Text="{DynamicResource Shadow_Blur}" />
                         <Slider Grid.Row="2" Grid.Column="1"
+                                x:Name="sliderShadowBlur"
+                                Minimum="0"
+                                Maximum="100"
+                                Value="{Binding ShadowBlur.Value, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="2" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderShadowBlur}"
+                                 />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0"
+                                   Text="{DynamicResource Shadow_Yaw}" />
+                        <Slider Grid.Row="3" Grid.Column="1"
                                 x:Name="sliderShadowYaw"
                                 Minimum="-180"
                                 Maximum="180"
                                 Value="{Binding ShadowYaw.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="2" Grid.Column="2"
+                        <TextBox Grid.Row="3" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderShadowYaw}"
                                  />
 
-                        <TextBlock Grid.Row="3" Grid.Column="0"
+                        <TextBlock Grid.Row="4" Grid.Column="0"
                                    Text="{DynamicResource Shadow_Pitch}" />
-                        <Slider Grid.Row="3" Grid.Column="1"
+                        <Slider Grid.Row="4" Grid.Column="1"
                                 x:Name="sliderShadowPitch"
                                 Minimum="-90"
                                 Maximum="90"
                                 Value="{Binding ShadowPitch.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="3" Grid.Column="2"
+                        <TextBox Grid.Row="4" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderShadowPitch}"
                                  />
 
-                        <TextBlock Grid.Row="4" Grid.Column="0"
+                        <TextBlock Grid.Row="5" Grid.Column="0"
                                    Text="{DynamicResource Shadow_DepthOffset}" />
-                        <Slider Grid.Row="4" Grid.Column="1"
+                        <Slider Grid.Row="5" Grid.Column="1"
                                 x:Name="sliderShadowDepthOffset"
                                 Minimum="1"
                                 Maximum="250"
                                 Value="{Binding ShadowDepthOffset.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="4" Grid.Column="2"
+                        <TextBox Grid.Row="5" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderShadowDepthOffset}"
                                  />
 

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -52,6 +52,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 new RgbColorBinding(LightR, LightG, LightB),
                 "Light_Color"
             ));
+            EditShadowColorCommand = new ActionCommand(() => ShowColorWindow(
+                new RgbColorBinding(ShadowR, ShadowG, ShadowB),
+                "Shadow_Color"
+            ));
             EditBloomColorCommand = new ActionCommand(() => ShowColorWindow(
                 new RgbColorBinding(BloomR, BloomG, BloomB),
                 "Bloom_Color"
@@ -87,6 +91,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 model.LightR.AddWeakEventHandler(UpdateLightColor);
                 model.LightG.AddWeakEventHandler(UpdateLightColor);
                 model.LightB.AddWeakEventHandler(UpdateLightColor);
+
+                model.ShadowR.AddWeakEventHandler(UpdateShadowColor);
+                model.ShadowG.AddWeakEventHandler(UpdateShadowColor);
+                model.ShadowB.AddWeakEventHandler(UpdateShadowColor);
 
                 model.BloomR.AddWeakEventHandler(UpdateBloomColor);
                 model.BloomG.AddWeakEventHandler(UpdateBloomColor);
@@ -128,6 +136,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<bool> DisableHdrAlways => _model.DisableHdrAlways;
 
         void UpdateLightColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(LightColor));
+        void UpdateShadowColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(ShadowColor));
         void UpdateBloomColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(BloomColor));
         void UpdateOutlineEffectColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(OutlineEffectColor));
         void UpdateRimColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(RimColor));
@@ -193,10 +202,24 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         #region Shadow
 
         public RProperty<bool> EnableShadow => _model.EnableShadow;
+        public RProperty<int> ShadowR => _model.ShadowR;
+        public RProperty<int> ShadowG => _model.ShadowG;
+        public RProperty<int> ShadowB => _model.ShadowB;
         public RProperty<int> ShadowIntensity => _model.ShadowIntensity;
         public RProperty<int> ShadowYaw => _model.ShadowYaw;
         public RProperty<int> ShadowPitch => _model.ShadowPitch;
         public RProperty<int> ShadowDepthOffset => _model.ShadowDepthOffset;
+
+        public Color ShadowColor
+        {
+            get => Color.FromRgb((byte)ShadowR.Value, (byte)ShadowG.Value, (byte)ShadowB.Value);
+            set
+            {
+                ShadowR.Value = value.R;
+                ShadowG.Value = value.G;
+                ShadowB.Value = value.B;
+            }
+        }
 
         public RProperty<bool> EnableFixedShadowAlways => _model.EnableFixedShadowAlways;
         public RProperty<bool> EnableFixedShadowWhenLocomotionActive => _model.EnableFixedShadowWhenLocomotionActive;
@@ -290,6 +313,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand ResetImageQualitySettingCommand { get; }
 
         public ActionCommand EditLightColorCommand { get; }
+        public ActionCommand EditShadowColorCommand { get; }
         public ActionCommand EditBloomColorCommand { get; }
         public ActionCommand EditOutlineEffectColorCommand { get; }
         public ActionCommand EditRimColorCommand { get; }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -205,6 +205,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<int> ShadowR => _model.ShadowR;
         public RProperty<int> ShadowG => _model.ShadowG;
         public RProperty<int> ShadowB => _model.ShadowB;
+        public RProperty<int> ShadowBlur => _model.ShadowBlur;
         public RProperty<int> ShadowIntensity => _model.ShadowIntensity;
         public RProperty<int> ShadowYaw => _model.ShadowYaw;
         public RProperty<int> ShadowPitch => _model.ShadowPitch;


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

#1241 で作ったシャドウについて、特にアバター背面のシャドウで

- ぼかしが効いてない
    - ギザギザ感を減らすにはアンチエイリアスの設定をいじる必要があり、分かりづらい
- いわゆる2Dデザイン的な影になったのに影色が指定できないと半端な感じがする

等の課題があったため下記の改修を行いました。

- 影色を指定できるようにする。指定した影色は固定影と背面影のどちらにも適用される
- ぼかしのサイズを指定できるようにする。この指定は背面影にのみ適用される
    - サイズは無次元量であり、既定値は10(ギザギザ感の低減のために小さくぼかす)
    - ぼかしのサイズによって処理を切り替える
        - 0: as-isと同じで、ぼかし処理を一切やらない
        - 1~29: 軽量なぼかし
        - 30~: ややリッチなぼかし(2-pass化する)

## How to confirm

Buildで一通り期待動作すること

## Note

既定値の調整意図として、この既定のぼかしが効いた状態でBuilt-in RP時のUltra画質くらいの見えになることを期待している