### PR TITLE
ハンドトラッキングについてHeadの姿勢オフセットを手のIKにも効かせるオプションを追加

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -152,6 +152,8 @@
         // +X: 手を体の横に広げる、+Y: 手を上げる
         SetHandTrackingOffsetX,
         SetHandTrackingOffsetY,
+        // percentベースで、頭の姿勢によってハンドトラッキングのIK姿勢が連動する強さを指定する
+        SetHandTrackingHeadPoseAdjustFactor,
 
         // Motion, GameInput
         UseGamepadForGameInput,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
@@ -17,6 +17,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
     public class MediaPipeHand : PresenterBase, ITickable
     {
         private const float HandPositionCutoffFrequency = 5f;
+        private const float ReduceSetHeadOffsetPoseFactor = 6f;
 
         private readonly IMessageReceiver _receiver;
         private readonly ICoroutineSource _coroutineSource;
@@ -224,11 +225,11 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 _mediaPipeKinematicSetter.TryGetLeftHandPose(out var handPose, out var maybeLost);
             _leftHandState.IsTracked = isTracked;
 
+            var dt = Time.deltaTime;
             if (isTracked)
             {
                 _leftHandState.SetHeadOffsetPose(GetHeadOffsetPose());
                 _trackingLostHandCalculator.CancelLeftHand();
-                var dt = Time.deltaTime;
 
                 if (maybeLost)
                 {
@@ -268,9 +269,10 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                     );
                 }
 
+                _leftHandState.ReduceSetHeadOffsetPose(dt * ReduceSetHeadOffsetPoseFactor);
                 _leftHandState.ForceSetPosition(_trackingLostHandCalculator.LeftHandPose.position);
                 _leftHandState.SetRotation(_trackingLostHandCalculator.LeftHandPose.rotation);
-                
+
                 // 完全にロストしてるケースで通過する
                 _leftHandTrackedSpeed = Vector3.zero;
             }
@@ -282,11 +284,11 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 _mediaPipeKinematicSetter.TryGetRightHandPose(out var handPose, out var maybeLost);
             _rightHandState.IsTracked = isTracked;
 
+            var dt = Time.deltaTime;
             if (isTracked)
             {
                 _rightHandState.SetHeadOffsetPose(GetHeadOffsetPose());
                 _trackingLostHandCalculator.CancelRightHand();
-                var dt = Time.deltaTime;
 
                 if (maybeLost)
                 {
@@ -325,6 +327,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                     );
                 }
 
+                _rightHandState.ReduceSetHeadOffsetPose(dt * ReduceSetHeadOffsetPoseFactor);
                 _rightHandState.ForceSetPosition(_trackingLostHandCalculator.RightHandPose.position);
                 _rightHandState.SetRotation(_trackingLostHandCalculator.RightHandPose.rotation);
                 
@@ -633,6 +636,14 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                     _headOffsetPose.rotation * RotationWithoutHeadPoseAdjust,
                     HeadPoseAdjustFactor
                 );
+            }
+
+            public void ReduceSetHeadOffsetPose(float factor)
+            {
+                SetHeadOffsetPose(new Pose(
+                    _headOffsetPose.position * (1 - factor),
+                    Quaternion.Slerp(_headOffsetPose.rotation, Quaternion.identity, 1 - factor)
+                ));
             }
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Threading;
 using UnityEngine;
 using Baku.VMagicMirror.IK;
@@ -17,6 +18,8 @@ namespace Baku.VMagicMirror.MediaPipeTracker
     {
         private const float HandPositionCutoffFrequency = 5f;
 
+        private readonly IMessageReceiver _receiver;
+        private readonly ICoroutineSource _coroutineSource;
         private readonly IVRMLoadable _vrmLoadable;
         private readonly MediaPipeKinematicSetter _mediaPipeKinematicSetter;
         private readonly TrackingLostHandCalculator _trackingLostHandCalculator;
@@ -24,10 +27,18 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         private readonly CurrentFramerateChecker _framerateChecker;
         private readonly CancellationTokenSource _cts = new();
         private readonly MediaPipeHandFinger _finger;
+        private readonly ReactiveProperty<float> _headPoseAdjustFactor = new(0f);
 
         private bool _hasModel;
+        private Transform _vrmRoot;
         private Transform _leftHandBone;
         private Transform _rightHandBone;
+        private Transform _headBone;
+        // NOTE: 初期値の回転はidentityのはずなので取得せず、初期値のrootはワールド原点のはずなのでこれも取得しない
+        private Vector3 _initialHeadPosition;
+        private Pose _currentHeadPose;
+        private Pose _currentRootPose;
+
         // NOTE:
         // - FKやIKが完全に適用し終わったあとの値を取得してキャッシュする。
         // - トラッキングロストの計算をするときの始点に使う
@@ -42,9 +53,12 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         private AlwaysDownHandIkGenerator _downHandIk;
         
         private bool IsInitialized => _dependency != null;
+        private bool _disposed;
 
         [Inject]
         public MediaPipeHand(
+            IMessageReceiver receiver,
+            ICoroutineSource coroutineSource,
             IVRMLoadable vrmLoadable,
             FingerController fingerController,
             MediaPipeKinematicSetter mediaPipeKinematicSetter, 
@@ -54,6 +68,8 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             MediapipePoseSetterSettings poseSetterSettings,
             CurrentFramerateChecker framerateChecker)
         {
+            _receiver = receiver;
+            _coroutineSource = coroutineSource;
             _vrmLoadable = vrmLoadable;
             _mediaPipeKinematicSetter = mediaPipeKinematicSetter;
             _trackingLostHandCalculator = trackingLostHandCalculator;
@@ -83,10 +99,18 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
         public override void Initialize()
         {
+            _receiver.BindPercentageProperty(
+                VmmCommands.SetHandTrackingHeadPoseAdjustFactor,
+                _headPoseAdjustFactor
+            );
+            
             _vrmLoadable.VrmLoaded += info =>
             {
+                _vrmRoot = info.vrmRoot;
                 _leftHandBone = info.animator.GetBoneTransform(HumanBodyBones.LeftHand);
                 _rightHandBone = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
+                _headBone = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                _initialHeadPosition = _headBone.position;
                 _hasModel = true;
             };
 
@@ -94,16 +118,19 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             _vrmLoadable.PostVrmLoaded += _ =>
             {
                 _leftHandState.ForceSetPosition(_downHandIk.LeftHand.Position);
-                _leftHandState.Rotation = _downHandIk.LeftHand.Rotation;
+                _leftHandState.SetRotation(_downHandIk.LeftHand.Rotation);
                 _rightHandState.ForceSetPosition(_downHandIk.RightHand.Position);
-                _rightHandState.Rotation = _downHandIk.RightHand.Rotation;
+                _rightHandState.SetRotation(_downHandIk.RightHand.Rotation);
             };
 
             _vrmLoadable.VrmDisposing += () =>
             {
                 _hasModel = false;
+                _vrmRoot = null;
                 _leftHandBone = null;
                 _rightHandBone = null;
+                _headBone = null;
+                _initialHeadPosition = Vector3.zero;
             };
 
             CheckHandLocalRotationAsync(_cts.Token).Forget();
@@ -119,6 +146,16 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             _framerateChecker.CurrentFramerate
                 .Subscribe(SetupFilters)
                 .AddTo(this);
+
+            _headPoseAdjustFactor
+                .Subscribe(factor =>
+                {
+                    _leftHandState.HeadPoseAdjustFactor = factor;
+                    _rightHandState.HeadPoseAdjustFactor = factor;
+                })
+                .AddTo(this);
+            
+            _coroutineSource.StartCoroutine(GetCurrentAvatarPoses());
         }
 
         public override void Dispose()
@@ -126,6 +163,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             base.Dispose();
             _cts.Cancel();
             _cts.Dispose();
+            _disposed = true;
         }
 
         private async UniTaskVoid CheckHandLocalRotationAsync(CancellationToken cancellationToken)
@@ -179,7 +217,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             _rightHandState.PositionFilter.CopyParametersFrom(_leftHandState.PositionFilter);
             _finger.SetupFilters(framerate);
         }
-        
+
         private void UpdateLeftHand()
         {
             var isTracked =
@@ -188,6 +226,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
             if (isTracked)
             {
+                _rightHandState.SetHeadOffsetPose(GetHeadOffsetPose());
                 _trackingLostHandCalculator.CancelLeftHand();
                 var dt = Time.deltaTime;
 
@@ -197,25 +236,25 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                     _leftHandTrackedSpeed *= 1f - _poseSetterSettings.HandInertiaFactorWhenLost * dt;
                     var inertiaSpeed = 
                         Vector3.ClampMagnitude(_leftHandTrackedSpeed, _poseSetterSettings.HandMoveSpeedMax);
-                    _leftHandState.ForceSetPosition(_leftHandState.Position + inertiaSpeed * dt);
+                    _leftHandState.ForceSetPosition(_leftHandState.PositionWithoutHeadPoseAdjust + inertiaSpeed * dt);
                 }
                 else
                 {
                     // ロストしてなさそうな場合: フィルタベースでpos/rotを動かしつつ、ロスト時に備えて速度を記録しておく
-                    var currentPosition = _leftHandState.Position;
+                    var currentPosition = _leftHandState.PositionWithoutHeadPoseAdjust;
                     _leftHandState.SetFilteredPosition(
                         handPose.position,
                         _poseSetterSettings.HandMoveSpeedMax * dt
                         );
                     _leftHandTrackedSpeed = Vector3.Lerp(
                         _leftHandTrackedSpeed, 
-                        (_leftHandState.Position - currentPosition) / dt,
+                        (_leftHandState.PositionWithoutHeadPoseAdjust - currentPosition) / dt,
                         _poseSetterSettings.HandInertiaFactorToLogTrackedSpeed * dt
                     );
-                    
-                    _leftHandState.Rotation = Quaternion.Slerp(
-                        _leftHandState.Rotation, handPose.rotation, _poseSetterSettings.HandIkSmoothRate * dt
-                    );
+
+                    _leftHandState.SetRotation(Quaternion.Slerp(
+                        _leftHandState.RotationWithoutHeadPoseAdjust, handPose.rotation, _poseSetterSettings.HandIkSmoothRate * dt
+                    ));
                 }
                 
                 _leftHandState.RaiseRequestToUse();
@@ -225,12 +264,12 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 if (!_trackingLostHandCalculator.LeftHandTrackingLostRunning)
                 {
                     _trackingLostHandCalculator.RunLeftHandTrackingLost(
-                        new Pose(_leftHandState.Position, _leftHandState.Rotation), _leftHandLocalRotation
+                        new Pose(_leftHandState.PositionWithoutHeadPoseAdjust, _leftHandState.RotationWithoutHeadPoseAdjust), _leftHandLocalRotation
                     );
                 }
 
                 _leftHandState.ForceSetPosition(_trackingLostHandCalculator.LeftHandPose.position);
-                _leftHandState.Rotation = _trackingLostHandCalculator.LeftHandPose.rotation;
+                _leftHandState.SetRotation(_trackingLostHandCalculator.LeftHandPose.rotation);
                 
                 // 完全にロストしてるケースで通過する
                 _leftHandTrackedSpeed = Vector3.zero;
@@ -245,6 +284,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
             if (isTracked)
             {
+                _rightHandState.SetHeadOffsetPose(GetHeadOffsetPose());
                 _trackingLostHandCalculator.CancelRightHand();
                 var dt = Time.deltaTime;
 
@@ -254,24 +294,24 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                     _rightHandTrackedSpeed *= 1f - _poseSetterSettings.HandInertiaFactorWhenLost * dt;
                     var inertiaSpeed = 
                         Vector3.ClampMagnitude(_rightHandTrackedSpeed, _poseSetterSettings.HandMoveSpeedMax);
-                    _rightHandState.ForceSetPosition(_rightHandState.Position + inertiaSpeed * dt);
+                    _rightHandState.ForceSetPosition(_rightHandState.PositionWithoutHeadPoseAdjust + inertiaSpeed * dt);
                 }
                 else
                 {
-                    var currentPosition = _rightHandState.Position;
+                    var currentPosition = _rightHandState.PositionWithoutHeadPoseAdjust;
                     _rightHandState.SetFilteredPosition(
                         handPose.position,
                         _poseSetterSettings.HandMoveSpeedMax * dt
                     );
                     _rightHandTrackedSpeed = Vector3.Lerp(
                         _rightHandTrackedSpeed, 
-                        (_rightHandState.Position - currentPosition) / dt,
+                        (_rightHandState.PositionWithoutHeadPoseAdjust - currentPosition) / dt,
                         _poseSetterSettings.HandInertiaFactorToLogTrackedSpeed * dt
                     );
                     
-                    _rightHandState.Rotation = Quaternion.Slerp(
-                        _rightHandState.Rotation, handPose.rotation, _poseSetterSettings.HandIkSmoothRate * dt
-                    );
+                    _rightHandState.SetRotation(Quaternion.Slerp(
+                        _rightHandState.RotationWithoutHeadPoseAdjust, handPose.rotation, _poseSetterSettings.HandIkSmoothRate * dt
+                    ));
                 }
 
                 _rightHandState.RaiseRequestToUse();
@@ -281,12 +321,14 @@ namespace Baku.VMagicMirror.MediaPipeTracker
                 if (!_trackingLostHandCalculator.RightHandTrackingLostRunning)
                 {
                     _trackingLostHandCalculator.RunRightHandTrackingLost(
-                        new Pose(_rightHandState.Position, _rightHandState.Rotation), _rightHandLocalRotation
+                        new Pose(_rightHandState.PositionWithoutHeadPoseAdjust, _rightHandState.RotationWithoutHeadPoseAdjust), _rightHandLocalRotation
                     );
                 }
 
                 _rightHandState.ForceSetPosition(_trackingLostHandCalculator.RightHandPose.position);
-                _rightHandState.Rotation = _trackingLostHandCalculator.RightHandPose.rotation;
+                _rightHandState.SetRotation(_trackingLostHandCalculator.RightHandPose.rotation);
+                
+                _rightHandTrackedSpeed = Vector3.zero;
             }
         }
         
@@ -306,6 +348,41 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             {
                 _finger.ReleaseRightHand();
                 _finger.ResetCalculatedRightFingerPoses();
+            }
+        }
+
+        private Pose GetHeadOffsetPose()
+        {
+            if (!_hasModel)
+            {
+                return Pose.identity;
+            }
+
+            // 「rootの座標系から見てheadの位置と回転が初期値とどのくらいズレたか」を取得する
+            var worldHeadPoseOffset = new Pose(
+                _currentHeadPose.position - _initialHeadPosition,
+                _currentHeadPose.rotation
+            );
+            
+            return new Pose(
+                Quaternion.Inverse(_currentRootPose.rotation) * worldHeadPoseOffset.position,
+                Quaternion.Inverse(_currentRootPose.rotation) * worldHeadPoseOffset.rotation
+            );
+        }
+
+        private IEnumerator GetCurrentAvatarPoses()
+        {
+            var eof = new WaitForEndOfFrame();
+            while (!_disposed)
+            {
+                yield return eof;
+                if (!_hasModel)
+                {
+                    continue;
+                }
+                
+                _currentRootPose = new Pose(_vrmRoot.position, _vrmRoot.rotation);
+                _currentHeadPose = new Pose(_headBone.position, _headBone.rotation);
             }
         }
         
@@ -460,6 +537,13 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             /// </summary>
             public bool IsTracked { get; set; }
 
+            private float _headPoseAdjustFactor = 0f;
+            public float HeadPoseAdjustFactor
+            {
+                get => _headPoseAdjustFactor;
+                set => _headPoseAdjustFactor = Mathf.Clamp01(value);
+            }
+            
             public bool SkipEnterIkBlend => false;
             public MediaPipeHandFinger Finger { get; set; }
 
@@ -468,13 +552,16 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             // NOTE: CopyParameter関数が使いたいのでpublicにしてしまう
             public BiQuadFilterVector3 PositionFilter { get; } = new();
 
-            public Vector3 Position => IKData.Position;
+            // NOTE: 
+            // - (Position|Rotation)WithoutHeadPoseAdjust はheadの動きの追従ぶんを含まず、補間の対象になる
+            // - (Position|Rotation) は上記の値にhead由来の計算を加えた、「補間済みの値を追加補間無しで合成した値」になる
+            //   MediaPipeHandが直接Position/Rotationをread/writeするのは期待してないのでinterface memberとしてのみ実装する
+            public Vector3 PositionWithoutHeadPoseAdjust { get; private set; }
+            public Quaternion RotationWithoutHeadPoseAdjust { get; private set; }
+            private Pose _headOffsetPose = Pose.identity;
 
-            public Quaternion Rotation
-            {
-                get => IKData.Rotation;
-                set => IKData.Rotation = value;
-            }
+            Vector3 IIKData.Position => IKData.Position;
+            Quaternion IIKData.Rotation => IKData.Rotation;
 
             public ReactedHand Hand { get; }
             public HandTargetType TargetType => HandTargetType.ImageBaseHand;
@@ -504,14 +591,47 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             public void ForceSetPosition(Vector3 value)
             {
                 PositionFilter.ResetValue(value);
-                IKData.Position = value;
+                PositionWithoutHeadPoseAdjust = value;
+                UpdateIKData();
             }
 
             public void SetFilteredPosition(Vector3 value, float maxDistance)
             {
                 var rawNextPosition = PositionFilter.Update(value);
-                IKData.Position = Vector3.MoveTowards(
-                    IKData.Position, rawNextPosition, maxDistance
+                PositionWithoutHeadPoseAdjust = Vector3.MoveTowards(
+                    PositionWithoutHeadPoseAdjust, rawNextPosition, maxDistance
+                );
+                UpdateIKData();
+            }
+
+            public void SetRotation(Quaternion value)
+            {
+                RotationWithoutHeadPoseAdjust = value;
+                UpdateIKData();
+            }
+            
+            public void SetHeadOffsetPose(Pose headOffset)
+            {
+                // オフセットのうち角度はヨーだけ使うので、先にここで計算しておく
+                _headOffsetPose = new Pose(
+                    headOffset.position, 
+                    Quaternion.Euler(0f, headOffset.rotation.eulerAngles.y, 0f)
+                );
+                UpdateIKData();
+            }
+
+            private void UpdateIKData()
+            {
+                IKData.Position = Vector3.Lerp(
+                    PositionWithoutHeadPoseAdjust,
+                    _headOffsetPose.rotation * PositionWithoutHeadPoseAdjust + _headOffsetPose.position,
+                    HeadPoseAdjustFactor
+                );
+
+                IKData.Rotation = Quaternion.Slerp(
+                    RotationWithoutHeadPoseAdjust,
+                    _headOffsetPose.rotation * RotationWithoutHeadPoseAdjust,
+                    HeadPoseAdjustFactor
                 );
             }
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
@@ -226,7 +226,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
             if (isTracked)
             {
-                _rightHandState.SetHeadOffsetPose(GetHeadOffsetPose());
+                _leftHandState.SetHeadOffsetPose(GetHeadOffsetPose());
                 _trackingLostHandCalculator.CancelLeftHand();
                 var dt = Time.deltaTime;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
@@ -27,7 +27,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         private readonly CurrentFramerateChecker _framerateChecker;
         private readonly CancellationTokenSource _cts = new();
         private readonly MediaPipeHandFinger _finger;
-        private readonly ReactiveProperty<float> _headPoseAdjustFactor = new(0f);
+        private readonly ReactiveProperty<float> _headPoseAdjustFactor = new(0.25f);
 
         private bool _hasModel;
         private Transform _vrmRoot;

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -54,7 +54,7 @@
         // NOTE: X/Yいずれもcentimeter単位
         public int HandTrackingMotionOffsetX { get; set; } = 0;
         public int HandTrackingMotionOffsetY { get; set; } = 0;
-        public int HandTrackingHeadPoseAdjustFactor { get; set; } = 0;
+        public int HandTrackingHeadPoseAdjustFactor { get; set; } = 25;
 
 
         public string CameraDeviceName { get; set; } = "";

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -54,6 +54,7 @@
         // NOTE: X/Yいずれもcentimeter単位
         public int HandTrackingMotionOffsetX { get; set; } = 0;
         public int HandTrackingMotionOffsetY { get; set; } = 0;
+        public int HandTrackingHeadPoseAdjustFactor { get; set; } = 0;
 
 
         public string CameraDeviceName { get; set; } = "";

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -139,6 +139,7 @@ namespace Baku.VMagicMirrorConfig
         public static Message SetHandTrackingMotionScale(int percent) => IntContent(VmmCommands.SetHandTrackingMotionScale, percent);
         public static Message SetHandTrackingMotionOffsetX(int offset) => IntContent(VmmCommands.SetHandTrackingOffsetX, offset);
         public static Message SetHandTrackingMotionOffsetY(int offset) => IntContent(VmmCommands.SetHandTrackingOffsetY, offset);
+        public static Message SetHandTrackingHeadPoseAdjustFactor(int percent) => IntContent(VmmCommands.SetHandTrackingHeadPoseAdjustFactor, percent);
 
 
 

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -75,6 +75,9 @@ namespace Baku.VMagicMirrorConfig
             HandTrackingMotionScale = new RProperty<int>(setting.HandTrackingMotionScale, v => SendMessage(MessageFactory.SetHandTrackingMotionScale(v)));
             HandTrackingMotionOffsetX = new RProperty<int>(setting.HandTrackingMotionOffsetX, v => SendMessage(MessageFactory.SetHandTrackingMotionOffsetX(v)));
             HandTrackingMotionOffsetY = new RProperty<int>(setting.HandTrackingMotionOffsetY, v => SendMessage(MessageFactory.SetHandTrackingMotionOffsetY(v)));
+            HandTrackingHeadPoseAdjustFactor = new RProperty<int>(
+                setting.HandTrackingHeadPoseAdjustFactor,
+                v => SendMessage(MessageFactory.SetHandTrackingHeadPoseAdjustFactor(v)));
 
             CameraDeviceName = new RProperty<string>(setting.CameraDeviceName, v => SendMessage(MessageFactory.SetCameraDeviceName(v)));
             CalibrateFaceDataHighPower = new RProperty<string>(setting.CalibrateFaceDataHighPower, v => SendMessage(MessageFactory.SetCalibrateFaceDataHighPower(v)));
@@ -221,6 +224,7 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<int> HandTrackingMotionScale { get; }
         public RProperty<int> HandTrackingMotionOffsetX { get; }
         public RProperty<int> HandTrackingMotionOffsetY { get; }
+        public RProperty<int> HandTrackingHeadPoseAdjustFactor { get; }
 
 
         public RProperty<string> CameraDeviceName { get; }

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -245,7 +245,8 @@ Get Full Edition to remove the effect.</sys:String>
     <sys:String x:Key="HandTracking_MotionScale">Motion Scale (%)</sys:String>
     <sys:String x:Key="HandTracking_OffsetX">Hand Horizontal Offset (cm)</sys:String>
     <sys:String x:Key="HandTracking_OffsetY">Hand Vertical Offset (cm)</sys:String>
-    
+    <sys:String x:Key="HandTracking_HeadPoseAdjustFactor">Hands Follow Head (%)</sys:String>
+
     <sys:String x:Key="HandTracking_ShowAreaChecker">Show Detection Status (*raw image is not displayed)</sys:String>    
     <sys:String x:Key="HandTracking_BodyMotionModeIncorrect" xml:space="preserve">*Body Motion Style is now "Standing Only."
 Use "Default" to apply hand tracking result.</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -248,7 +248,8 @@
     <sys:String x:Key="HandTracking_MotionScale">動きの大きさ (%)</sys:String>
     <sys:String x:Key="HandTracking_OffsetX">手の広げ方を調整 (cm)</sys:String>
     <sys:String x:Key="HandTracking_OffsetY">手の高さを調整 (cm)</sys:String>
-    
+    <sys:String x:Key="HandTracking_HeadPoseAdjustFactor">頭の動きで手も動かす (%)</sys:String>
+
     <sys:String x:Key="HandTracking_ShowAreaChecker">手の検出状況を表示(※カメラ映像は表示されません)</sys:String> 
     <sys:String x:Key="HandTracking_DetectionResult">手の検出状況:</sys:String>
     <sys:String x:Key="HandTracking_DetectionResult_Notice" xml:space="preserve">ヒント:

--- a/WPF/VMagicMirrorConfig/View/ControlPanel/HandTrackingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/ControlPanel/HandTrackingPanel.xaml
@@ -103,6 +103,7 @@
                             <RowDefinition/>
                             <RowDefinition/>
                             <RowDefinition/>
+                            <RowDefinition/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -148,6 +149,20 @@
                                 />
                         <TextBox Grid.Row="2" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderHandOffsetY}"
+                                 />
+
+                        <TextBlock Grid.Row="3" Grid.Column="0"
+                                    Text="{DynamicResource HandTracking_HeadPoseAdjustFactor}"/>
+                        <Slider Grid.Row="3" Grid.Column="1"
+                                x:Name="sliderHandTrackingHeadPoseAdjustFactor"
+                                Minimum="0"
+                                Maximum="100"
+                                TickFrequency="1"
+                                IsSnapToTickEnabled="True"
+                                Value="{Binding HandTrackingHeadPoseAdjustFactor.Value, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="3" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderHandTrackingHeadPoseAdjustFactor}"
                                  />
                     </Grid>
 

--- a/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/HandTracking/HandTrackingViewModel.cs
@@ -74,6 +74,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public RProperty<int> HandTrackingMotionScale => _model.HandTrackingMotionScale;
         public RProperty<int> HandPositionOffsetX => _model.HandTrackingMotionOffsetX;
         public RProperty<int> HandPositionOffsetY => _model.HandTrackingMotionOffsetY;
+        public RProperty<int> HandTrackingHeadPoseAdjustFactor => _model.HandTrackingHeadPoseAdjustFactor;
         public RProperty<bool> EnableSendHandTrackingResult => _model.EnableSendHandTrackingResult;
         public HandTrackingResultViewModel HandTrackingResult { get; } = new HandTrackingResultViewModel();
         public ActionCommand OpenFullEditionDownloadUrlCommand { get; }


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature
- [x] Improve existing feature

## What the PR does

fixes #1271 

- ハンドトラッキングの動きがより自然になるようにするための改修。
- デフォルトでも多少効かせて良さそうなので効かせる
- on/offではなく連続値で動作し、値を 0% に指定すると従来動作になる
- トラッキングロストしたときの姿勢にはこの補正は効かないようにしている (利かすと手が沈み込んだりして不自然なので、意図して避けるための実装が入っている)

## How to confirm

Unity Editor + WPF Buildで

- [x] 新規追加したオプション値を0~100に振ると頭の姿勢との連動が確認できること
- [x] トラッキングロスト時の挙動が不自然でないこと
