### PR TITLE
SSAOで色が指定できてなかったのを指定できるよう直す

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/GraphicsSetting/URPAsset_Renderer.asset
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/GraphicsSetting/URPAsset_Renderer.asset
@@ -93,7 +93,7 @@ MonoBehaviour:
   m_Settings:
     AOMethod: 0
     Downsample: 0
-    AfterOpaque: 1
+    AfterOpaque: 0
     Source: 1
     NormalSamples: 1
     Intensity: 0.099999994

--- a/VMagicMirror/Assets/Baku/VMagicMirror/GraphicsSetting/URPAsset_Renderer.asset
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/GraphicsSetting/URPAsset_Renderer.asset
@@ -96,7 +96,7 @@ MonoBehaviour:
     AfterOpaque: 0
     Source: 1
     NormalSamples: 1
-    Intensity: 0.099999994
+    Intensity: 0.15
     DirectLightingStrength: 0.25
     Radius: 0.035
     Samples: 1

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer_Profiles/MainViewerProfile.asset
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scenes/MainViewer_Profiles/MainViewerProfile.asset
@@ -123,6 +123,7 @@ MonoBehaviour:
   - {fileID: 4566603527965537225}
   - {fileID: 1549041718483320946}
   - {fileID: 7087179697058346899}
+  - {fileID: 8229849218361457301}
 --- !u!114 &1549041718483320946
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -207,3 +208,22 @@ MonoBehaviour:
   applyRate:
     m_OverrideState: 1
     m_Value: 1
+--- !u!114 &8229849218361457301
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a96dc17c72e4d8f9b776e17af2cb2f2, type: 3}
+  m_Name: VmmColoredSsaoVolume
+  m_EditorClassIdentifier: Assembly-CSharp::Baku.VMagicMirror.VmmColoredSsaoVolume
+  active: 1
+  enabled:
+    m_OverrideState: 1
+    m_Value: 0
+  color:
+    m_OverrideState: 1
+    m_Value: {r: 0, g: 0, b: 0, a: 1}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -29,6 +29,8 @@ namespace Baku.VMagicMirror
         private object _screenSpaceAmbientOcclusionSettings;
         private FieldInfo _screenSpaceAmbientOcclusionIntensityField;
         private FieldInfo _screenSpaceAmbientOcclusionAfterOpaqueField;
+        private bool _ambientOcclusionEnabled = false;
+        private float _ambientOcclusionIntensity = 0.15f;
         private bool _handTrackingEnabled = false;
         //NOTE: この値自体はビルドバージョンによらずfalseがデフォルトで良いことに注意。
         // 制限版でGUI側にtrue相当の値が表示されるが、これはGUI側が別途決め打ちしてくれてる。
@@ -161,11 +163,8 @@ namespace Baku.VMagicMirror
                 message =>
                 {
                     EnsureVolumeOverrides();
-                    if (_screenSpaceAmbientOcclusionFeature != null)
-                    {
-                        _screenSpaceAmbientOcclusionFeature.SetActive(message.ToBoolean());
-                    }
-                    VmmVolumeComponentAccessor.SetVmmColoredSsaoActive(message.ToBoolean());
+                    _ambientOcclusionEnabled = message.ToBoolean();
+                    UpdateAmbientOcclusionActive();
                 });
 
             receiver.AssignCommandHandler(
@@ -173,13 +172,15 @@ namespace Baku.VMagicMirror
                 message =>
                 {
                     EnsureVolumeOverrides();
+                    _ambientOcclusionIntensity = Mathf.Max(0f, message.ParseAsPercentage());
                     if (_screenSpaceAmbientOcclusionSettings != null &&
                         _screenSpaceAmbientOcclusionIntensityField != null)
                     {
                         _screenSpaceAmbientOcclusionIntensityField.SetValue(
                             _screenSpaceAmbientOcclusionSettings,
-                            Mathf.Max(0f, message.ParseAsPercentage()));
+                            _ambientOcclusionIntensity);
                     }
+                    UpdateAmbientOcclusionActive();
                 });
 
             receiver.AssignCommandHandler(
@@ -324,6 +325,16 @@ namespace Baku.VMagicMirror
                 component => component.color.Override(new Color(r, g, b)));
         }
 
+        private void UpdateAmbientOcclusionActive()
+        {
+            var active = _ambientOcclusionEnabled && _ambientOcclusionIntensity > 0f;
+            if (_screenSpaceAmbientOcclusionFeature != null)
+            {
+                _screenSpaceAmbientOcclusionFeature.SetActive(active);
+            }
+            VmmVolumeComponentAccessor.SetVmmColoredSsaoActive(active);
+        }
+
         private void EnsureVolumeOverrides()
         {
             if (_globalVolume == null)
@@ -424,6 +435,10 @@ namespace Baku.VMagicMirror
                     {
                         var settingsType = _screenSpaceAmbientOcclusionSettings.GetType();
                         _screenSpaceAmbientOcclusionIntensityField = settingsType.GetField("Intensity", InstanceBindingFlags);
+                        if (_screenSpaceAmbientOcclusionIntensityField?.GetValue(_screenSpaceAmbientOcclusionSettings) is float intensity)
+                        {
+                            _ambientOcclusionIntensity = Mathf.Max(0f, intensity);
+                        }
                         _screenSpaceAmbientOcclusionAfterOpaqueField = settingsType.GetField("AfterOpaque", InstanceBindingFlags);
                         _screenSpaceAmbientOcclusionAfterOpaqueField?.SetValue(
                             _screenSpaceAmbientOcclusionSettings,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -14,6 +14,8 @@ namespace Baku.VMagicMirror
         private const float LightIntensityConstFactor = 0.85f;
         private const BindingFlags InstanceBindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
         private const string ScreenSpaceAmbientOcclusionFeatureTypeName = "ScreenSpaceAmbientOcclusion";
+        // NOTE: 見た感じ効きが弱いのでちょっと強くしたものを当てる
+        private const float AmbientOcclusionIntensityConstFactor = 2f;
 
         [SerializeField] private Light mainLight = null;
         [SerializeField] private Vector3 mainLightLocalEulerAngle = default;
@@ -30,7 +32,7 @@ namespace Baku.VMagicMirror
         private FieldInfo _screenSpaceAmbientOcclusionIntensityField;
         private FieldInfo _screenSpaceAmbientOcclusionAfterOpaqueField;
         private bool _ambientOcclusionEnabled = false;
-        private float _ambientOcclusionIntensity = 0.15f;
+        private float _ambientOcclusionIntensity = 0.15f * AmbientOcclusionIntensityConstFactor;
         private bool _handTrackingEnabled = false;
         //NOTE: この値自体はビルドバージョンによらずfalseがデフォルトで良いことに注意。
         // 制限版でGUI側にtrue相当の値が表示されるが、これはGUI側が別途決め打ちしてくれてる。
@@ -172,7 +174,8 @@ namespace Baku.VMagicMirror
                 message =>
                 {
                     EnsureVolumeOverrides();
-                    _ambientOcclusionIntensity = Mathf.Max(0f, message.ParseAsPercentage());
+                    _ambientOcclusionIntensity =
+                        Mathf.Max(0f, message.ParseAsPercentage()) * AmbientOcclusionIntensityConstFactor;
                     if (_screenSpaceAmbientOcclusionSettings != null &&
                         _screenSpaceAmbientOcclusionIntensityField != null)
                     {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/LightingController.cs
@@ -28,6 +28,7 @@ namespace Baku.VMagicMirror
         private ScriptableRendererFeature _screenSpaceAmbientOcclusionFeature;
         private object _screenSpaceAmbientOcclusionSettings;
         private FieldInfo _screenSpaceAmbientOcclusionIntensityField;
+        private FieldInfo _screenSpaceAmbientOcclusionAfterOpaqueField;
         private bool _handTrackingEnabled = false;
         //NOTE: この値自体はビルドバージョンによらずfalseがデフォルトで良いことに注意。
         // 制限版でGUI側にtrue相当の値が表示されるが、これはGUI側が別途決め打ちしてくれてる。
@@ -46,6 +47,7 @@ namespace Baku.VMagicMirror
             }
 
             VmmVolumeComponentAccessor.SetVmmRetroActive(false);
+            VmmVolumeComponentAccessor.SetVmmColoredSsaoActive(false);
 
             EnsureVolumeOverrides();
         }
@@ -163,6 +165,7 @@ namespace Baku.VMagicMirror
                     {
                         _screenSpaceAmbientOcclusionFeature.SetActive(message.ToBoolean());
                     }
+                    VmmVolumeComponentAccessor.SetVmmColoredSsaoActive(message.ToBoolean());
                 });
 
             receiver.AssignCommandHandler(
@@ -177,6 +180,14 @@ namespace Baku.VMagicMirror
                             _screenSpaceAmbientOcclusionSettings,
                             Mathf.Max(0f, message.ParseAsPercentage()));
                     }
+                });
+
+            receiver.AssignCommandHandler(
+                VmmCommands.AmbientOcclusionColor,
+                message =>
+                {
+                    var rgb = message.ToColorFloats();
+                    SetAmbientOcclusionColor(rgb[0], rgb[1], rgb[2]);
                 });
 
             receiver.AssignCommandHandler(
@@ -307,6 +318,12 @@ namespace Baku.VMagicMirror
             }
         }
 
+        private void SetAmbientOcclusionColor(float r, float g, float b)
+        {
+            VmmVolumeComponentAccessor.UpdateColoredSsao(
+                component => component.color.Override(new Color(r, g, b)));
+        }
+
         private void EnsureVolumeOverrides()
         {
             if (_globalVolume == null)
@@ -407,6 +424,10 @@ namespace Baku.VMagicMirror
                     {
                         var settingsType = _screenSpaceAmbientOcclusionSettings.GetType();
                         _screenSpaceAmbientOcclusionIntensityField = settingsType.GetField("Intensity", InstanceBindingFlags);
+                        _screenSpaceAmbientOcclusionAfterOpaqueField = settingsType.GetField("AfterOpaque", InstanceBindingFlags);
+                        _screenSpaceAmbientOcclusionAfterOpaqueField?.SetValue(
+                            _screenSpaceAmbientOcclusionSettings,
+                            false);
                     }
                     break;
                 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmColoredSsaoVolume.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmColoredSsaoVolume.cs
@@ -1,0 +1,17 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace Baku.VMagicMirror
+{
+    [Serializable]
+    [VolumeComponentMenu("Post-processing Custom/VMM Colored SSAO")]
+    [SupportedOnRenderPipeline(typeof(UniversalRenderPipelineAsset))]
+    [DisplayInfo(name = "VMM Colored SSAO")]
+    public sealed class VmmColoredSsaoVolume : VolumeComponent
+    {
+        public BoolParameter enabled = new(false);
+        public ColorParameter color = new(Color.black, false, false, true);
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmColoredSsaoVolume.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmColoredSsaoVolume.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a96dc17c72e4d8f9b776e17af2cb2f2

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmVolumeComponentAccessor.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmVolumeComponentAccessor.cs
@@ -90,7 +90,10 @@ namespace Baku.VMagicMirror
 
         public static void UpdateColoredSsao(Action<VmmColoredSsaoVolume> updateAction)
         {
-            updateAction(GetColoredSsaoVolumeFromStack());
+            if (TryGetOrCreateRuntimeComponent(out VmmColoredSsaoVolume component))
+            {
+                updateAction(component);
+            }
         }
 
         public static void SetVmmColoredSsaoActive(bool active)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmVolumeComponentAccessor.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/PostProcessing/VmmVolumeComponentAccessor.cs
@@ -18,7 +18,8 @@ namespace Baku.VMagicMirror
         public static bool HasAnyPostProcessEffect() =>
             GetCropVolumeFromStack().enabled.value ||
             GetAlphaEdgeVolumeFromStack().enabled.value ||
-            GetRetroVolumeFromStack().enabled.value;
+            GetRetroVolumeFromStack().enabled.value ||
+            GetColoredSsaoVolumeFromStack().enabled.value;
 
         public static VmmAvatarOffsetRimVolume GetAvatarOffsetRimVolumeFromStack() =>
             GetComponentFromStack<VmmAvatarOffsetRimVolume>();
@@ -31,6 +32,9 @@ namespace Baku.VMagicMirror
 
         public static VmmRetroVolume GetRetroVolumeFromStack() =>
             GetComponentFromStack<VmmRetroVolume>();
+
+        public static VmmColoredSsaoVolume GetColoredSsaoVolumeFromStack() =>
+            GetComponentFromStack<VmmColoredSsaoVolume>();
 
         public static void UpdateCrop(Action<VmmCropVolume> updateAction)
         {
@@ -82,6 +86,16 @@ namespace Baku.VMagicMirror
         public static void SetVmmRetroActive(bool active)
         {
             UpdateRetro(component => component.enabled.Override(active));
+        }
+
+        public static void UpdateColoredSsao(Action<VmmColoredSsaoVolume> updateAction)
+        {
+            updateAction(GetColoredSsaoVolumeFromStack());
+        }
+
+        public static void SetVmmColoredSsaoActive(bool active)
+        {
+            UpdateColoredSsao(component => component.enabled.Override(active));
         }
 
         private static T GetComponentFromStack<T>() where T : VolumeComponent

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmRenderFeature.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/VmmRenderFeature.cs
@@ -12,6 +12,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private RenderPassEvent passEvent = RenderPassEvent.AfterRenderingPostProcessing;
 
         private AvatarShadowMaskPass _maskPass;
+        private SuppressStandardSsaoPass _suppressStandardSsaoPass;
         private VmmPreBloomPass _preBloomPass;
         private VmmPostProcessingPass _pass;
 
@@ -20,6 +21,10 @@ namespace Baku.VMagicMirror
             _maskPass = new AvatarShadowMaskPass
             {
                 renderPassEvent = RenderPassEvent.BeforeRenderingTransparents
+            };
+            _suppressStandardSsaoPass = new SuppressStandardSsaoPass
+            {
+                renderPassEvent = RenderPassEvent.AfterRenderingPrePasses + 2
             };
             _preBloomPass = new VmmPreBloomPass
             {
@@ -37,6 +42,7 @@ namespace Baku.VMagicMirror
             var useAvatarMask = controller?.UseAvatarMask.CurrentValue ?? false;
             var hasPreBloomPostProcess = VmmVolumeComponentAccessor.HasAnyPreBloomEffect();
             var hasPostProcess = VmmVolumeComponentAccessor.HasAnyPostProcessEffect();
+            var hasColoredSsao = VmmVolumeComponentAccessor.GetColoredSsaoVolumeFromStack().enabled.value;
 
             if (renderingData.cameraData.cameraType == CameraType.Preview ||
                 renderingData.cameraData.cameraType == CameraType.Reflection ||
@@ -51,6 +57,11 @@ namespace Baku.VMagicMirror
             {
                 _maskPass.Setup(controller);
                 renderer.EnqueuePass(_maskPass);
+            }
+
+            if (hasColoredSsao)
+            {
+                renderer.EnqueuePass(_suppressStandardSsaoPass);
             }
 
             if (hasPreBloomPostProcess)
@@ -71,6 +82,33 @@ namespace Baku.VMagicMirror
             _maskPass?.Dispose();
             _preBloomPass?.Dispose();
             _pass?.Dispose();
+        }
+
+        private sealed class SuppressStandardSsaoPass : ScriptableRenderPass
+        {
+            private static readonly GlobalKeyword ScreenSpaceOcclusionKeyword =
+                GlobalKeyword.Create("_SCREEN_SPACE_OCCLUSION");
+            private static readonly int AmbientOcclusionParamId =
+                Shader.PropertyToID("_AmbientOcclusionParam");
+
+            private sealed class PassData
+            {
+            }
+
+            public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+            {
+                using var builder = renderGraph.AddUnsafePass<PassData>(
+                    "Vmm Suppress Standard SSAO",
+                    out _,
+                    new ProfilingSampler("VmmSuppressStandardSsao"));
+                builder.AllowPassCulling(false);
+                builder.AllowGlobalStateModification(true);
+                builder.SetRenderFunc(static (PassData data, UnsafeGraphContext context) =>
+                {
+                    context.cmd.SetKeyword(ScreenSpaceOcclusionKeyword, false);
+                    context.cmd.SetGlobalVector(AmbientOcclusionParamId, Vector4.zero);
+                });
+            }
         }
 
         private sealed class AvatarShadowMaskPass : ScriptableRenderPass
@@ -456,6 +494,9 @@ namespace Baku.VMagicMirror
             private static readonly int VhsSrcId = Shader.PropertyToID("_src");
             private static readonly int VhsNoiseYId = Shader.PropertyToID("_NoiseY");
 
+            private static readonly int ColoredSsaoColorId = Shader.PropertyToID("_SsaoColor");
+
+            private Material _coloredSsaoMaterial;
             private Material _cropMaterial;
             private Material _alphaEdgeMaterial;
             private Material _monochromeMaterial;
@@ -473,6 +514,7 @@ namespace Baku.VMagicMirror
 
             public void Dispose()
             {
+                CoreUtils.Destroy(_coloredSsaoMaterial);
                 CoreUtils.Destroy(_cropMaterial);
                 CoreUtils.Destroy(_alphaEdgeMaterial);
                 CoreUtils.Destroy(_monochromeMaterial);
@@ -494,12 +536,14 @@ namespace Baku.VMagicMirror
                 var cropVolume = VmmVolumeComponentAccessor.GetCropVolumeFromStack();
                 var alphaEdgeVolume = VmmVolumeComponentAccessor.GetAlphaEdgeVolumeFromStack();
                 var retroVolume = VmmVolumeComponentAccessor.GetRetroVolumeFromStack();
+                var coloredSsaoVolume = VmmVolumeComponentAccessor.GetColoredSsaoVolumeFromStack();
+                var hasColoredSsao = coloredSsaoVolume.enabled.value;
                 var hasRetro = retroVolume.enabled.value;
                 var hasCrop = cropVolume.enabled.value;
                 var hasAlphaEdge = alphaEdgeVolume.enabled.value;
 
-                if (!HasRequiredMaterials(hasRetro, hasCrop, hasAlphaEdge) ||
-                    (!hasRetro && !hasCrop && !hasAlphaEdge))
+                if (!HasRequiredMaterials(hasColoredSsao, hasRetro, hasCrop, hasAlphaEdge) ||
+                    (!hasColoredSsao && !hasRetro && !hasCrop && !hasAlphaEdge))
                 {
                     return;
                 }
@@ -523,6 +567,12 @@ namespace Baku.VMagicMirror
                 var source = resources.activeColorTexture;
                 var destination = tempA;
                 var used = false;
+
+                if (hasColoredSsao)
+                {
+                    UpdateColoredSsaoMaterial(coloredSsaoVolume);
+                    Apply(_coloredSsaoMaterial, "Vmm Colored SSAO");
+                }
 
                 if (hasRetro)
                 {
@@ -563,16 +613,23 @@ namespace Baku.VMagicMirror
 
             private void EnsureMaterials()
             {
+                _coloredSsaoMaterial ??= CreateMaterial("Hidden/Vmm/ColoredSsao");
                 _cropMaterial ??= CreateMaterial("Hidden/Vmm/Crop");
                 _alphaEdgeMaterial ??= CreateMaterial("Hidden/Vmm/AlphaEdge");
                 _monochromeMaterial ??= CreateMaterial("Hidden/Vmm/Monochrome");
                 _vhsMaterial ??= CreateMaterial("Hidden/Vmm/VHS");
             }
 
-            private bool HasRequiredMaterials(bool hasRetro, bool hasCrop, bool hasAlphaEdge) =>
+            private bool HasRequiredMaterials(bool hasColoredSsao, bool hasRetro, bool hasCrop, bool hasAlphaEdge) =>
+                (!hasColoredSsao || _coloredSsaoMaterial != null) &&
                 (!hasRetro || (_monochromeMaterial != null && _vhsMaterial != null)) &&
                 (!hasCrop || _cropMaterial != null) &&
                 (!hasAlphaEdge || _alphaEdgeMaterial != null);
+
+            private void UpdateColoredSsaoMaterial(VmmColoredSsaoVolume volume)
+            {
+                _coloredSsaoMaterial.SetColor(ColoredSsaoColorId, volume.color.value);
+            }
 
             private void UpdateCropMaterial(VmmCropVolume volume)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -231,6 +231,7 @@
 
         AmbientOcclusionEnable,
         AmbientOcclusionIntensity,
+        AmbientOcclusionColor,
 
         OutlineEffectEnable,
         OutlineEffectThickness,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmColoredSsao.shader
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmColoredSsao.shader
@@ -1,0 +1,36 @@
+Shader "Hidden/Vmm/ColoredSsao"
+{
+    HLSLINCLUDE
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+        #include "Packages/com.unity.render-pipelines.core/Runtime/Utilities/Blit.hlsl"
+
+        TEXTURE2D_X(_ScreenSpaceOcclusionTexture);
+        float4 _SsaoColor;
+
+        float4 Frag(Varyings i) : SV_Target
+        {
+            UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(i);
+
+            float2 uv = i.texcoord;
+            float4 original = SAMPLE_TEXTURE2D_X(_BlitTexture, sampler_LinearClamp, uv);
+            float ao = SAMPLE_TEXTURE2D_X(_ScreenSpaceOcclusionTexture, sampler_LinearClamp, uv).r;
+            float occlusion = saturate(1.0 - ao);
+            float3 multiplier = lerp(float3(1.0, 1.0, 1.0), _SsaoColor.rgb, occlusion);
+            return float4(original.rgb * multiplier, original.a);
+        }
+    ENDHLSL
+
+    SubShader
+    {
+        Tags { "RenderPipeline" = "UniversalPipeline" }
+        Cull Off ZWrite Off ZTest Always
+
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex Vert
+            #pragma fragment Frag
+            ENDHLSL
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmColoredSsao.shader.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Shaders/PostProcessing/VmmColoredSsao.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5fdf3f92bbdb487ca691a9810b5bcd58
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/DefaultVolumeProfile.asset
+++ b/VMagicMirror/Assets/DefaultVolumeProfile.asset
@@ -400,6 +400,25 @@ MonoBehaviour:
   maxNits:
     m_OverrideState: 1
     m_Value: 1000
+--- !u!114 &-3622492587973870127
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a96dc17c72e4d8f9b776e17af2cb2f2, type: 3}
+  m_Name: VmmColoredSsaoVolume
+  m_EditorClassIdentifier: Assembly-CSharp::Baku.VMagicMirror.VmmColoredSsaoVolume
+  active: 1
+  enabled:
+    m_OverrideState: 1
+    m_Value: 0
+  color:
+    m_OverrideState: 1
+    m_Value: {r: 0, g: 0, b: 0, a: 1}
 --- !u!114 &-2114576328732316320
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -569,6 +588,7 @@ MonoBehaviour:
   - {fileID: -6431207035153375467}
   - {fileID: -5095637621997249151}
   - {fileID: 3545826068585525326}
+  - {fileID: -3622492587973870127}
 --- !u!114 &1455381220074614261
 MonoBehaviour:
   m_ObjectHideFlags: 3

--- a/VMagicMirror/ProjectSettings/GraphicsSettings.asset
+++ b/VMagicMirror/ProjectSettings/GraphicsSettings.asset
@@ -51,6 +51,7 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 8c17b56f4bf084c47872edcb95237e4a, type: 3}
   - {fileID: 4800000, guid: 1a60714b3f0ce4147a009855466aceda, type: 3}
   - {fileID: 4800000, guid: 9e2c3e123a5348f58e2db6c076a0db8d, type: 3}
+  - {fileID: 4800000, guid: 5fdf3f92bbdb487ca691a9810b5bcd58, type: 3}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,

--- a/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/LightSetting.cs
@@ -54,6 +54,9 @@
 
         public bool EnableAmbientOcclusion { get; set; } = false;
         public int AmbientOcclusionIntensity { get; set; } = 15;
+        public int AmbientOcclusionR { get; set; } = 0;
+        public int AmbientOcclusionG { get; set; } = 0;
+        public int AmbientOcclusionB { get; set; } = 0;
 
         #endregion
 

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -318,6 +318,7 @@ namespace Baku.VMagicMirrorConfig
 
         public static Message AmbientOcclusionEnable(bool enable) => BoolContent(VmmCommands.AmbientOcclusionEnable, enable);
         public static Message AmbientOcclusionIntensity(int intensityPercent) => IntContent(VmmCommands.AmbientOcclusionIntensity, intensityPercent);
+        public static Message AmbientOcclusionColor(int r, int g, int b) => IntArrayContent(VmmCommands.AmbientOcclusionColor, [r, g, b]);
 
         public static Message OutlineEffectEnable(bool active) => BoolContent(VmmCommands.OutlineEffectEnable, active);
         public static Message OutlineEffectThickness(int thickness) => IntContent(VmmCommands.OutlineEffectThickness, thickness);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/LightSettingModel.cs
@@ -97,6 +97,11 @@ namespace Baku.VMagicMirrorConfig
 
             EnableAmbientOcclusion = new RProperty<bool>(s.EnableAmbientOcclusion, b => SendMessage(MessageFactory.AmbientOcclusionEnable(b)));
             AmbientOcclusionIntensity = new RProperty<int>(s.AmbientOcclusionIntensity, i => SendMessage(MessageFactory.AmbientOcclusionIntensity(i)));
+            Action sendAmbientOcclusionColor = () =>
+                SendMessage(MessageFactory.AmbientOcclusionColor(AmbientOcclusionR?.Value ?? 0, AmbientOcclusionG?.Value ?? 0, AmbientOcclusionB?.Value ?? 0));
+            AmbientOcclusionR = new RProperty<int>(s.AmbientOcclusionR, _ => sendAmbientOcclusionColor());
+            AmbientOcclusionG = new RProperty<int>(s.AmbientOcclusionG, _ => sendAmbientOcclusionColor());
+            AmbientOcclusionB = new RProperty<int>(s.AmbientOcclusionB, _ => sendAmbientOcclusionColor());
         }
 
         #region Image Quality
@@ -143,6 +148,9 @@ namespace Baku.VMagicMirrorConfig
 
         public RProperty<bool> EnableAmbientOcclusion { get; }
         public RProperty<int> AmbientOcclusionIntensity { get; }
+        public RProperty<int> AmbientOcclusionR { get; }
+        public RProperty<int> AmbientOcclusionG { get; }
+        public RProperty<int> AmbientOcclusionB { get; }
 
         #endregion
 
@@ -239,6 +247,9 @@ namespace Baku.VMagicMirrorConfig
             var setting = LightSetting.Default;
             EnableAmbientOcclusion.Value = setting.EnableAmbientOcclusion;
             AmbientOcclusionIntensity.Value = setting.AmbientOcclusionIntensity;
+            AmbientOcclusionR.Value = setting.AmbientOcclusionR;
+            AmbientOcclusionG.Value = setting.AmbientOcclusionG;
+            AmbientOcclusionB.Value = setting.AmbientOcclusionB;
         }
 
         public void ResetBloomSetting()

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -616,6 +616,7 @@ Translate (2 way):
     
     <sys:String x:Key="AO_Title">Ambient Occlusion</sys:String>
     <sys:String x:Key="AO_Enable">Enable Effect</sys:String>
+    <sys:String x:Key="AO_Color">Color</sys:String>
     <sys:String x:Key="AO_Intensity">Intensity [%]</sys:String>
     
     <sys:String x:Key="OutlineEffect">Outline (require transparent background)</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -616,6 +616,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     
     <sys:String x:Key="AO_Title">Ambient Occlusion</sys:String>
     <sys:String x:Key="AO_Enable">エフェクトを有効化</sys:String>
+    <sys:String x:Key="AO_Color">エフェクトの色</sys:String>
     <sys:String x:Key="AO_Intensity">エフェクトの強さ[%]</sys:String>
     
     <sys:String x:Key="OutlineEffect">縁取り (背景透過でのみ有効)</sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/EffectSettingPanel.xaml
@@ -767,21 +767,44 @@
                               />
 
                     <Grid Margin="5">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="32"/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="3*" />
                             <ColumnDefinition Width="1*"/>
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0"
+                        <TextBlock Grid.Row="0" Grid.Column="0"
+                                   Text="{DynamicResource AO_Color}" />
+                        <StackPanel Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
+                                    Orientation="Horizontal">
+                            <Rectangle Style="{StaticResource ColorSampleRectangle}">
+                                <Rectangle.Fill>
+                                    <SolidColorBrush Color="{Binding AmbientOcclusionColor}"/>
+                                </Rectangle.Fill>
+                            </Rectangle>
+                            <Button Style="{StaticResource ColorEditButton}"
+                                    Command="{Binding EditAmbientOcclusionColorCommand}">
+                                <StackPanel Orientation="Horizontal">
+                                    <md:PackIcon Style="{StaticResource ColorEditButtonIcon}"/>
+                                    <TextBlock Style="{StaticResource ColorEditButtonText}"
+                                               Text="{DynamicResource Setting_EditColor}"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+
+                        <TextBlock Grid.Row="1" Grid.Column="0"
                                    Text="{DynamicResource AO_Intensity}" />
-                        <Slider Grid.Column="1"
+                        <Slider Grid.Row="1" Grid.Column="1"
                                 x:Name="sliderAmbientOcclusionIntensity"
                                 Minimum="0"
                                 Maximum="200"
                                 Value="{Binding AmbientOcclusionIntensity.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Column="2"
+                        <TextBox Grid.Row="1" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderAmbientOcclusionIntensity}"
                                  />
                     </Grid>

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/EffectSettingViewModel.cs
@@ -60,6 +60,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 new RgbColorBinding(BloomR, BloomG, BloomB),
                 "Bloom_Color"
             ));
+            EditAmbientOcclusionColorCommand = new ActionCommand(() => ShowColorWindow(
+                new RgbColorBinding(AmbientOcclusionR, AmbientOcclusionG, AmbientOcclusionB),
+                "AO_Color"
+            ));
             EditOutlineEffectColorCommand = new ActionCommand(() => ShowColorWindow(
                 new RgbColorBinding(OutlineEffectR, OutlineEffectG, OutlineEffectB),
                 "OutlineEffect_Color"
@@ -100,6 +104,10 @@ namespace Baku.VMagicMirrorConfig.ViewModel
                 model.BloomG.AddWeakEventHandler(UpdateBloomColor);
                 model.BloomB.AddWeakEventHandler(UpdateBloomColor);
 
+                model.AmbientOcclusionR.AddWeakEventHandler(UpdateAmbientOcclusionColor);
+                model.AmbientOcclusionG.AddWeakEventHandler(UpdateAmbientOcclusionColor);
+                model.AmbientOcclusionB.AddWeakEventHandler(UpdateAmbientOcclusionColor);
+
                 model.OutlineEffectR.AddWeakEventHandler(UpdateOutlineEffectColor);
                 model.OutlineEffectG.AddWeakEventHandler(UpdateOutlineEffectColor);
                 model.OutlineEffectB.AddWeakEventHandler(UpdateOutlineEffectColor);
@@ -138,6 +146,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         void UpdateLightColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(LightColor));
         void UpdateShadowColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(ShadowColor));
         void UpdateBloomColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(BloomColor));
+        void UpdateAmbientOcclusionColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(AmbientOcclusionColor));
         void UpdateOutlineEffectColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(OutlineEffectColor));
         void UpdateRimColor(object? sender, PropertyChangedEventArgs e) => RaisePropertyChanged(nameof(RimColor));
 
@@ -231,6 +240,20 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         public RProperty<bool> EnableAmbientOcclusion => _model.EnableAmbientOcclusion;
         public RProperty<int> AmbientOcclusionIntensity => _model.AmbientOcclusionIntensity;
+        public RProperty<int> AmbientOcclusionR => _model.AmbientOcclusionR;
+        public RProperty<int> AmbientOcclusionG => _model.AmbientOcclusionG;
+        public RProperty<int> AmbientOcclusionB => _model.AmbientOcclusionB;
+
+        public Color AmbientOcclusionColor
+        {
+            get => Color.FromRgb((byte)AmbientOcclusionR.Value, (byte)AmbientOcclusionG.Value, (byte)AmbientOcclusionB.Value);
+            set
+            {
+                AmbientOcclusionR.Value = value.R;
+                AmbientOcclusionG.Value = value.G;
+                AmbientOcclusionB.Value = value.B;
+            }
+        }
 
         #endregion
 
@@ -316,6 +339,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand EditLightColorCommand { get; }
         public ActionCommand EditShadowColorCommand { get; }
         public ActionCommand EditBloomColorCommand { get; }
+        public ActionCommand EditAmbientOcclusionColorCommand { get; }
         public ActionCommand EditOutlineEffectColorCommand { get; }
         public ActionCommand EditRimColorCommand { get; }
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Bug fix
- [x] Improve existing feature

## What the PR does

fixes  #1267 

#1241 の時点では「URPの標準SSAOがサポートしてないから」という理由でSSAOの色を指定することを諦めていたが、　#1267 に書いたアプローチで実際にworkaroundできたので、これを適用する。

## How to confirm

- [x] Unity Editor + WPF Buildでオンオフと色設定が期待通りに反映されること
- [x] Unity Buildについても同様であること
- [x] エフェクトが有効かつintensityが0のときの見栄えがおかしくならないこと

## Note

- この変更はv5.0.0に差し込むのでv5.0.0のchangelogも更新する: #1266 
- 動作確認にあたり、v4.0.0より後のv4系のどこかでSSAOの見えが意図しない形に変わってしまってたっぽいのを確認しているが、これについては深追いしない
    - SSAOについてはv4 / v5で完全に互換な見えになるのはあまり期待できなさそうなので…
