### PR TITLE
リファクタ: GetBoneTransformが各所で散発的に呼ばれているのをなるべく減らす

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -397,7 +397,7 @@ namespace Baku.VMagicMirror
         }
 
         /// <summary>
-        /// ロードされたVRMのAnimatorを指定し、アイテムをモデルの特定部位にアタッチできるようにします。
+        /// ロードされたVRMのボーン情報を指定し、アイテムをモデルの特定部位にアタッチできるようにします。
         /// </summary>
         /// <param name="avatarBones"></param>
         public void SetAvatarBones(VRMAvatarBones avatarBones)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -31,14 +31,13 @@ namespace Baku.VMagicMirror
         private IAccessoryFileActions _fileActions = null;
         private Camera _cam = null;
 
-        private Animator _animator = null;
-        private readonly Dictionary<AccessoryAttachTarget, Transform> _attachBones 
-            = new Dictionary<AccessoryAttachTarget, Transform>();
+        private VRMAvatarBones _avatarBones;
+        private readonly Dictionary<AccessoryAttachTarget, Transform> _attachBones = new();
 
         private bool _firstEnabledCalled;
         public Action<AccessoryItem> FirstEnabled;
         
-        private readonly CancellationTokenSource _blinkCts = new CancellationTokenSource();
+        private readonly CancellationTokenSource _blinkCts = new();
 
         private bool _visibleByWordToMotion;
         public bool VisibleByWordToMotion
@@ -100,7 +99,7 @@ namespace Baku.VMagicMirror
         {
             get
             {
-                if (_file == null || _animator == null || ItemLayout == null)
+                if (_file == null || _avatarBones == null || ItemLayout == null)
                 {
                     return false;
                 }
@@ -176,7 +175,7 @@ namespace Baku.VMagicMirror
 
         public void RunBlinkTrigger()
         {
-            if (_file == null || _animator == null || ItemLayout == null ||
+            if (_file == null || _avatarBones == null || ItemLayout == null ||
                 !ItemLayout.UseAsBlinkEffect ||
                 VisibleByBlinkTrigger
                 )
@@ -330,7 +329,7 @@ namespace Baku.VMagicMirror
             HasLayoutChange = false;
             ItemLayout = layout;
             _fileActions?.UpdateLayout(layout);
-            if (_animator == null)
+            if (_avatarBones == null)
             {
                 return;
             }
@@ -400,18 +399,17 @@ namespace Baku.VMagicMirror
         /// <summary>
         /// ロードされたVRMのAnimatorを指定し、アイテムをモデルの特定部位にアタッチできるようにします。
         /// </summary>
-        /// <param name="animator"></param>
-        public void SetAnimator(Animator animator)
+        /// <param name="avatarBones"></param>
+        public void SetAvatarBones(VRMAvatarBones avatarBones)
         {
-            _animator = animator;
+            _avatarBones = avatarBones;
 
-            _attachBones[AccessoryAttachTarget.Head] = animator.GetBoneTransform(HumanBodyBones.Head);
-            _attachBones[AccessoryAttachTarget.Neck] = 
-                animator.GetBoneTransform(HumanBodyBones.Neck) ?? animator.GetBoneTransform(HumanBodyBones.Head);
-            _attachBones[AccessoryAttachTarget.Chest] = animator.GetBoneTransform(HumanBodyBones.Chest);
-            _attachBones[AccessoryAttachTarget.Waist] = animator.GetBoneTransform(HumanBodyBones.Hips);
-            _attachBones[AccessoryAttachTarget.LeftHand] = animator.GetBoneTransform(HumanBodyBones.LeftHand);
-            _attachBones[AccessoryAttachTarget.RightHand] = animator.GetBoneTransform(HumanBodyBones.RightHand);
+            _attachBones[AccessoryAttachTarget.Head] = _avatarBones.Head;
+            _attachBones[AccessoryAttachTarget.Neck] = _avatarBones.Neck ?? avatarBones.Head;
+            _attachBones[AccessoryAttachTarget.Chest] = _avatarBones.Chest;
+            _attachBones[AccessoryAttachTarget.Waist] = _avatarBones.Hips;
+            _attachBones[AccessoryAttachTarget.LeftHand] = _avatarBones.LeftHand;
+            _attachBones[AccessoryAttachTarget.RightHand] = _avatarBones.RightHand;
 
             if (_file == null)
             {
@@ -431,7 +429,7 @@ namespace Baku.VMagicMirror
         public void UnsetModel()
         {
             transform.SetParent(null);
-            _animator = null;
+            _avatarBones = null;
             _attachBones.Clear();
             transformControl.mode = TransformControl.TransformMode.None;
             SetVisibility(false);
@@ -443,7 +441,7 @@ namespace Baku.VMagicMirror
         /// <param name="request"></param>
         public void ControlItemTransform(TransformControlRequest request)
         {
-            if (_animator == null && ItemLayout == null)
+            if (_avatarBones == null && ItemLayout == null)
             {
                 return;
             }
@@ -496,7 +494,7 @@ namespace Baku.VMagicMirror
         {
             Transform bone = null;
             if (ItemLayout == null || 
-                _animator == null || 
+                _avatarBones == null || 
                 (ItemLayout.AttachTarget != AccessoryAttachTarget.World &&
                  !_attachBones.TryGetValue(ItemLayout.AttachTarget, out bone)
                 ))

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -47,8 +47,8 @@ namespace Baku.VMagicMirror
 
             vrmLoader.VrmLoaded += info =>
             {
-                _items.ForEach(i => i.SetAnimator(info.animator));
-                _animator = info.animator;
+                _items.ForEach(i => i.SetAnimator(info.Animator));
+                _animator = info.Animator;
                 _hasModel = true;
             };
             vrmLoader.VrmDisposing += () =>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -47,8 +47,8 @@ namespace Baku.VMagicMirror
 
             vrmLoader.VrmLoaded += info =>
             {
-                _items.ForEach(i => i.SetAnimator(info.controlRig));
-                _animator = info.controlRig;
+                _items.ForEach(i => i.SetAnimator(info.animator));
+                _animator = info.animator;
                 _hasModel = true;
             };
             vrmLoader.VrmDisposing += () =>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -26,7 +26,7 @@ namespace Baku.VMagicMirror
         private IMessageSender _sender;
         private readonly List<AccessoryItem> _items = new List<AccessoryItem>();
         private IDisposable _layoutSender = null;
-        private Animator _animator;
+        private VRMAvatarBones _avatarBones;
         private bool _hasModel;
 
         [Inject]
@@ -47,13 +47,14 @@ namespace Baku.VMagicMirror
 
             vrmLoader.VrmLoaded += info =>
             {
-                _items.ForEach(i => i.SetAnimator(info.Animator));
-                _animator = info.Animator;
+                _items.ForEach(i => i.SetAvatarBones(info.AvatarBones));
+                _avatarBones = info.AvatarBones;
                 _hasModel = true;
             };
             vrmLoader.VrmDisposing += () =>
             {
                 _hasModel = false;
+                _avatarBones = null;
                 _items.ForEach(i => i.UnsetModel());
             };
             
@@ -173,7 +174,7 @@ namespace Baku.VMagicMirror
                 item.FirstEnabled += OnItemFirstEnabled;
                 if (_hasModel)
                 {
-                    item.SetAnimator(_animator);
+                    item.SetAvatarBones(_avatarBones);
                 }
                 _items.Add(item);
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceAttitudeController.cs
@@ -52,9 +52,8 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var animator = info.Animator;
-                _neck = animator.GetBoneTransform(HumanBodyBones.Neck);
-                _head = animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.AvatarBones.Neck;
+                _head = info.AvatarBones.Head;
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceAttitudeController.cs
@@ -52,7 +52,7 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var animator = info.controlRig;
+                var animator = info.animator;
                 _neck = animator.GetBoneTransform(HumanBodyBones.Neck);
                 _head = animator.GetBoneTransform(HumanBodyBones.Head);
                 _hasNeck = _neck != null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerFaceAttitudeController.cs
@@ -52,7 +52,7 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var animator = info.animator;
+                var animator = info.Animator;
                 _neck = animator.GetBoneTransform(HumanBodyBones.Neck);
                 _head = animator.GetBoneTransform(HumanBodyBones.Head);
                 _hasNeck = _neck != null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/ExternalTracker/ExternalTrackerPerfectSync.cs
@@ -75,7 +75,7 @@ namespace Baku.VMagicMirror.ExternalTracker
             vrmLoadable.VrmLoaded += info =>
             {
                 //参照じゃなくて値コピーしとくことに注意(なにかと安全なので)
-                _modelBasedMap = info.instance.Vrm.Expression.LoadExpressionMap();
+                _modelBasedMap = info.Instance.Vrm.Expression.LoadExpressionMap();
                 NonPerfectSyncKeys = LoadNonPerfectSyncKeys();
                 _hasModel = true;
                 ParseClipCompletenessToSendMessage();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeExclusivenessChecker.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeExclusivenessChecker.cs
@@ -14,7 +14,7 @@ namespace Baku.VMagicMirror
         private void CheckBlendShape(VrmLoadedInfo info)
         {
             //表情のセットアップで排他系の設定がちゃんとあると検出するクラス
-            var expr = info.instance.Vrm.Expression;
+            var expr = info.Instance.Vrm.Expression;
             
             var clipAboutOverride = expr.Clips.FirstOrDefault(c =>
                 c.Clip.OverrideBlink != ExpressionOverrideType.none ||

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/BlendShapeInterpolator.cs
@@ -54,7 +54,7 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += info =>
             {
-                _expressionMap = info.instance.Vrm.Expression.LoadExpressionMap();
+                _expressionMap = info.Instance.Vrm.Expression.LoadExpressionMap();
                 //CheckBinaryClips(_expressionMap);
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/BehaviorBasedAutoBlinkAdjust.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/BehaviorBasedAutoBlinkAdjust.cs
@@ -81,7 +81,7 @@ namespace Baku.VMagicMirror
             _lipSyncContext = lipSyncContext;
             vrmLoadable.VrmLoaded += vrm =>
             {
-                _head = vrm.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _head = vrm.AvatarBones.Head;
                 _prevHeadRotation = _head.rotation;
                 _headRotationDegree = 0;
                 _isVrmLoaded = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/BehaviorBasedAutoBlinkAdjust.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/BehaviorBasedAutoBlinkAdjust.cs
@@ -81,7 +81,7 @@ namespace Baku.VMagicMirror
             _lipSyncContext = lipSyncContext;
             vrmLoadable.VrmLoaded += vrm =>
             {
-                _head = vrm.controlRig.GetBoneTransform(HumanBodyBones.Head);
+                _head = vrm.animator.GetBoneTransform(HumanBodyBones.Head);
                 _prevHeadRotation = _head.rotation;
                 _headRotationDegree = 0;
                 _isVrmLoaded = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/BehaviorBasedAutoBlinkAdjust.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/Blink/BehaviorBasedAutoBlinkAdjust.cs
@@ -81,7 +81,7 @@ namespace Baku.VMagicMirror
             _lipSyncContext = lipSyncContext;
             vrmLoadable.VrmLoaded += vrm =>
             {
-                _head = vrm.animator.GetBoneTransform(HumanBodyBones.Head);
+                _head = vrm.Animator.GetBoneTransform(HumanBodyBones.Head);
                 _prevHeadRotation = _head.rotation;
                 _headRotationDegree = 0;
                 _isVrmLoaded = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/ExpressionAccumulator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/ExpressionAccumulator.cs
@@ -29,8 +29,8 @@ namespace Baku.VMagicMirror
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                _expression = info.instance.Runtime.Expression;
-                var exprMap = info.instance.Vrm.Expression.LoadExpressionMap();
+                _expression = info.Instance.Runtime.Expression;
+                var exprMap = info.Instance.Vrm.Expression.LoadExpressionMap();
 
                 _values.Clear();
                 _keys.Clear();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBlendShapeAngleMapApplier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBlendShapeAngleMapApplier.cs
@@ -43,14 +43,14 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            if (info.instance.Vrm.LookAt.LookAtType != LookAtType.expression)
+            if (info.Instance.Vrm.LookAt.LookAtType != LookAtType.expression)
             {
                 _hasApplier = false;
                 return;
             }
 
             _hasApplier = true;
-            _applier = info.instance.Vrm.LookAt;
+            _applier = info.Instance.Vrm.LookAt;
         }
 
         private void OnVrmDisposed()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleMapApplier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleMapApplier.cs
@@ -27,14 +27,14 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            if (info.instance.Vrm.LookAt.LookAtType != LookAtType.bone)
+            if (info.Instance.Vrm.LookAt.LookAtType != LookAtType.bone)
             {
                 _hasBoneApplier = false;
                 return;
             }
 
             _hasBoneApplier = true;
-            _applier = info.instance.Vrm.LookAt;
+            _applier = info.Instance.Vrm.LookAt;
         }
 
         private void OnVrmDisposed()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeBoneAngleSetter.cs
@@ -110,7 +110,7 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            var controlRigBones = info.instance.Runtime.ControlRig.Bones;
+            var controlRigBones = info.Instance.Runtime.ControlRig.Bones;
             _hasLeftEyeBone = controlRigBones.TryGetValue(HumanBodyBones.LeftEye, out var leftEyeBone);
             if (_hasLeftEyeBone && leftEyeBone != null)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeDownMotionController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeDownMotionController.cs
@@ -43,7 +43,7 @@ namespace Baku.VMagicMirror
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
             _runtimeExpression = info.RuntimeFacialExpression;
-            _hasValidEyeSettings = CheckBlinkBlendShapeClips(info.instance.Vrm.Expression);
+            _hasValidEyeSettings = CheckBlinkBlendShapeClips(info.Instance.Vrm.Expression);
         }
 
         private void OnVrmDisposing()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeLookAt.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeLookAt.cs
@@ -27,7 +27,7 @@ namespace Baku.VMagicMirror
         public EyeLookAt(IVRMLoadable vrmLoadable, IKTargetTransforms ikTargets)
         {
             _lookAtTarget = ikTargets.LookAt;
-            vrmLoadable.VrmLoaded += info => SetAvatarHead(info.animator.GetBoneTransform(HumanBodyBones.Head));
+            vrmLoadable.VrmLoaded += info => SetAvatarHead(info.Animator.GetBoneTransform(HumanBodyBones.Head));
             vrmLoadable.VrmDisposing += ReleaseAvatarHead;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeLookAt.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeLookAt.cs
@@ -27,7 +27,7 @@ namespace Baku.VMagicMirror
         public EyeLookAt(IVRMLoadable vrmLoadable, IKTargetTransforms ikTargets)
         {
             _lookAtTarget = ikTargets.LookAt;
-            vrmLoadable.VrmLoaded += info => SetAvatarHead(info.Animator.GetBoneTransform(HumanBodyBones.Head));
+            vrmLoadable.VrmLoaded += info => SetAvatarHead(info.AvatarBones.Head);
             vrmLoadable.VrmDisposing += ReleaseAvatarHead;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeLookAt.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/EyeLookAt.cs
@@ -27,7 +27,7 @@ namespace Baku.VMagicMirror
         public EyeLookAt(IVRMLoadable vrmLoadable, IKTargetTransforms ikTargets)
         {
             _lookAtTarget = ikTargets.LookAt;
-            vrmLoadable.VrmLoaded += info => SetAvatarHead(info.controlRig.GetBoneTransform(HumanBodyBones.Head));
+            vrmLoadable.VrmLoaded += info => SetAvatarHead(info.animator.GetBoneTransform(HumanBodyBones.Head));
             vrmLoadable.VrmDisposing += ReleaseAvatarHead;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/FaceContol/FaceSwitch/FaceSwitchUpdater.cs
@@ -102,7 +102,7 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            var expressionKeys = info.instance.Vrm.Expression.LoadExpressionMap().Keys;
+            var expressionKeys = info.Instance.Vrm.Expression.LoadExpressionMap().Keys;
             _faceSwitch.AvatarBlendShapeNames = expressionKeys.Select(k =>
                 {
                     var result = k.Name;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyLeanIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyLeanIntegrator.cs
@@ -47,7 +47,7 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmLoaded += info =>
             {
                 _bodyHorizontalOffsetSuggest = 0;
-                float hipsHeight = info.Animator.GetBoneTransform(HumanBodyBones.Hips).position.y;
+                float hipsHeight = info.AvatarBones.Hips.position.y;
                 //あまり非常識な値が来たらもう適当に蹴ってしまう。別に蹴ってもそこまで危険でもないし。
                 _hipsHeightRate = Mathf.Clamp(hipsHeight / ReferenceHipsHeight, 0.1f, 3f);
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyLeanIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyLeanIntegrator.cs
@@ -47,7 +47,7 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmLoaded += info =>
             {
                 _bodyHorizontalOffsetSuggest = 0;
-                float hipsHeight = info.controlRig.GetBoneTransform(HumanBodyBones.Hips).position.y;
+                float hipsHeight = info.animator.GetBoneTransform(HumanBodyBones.Hips).position.y;
                 //あまり非常識な値が来たらもう適当に蹴ってしまう。別に蹴ってもそこまで危険でもないし。
                 _hipsHeightRate = Mathf.Clamp(hipsHeight / ReferenceHipsHeight, 0.1f, 3f);
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyLeanIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyLeanIntegrator.cs
@@ -47,7 +47,7 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmLoaded += info =>
             {
                 _bodyHorizontalOffsetSuggest = 0;
-                float hipsHeight = info.animator.GetBoneTransform(HumanBodyBones.Hips).position.y;
+                float hipsHeight = info.Animator.GetBoneTransform(HumanBodyBones.Hips).position.y;
                 //あまり非常識な値が来たらもう適当に蹴ってしまう。別に蹴ってもそこまで危険でもないし。
                 _hipsHeightRate = Mathf.Clamp(hipsHeight / ReferenceHipsHeight, 0.1f, 3f);
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManager.cs
@@ -118,13 +118,13 @@ namespace Baku.VMagicMirror
         {
             //NOTE: VRMLoadControllerがロード時点でbodyIkの位置をキャラのHipsあたりに調整しているので、それを貰う
             _defaultBodyIkPosition = _bodyIk.position;
-            _vrmRoot = info.vrmRoot;
+            _vrmRoot = info.VrmRoot;
 
             _upperBodyBones = new[]
                 {
-                    info.animator.GetBoneTransform(HumanBodyBones.Spine),
-                    info.animator.GetBoneTransform(HumanBodyBones.Chest),
-                    info.animator.GetBoneTransform(HumanBodyBones.UpperChest),
+                    info.Animator.GetBoneTransform(HumanBodyBones.Spine),
+                    info.Animator.GetBoneTransform(HumanBodyBones.Chest),
+                    info.Animator.GetBoneTransform(HumanBodyBones.UpperChest),
                 }
                 .Where(t => t != null)
                 .ToArray();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManager.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/BodyMotionManager.cs
@@ -122,9 +122,9 @@ namespace Baku.VMagicMirror
 
             _upperBodyBones = new[]
                 {
-                    info.Animator.GetBoneTransform(HumanBodyBones.Spine),
-                    info.Animator.GetBoneTransform(HumanBodyBones.Chest),
-                    info.Animator.GetBoneTransform(HumanBodyBones.UpperChest),
+                    info.AvatarBones.Spine,
+                    info.AvatarBones.Chest,
+                    info.AvatarBones.UpperChest,
                 }
                 .Where(t => t != null)
                 .ToArray();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
@@ -33,8 +33,8 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmLoaded += info =>
             {
                 SetZeroTarget();
-                _head = info.controlRig.GetBoneTransform(HumanBodyBones.Head);
-                _neck = info.controlRig.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.animator.GetBoneTransform(HumanBodyBones.Neck);
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
@@ -33,8 +33,8 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmLoaded += info =>
             {
                 SetZeroTarget();
-                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
-                _neck = info.Animator.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.AvatarBones.Head;
+                _neck = info.AvatarBones.Neck;
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/FaceAngleToBodyAngle.cs
@@ -33,8 +33,8 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmLoaded += info =>
             {
                 SetZeroTarget();
-                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
-                _neck = info.animator.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.Animator.GetBoneTransform(HumanBodyBones.Neck);
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
@@ -166,18 +166,17 @@ namespace Baku.VMagicMirror
         
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _leftShoulder = info.Animator.GetBoneTransform(HumanBodyBones.LeftShoulder);
-            _leftUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-            _leftLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftLowerArm);
+            _leftShoulder = info.AvatarBones.LeftShoulder;
+            _leftUpperArm = info.AvatarBones.LeftUpperArm;
+            _leftLowerArm = info.AvatarBones.LeftLowerArm;
 
-            _rightShoulder = info.Animator.GetBoneTransform(HumanBodyBones.RightShoulder);
-            _rightUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
-            _rightLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.RightLowerArm);
+            _rightShoulder = info.AvatarBones.RightShoulder;
+            _rightUpperArm = info.AvatarBones.RightUpperArm;
+            _rightLowerArm = info.AvatarBones.RightLowerArm;
 
             _rightHandEffector = info.FbbIk.solver.rightHandEffector;
             
-            _handDiffMax = handDiffMaxBase * 
-                info.Animator.GetBoneTransform(HumanBodyBones.Head).position.y / ReferenceHeadHeight;
+            _handDiffMax = handDiffMaxBase * info.AvatarBones.Head.position.y / ReferenceHeadHeight;
             //値が0寄りすぎると危ないので念のため。
             if (_handDiffMax < 0.001f)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
@@ -166,18 +166,18 @@ namespace Baku.VMagicMirror
         
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _leftShoulder = info.controlRig.GetBoneTransform(HumanBodyBones.LeftShoulder);
-            _leftUpperArm = info.controlRig.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-            _leftLowerArm = info.controlRig.GetBoneTransform(HumanBodyBones.LeftLowerArm);
+            _leftShoulder = info.animator.GetBoneTransform(HumanBodyBones.LeftShoulder);
+            _leftUpperArm = info.animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
+            _leftLowerArm = info.animator.GetBoneTransform(HumanBodyBones.LeftLowerArm);
 
-            _rightShoulder = info.controlRig.GetBoneTransform(HumanBodyBones.RightShoulder);
-            _rightUpperArm = info.controlRig.GetBoneTransform(HumanBodyBones.RightUpperArm);
-            _rightLowerArm = info.controlRig.GetBoneTransform(HumanBodyBones.RightLowerArm);
+            _rightShoulder = info.animator.GetBoneTransform(HumanBodyBones.RightShoulder);
+            _rightUpperArm = info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+            _rightLowerArm = info.animator.GetBoneTransform(HumanBodyBones.RightLowerArm);
 
             _rightHandEffector = info.fbbIk.solver.rightHandEffector;
             
             _handDiffMax = handDiffMaxBase * 
-                info.controlRig.GetBoneTransform(HumanBodyBones.Head).position.y / ReferenceHeadHeight;
+                info.animator.GetBoneTransform(HumanBodyBones.Head).position.y / ReferenceHeadHeight;
             //値が0寄りすぎると危ないので念のため。
             if (_handDiffMax < 0.001f)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
@@ -166,18 +166,18 @@ namespace Baku.VMagicMirror
         
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _leftShoulder = info.animator.GetBoneTransform(HumanBodyBones.LeftShoulder);
-            _leftUpperArm = info.animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-            _leftLowerArm = info.animator.GetBoneTransform(HumanBodyBones.LeftLowerArm);
+            _leftShoulder = info.Animator.GetBoneTransform(HumanBodyBones.LeftShoulder);
+            _leftUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
+            _leftLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftLowerArm);
 
-            _rightShoulder = info.animator.GetBoneTransform(HumanBodyBones.RightShoulder);
-            _rightUpperArm = info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
-            _rightLowerArm = info.animator.GetBoneTransform(HumanBodyBones.RightLowerArm);
+            _rightShoulder = info.Animator.GetBoneTransform(HumanBodyBones.RightShoulder);
+            _rightUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+            _rightLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.RightLowerArm);
 
-            _rightHandEffector = info.fbbIk.solver.rightHandEffector;
+            _rightHandEffector = info.FbbIk.solver.rightHandEffector;
             
             _handDiffMax = handDiffMaxBase * 
-                info.animator.GetBoneTransform(HumanBodyBones.Head).position.y / ReferenceHeadHeight;
+                info.Animator.GetBoneTransform(HumanBodyBones.Head).position.y / ReferenceHeadHeight;
             //値が0寄りすぎると危ないので念のため。
             if (_handDiffMax < 0.001f)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ElbowMotionModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ElbowMotionModifier.cs
@@ -289,7 +289,7 @@ namespace Baku.VMagicMirror
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
             _ik = info.FbbIk;
-            _spine = info.Animator.GetBoneTransform(HumanBodyBones.Spine);
+            _spine = info.AvatarBones.Spine;
 
             _rightArmBendGoal = new GameObject().transform;
             _rightArmBendGoal.SetParent(_spine);
@@ -301,12 +301,12 @@ namespace Baku.VMagicMirror
             _leftArmBendGoal.localRotation = Quaternion.identity;
             _ik.solver.leftArmChain.bendConstraint.bendGoal = _leftArmBendGoal;
 
-            _leftUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftUpperArm).position;
-            var leftLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftLowerArm).position;
+            _leftUpperArm = info.AvatarBones.LeftUpperArm.position;
+            var leftLowerArm = info.AvatarBones.LeftLowerArm.position;
             _leftUpperArmLength = Vector3.Distance(_leftUpperArm, leftLowerArm);
 
-            _rightUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm).position;
-            var rightLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.RightLowerArm).position;
+            _rightUpperArm = info.AvatarBones.RightUpperArm.position;
+            var rightLowerArm = info.AvatarBones.RightLowerArm.position;
             _rightUpperArmLength = Vector3.Distance(_rightUpperArm, rightLowerArm);
             
             _vrmRoot = info.VrmRoot;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ElbowMotionModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ElbowMotionModifier.cs
@@ -288,8 +288,8 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _ik = info.fbbIk;
-            _spine = info.animator.GetBoneTransform(HumanBodyBones.Spine);
+            _ik = info.FbbIk;
+            _spine = info.Animator.GetBoneTransform(HumanBodyBones.Spine);
 
             _rightArmBendGoal = new GameObject().transform;
             _rightArmBendGoal.SetParent(_spine);
@@ -301,15 +301,15 @@ namespace Baku.VMagicMirror
             _leftArmBendGoal.localRotation = Quaternion.identity;
             _ik.solver.leftArmChain.bendConstraint.bendGoal = _leftArmBendGoal;
 
-            _leftUpperArm = info.animator.GetBoneTransform(HumanBodyBones.LeftUpperArm).position;
-            var leftLowerArm = info.animator.GetBoneTransform(HumanBodyBones.LeftLowerArm).position;
+            _leftUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftUpperArm).position;
+            var leftLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftLowerArm).position;
             _leftUpperArmLength = Vector3.Distance(_leftUpperArm, leftLowerArm);
 
-            _rightUpperArm = info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm).position;
-            var rightLowerArm = info.animator.GetBoneTransform(HumanBodyBones.RightLowerArm).position;
+            _rightUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm).position;
+            var rightLowerArm = info.Animator.GetBoneTransform(HumanBodyBones.RightLowerArm).position;
             _rightUpperArmLength = Vector3.Distance(_rightUpperArm, rightLowerArm);
             
-            _vrmRoot = info.vrmRoot;
+            _vrmRoot = info.VrmRoot;
             _hasModel = true;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ElbowMotionModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/ElbowMotionModifier.cs
@@ -289,7 +289,7 @@ namespace Baku.VMagicMirror
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
             _ik = info.fbbIk;
-            _spine = info.controlRig.GetBoneTransform(HumanBodyBones.Spine);
+            _spine = info.animator.GetBoneTransform(HumanBodyBones.Spine);
 
             _rightArmBendGoal = new GameObject().transform;
             _rightArmBendGoal.SetParent(_spine);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/ArmMuscleInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/ArmMuscleInterpolator.cs
@@ -188,15 +188,15 @@ namespace Baku.VMagicMirror.FK
         {
             OnVrmDisposing();
 
-            _humanPoseHandler = new HumanPoseHandler(info.animator.avatar, info.animator.transform);
-            _hips = info.animator.GetBoneTransform(HumanBodyBones.Hips);
+            _humanPoseHandler = new HumanPoseHandler(info.Animator.avatar, info.Animator.transform);
+            _hips = info.Animator.GetBoneTransform(HumanBodyBones.Hips);
             _humanPoseHandler.GetHumanPose(ref _humanPose);
             ResetBothArmFilters();
             
             foreach (var bone in (HumanBodyBones[])System.Enum.GetValues(typeof(HumanBodyBones)))
             {
                 if (bone is HumanBodyBones.Hips or HumanBodyBones.Jaw or HumanBodyBones.LastBone) continue;
-                var transform = info.animator.GetBoneTransform(bone);
+                var transform = info.Animator.GetBoneTransform(bone);
                 if (transform != null)
                 {
                     _bones[bone] = transform;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/ArmMuscleInterpolator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/ArmMuscleInterpolator.cs
@@ -189,7 +189,7 @@ namespace Baku.VMagicMirror.FK
             OnVrmDisposing();
 
             _humanPoseHandler = new HumanPoseHandler(info.Animator.avatar, info.Animator.transform);
-            _hips = info.Animator.GetBoneTransform(HumanBodyBones.Hips);
+            _hips = info.AvatarBones.Hips;
             _humanPoseHandler.GetHumanPose(ref _humanPose);
             ResetBothArmFilters();
             

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
@@ -57,12 +57,12 @@ namespace Baku.VMagicMirror.FK
             _bones.Clear();
             _reducedRotations.Clear();
             _tempRotations.Clear();
-            _vrm10Instance = info.instance;
+            _vrm10Instance = info.Instance;
 
             for (var i = (int) HumanBodyBones.Hips; i < (int) HumanBodyBones.LastBone; i++)
             {
                 var boneType = (HumanBodyBones) i;
-                var bone = info.animator.GetBoneTransform(boneType);
+                var bone = info.Animator.GetBoneTransform(boneType);
                 if (bone != null)
                 {
                     _bones[boneType] = bone;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FK/BoneFrameReducer.cs
@@ -62,7 +62,7 @@ namespace Baku.VMagicMirror.FK
             for (var i = (int) HumanBodyBones.Hips; i < (int) HumanBodyBones.LastBone; i++)
             {
                 var boneType = (HumanBodyBones) i;
-                var bone = info.controlRig.GetBoneTransform(boneType);
+                var bone = info.animator.GetBoneTransform(boneType);
                 if (bone != null)
                 {
                     _bones[boneType] = bone;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/FingerController.cs
@@ -58,7 +58,6 @@ namespace Baku.VMagicMirror
         private KeyboardProvider _keyboard;
 
         private bool _hasModel;
-        private Animator _animator;
 
         //左手親指 = 0,
         //左手人差し指 = 1,
@@ -117,72 +116,71 @@ namespace Baku.VMagicMirror
         public bool RightHandPresentationMode { get; set; } = false;
         public bool RightHandPenTabletMode { get; set; } = false;
 
-        public void Initialize(Animator animator)
+        public void Initialize(VRMAvatarBones avatarBones)
         {
-            if(animator == null) { return; }
+            if(avatarBones == null) { return; }
 
-            _animator = animator;
             _fingers = new[]
             {
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.LeftThumbDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftThumbIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftThumbProximal),
+                    avatarBones.LeftThumbDistal,
+                    avatarBones.LeftThumbIntermediate,
+                    avatarBones.LeftThumbProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.LeftIndexDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftIndexIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftIndexProximal),
+                    avatarBones.LeftIndexDistal,
+                    avatarBones.LeftIndexIntermediate,
+                    avatarBones.LeftIndexProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.LeftMiddleDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftMiddleIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftMiddleProximal),
+                    avatarBones.LeftMiddleDistal,
+                    avatarBones.LeftMiddleIntermediate,
+                    avatarBones.LeftMiddleProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.LeftRingDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftRingIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftRingProximal),
+                    avatarBones.LeftRingDistal,
+                    avatarBones.LeftRingIntermediate,
+                    avatarBones.LeftRingProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.LeftLittleDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftLittleIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.LeftLittleProximal),
+                    avatarBones.LeftLittleDistal,
+                    avatarBones.LeftLittleIntermediate,
+                    avatarBones.LeftLittleProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.RightThumbDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.RightThumbProximal),
+                    avatarBones.RightThumbDistal,
+                    avatarBones.RightThumbIntermediate,
+                    avatarBones.RightThumbProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.RightIndexDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.RightIndexProximal),
+                    avatarBones.RightIndexDistal,
+                    avatarBones.RightIndexIntermediate,
+                    avatarBones.RightIndexProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.RightMiddleDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal),
+                    avatarBones.RightMiddleDistal,
+                    avatarBones.RightMiddleIntermediate,
+                    avatarBones.RightMiddleProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.RightRingDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.RightRingIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.RightRingProximal),
+                    avatarBones.RightRingDistal,
+                    avatarBones.RightRingIntermediate,
+                    avatarBones.RightRingProximal,
                 },
                 new[]
                 {
-                    _animator.GetBoneTransform(HumanBodyBones.RightLittleDistal),
-                    _animator.GetBoneTransform(HumanBodyBones.RightLittleIntermediate),
-                    _animator.GetBoneTransform(HumanBodyBones.RightLittleProximal),
+                    avatarBones.RightLittleDistal,
+                    avatarBones.RightLittleIntermediate,
+                    avatarBones.RightLittleProximal,
                 },
             };
 
@@ -212,7 +210,6 @@ namespace Baku.VMagicMirror
         public void Dispose()
         {
             _hasModel = false;
-            _animator = null;
             _fingers = null;
             _fingerBendAxis = null;
             _defaultFingerBendRotations = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/GameInputBodyMotionController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/GamePadBasedBody/GameInputBodyMotionController.cs
@@ -199,8 +199,8 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo obj)
         {
-            _animator = obj.animator;
-            _vrmRoot = obj.vrmRoot;
+            _animator = obj.Animator;
+            _vrmRoot = obj.VrmRoot;
             _baseLayerIndex = _animator.GetLayerIndex("Base");
 
             _hasModel = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -425,7 +425,7 @@ namespace Baku.VMagicMirror
         
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            fingerController.Initialize(info.controlRig);
+            fingerController.Initialize(info.animator);
             
             //キャラロード前のHandDownとブレンドするとIK位置が原点に飛ぶので、その値を捨てる
             MouseMove.ResetHandDownTimeout(true);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -425,7 +425,7 @@ namespace Baku.VMagicMirror
         
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            fingerController.Initialize(info.Animator);
+            fingerController.Initialize(info.AvatarBones);
             
             //キャラロード前のHandDownとブレンドするとIK位置が原点に飛ぶので、その値を捨てる
             MouseMove.ResetHandDownTimeout(true);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HandIKIntegrator.cs
@@ -425,7 +425,7 @@ namespace Baku.VMagicMirror
         
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            fingerController.Initialize(info.animator);
+            fingerController.Initialize(info.Animator);
             
             //キャラロード前のHandDownとブレンドするとIK位置が原点に飛ぶので、その値を捨てる
             MouseMove.ResetHandDownTimeout(true);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadIkIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadIkIntegrator.cs
@@ -66,7 +66,7 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += info =>
             {
-                _head = info.controlRig.GetBoneTransform(HumanBodyBones.Head);
+                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
                 _lookAtIk = info.vrmRoot.GetComponentInChildren<LookAtIK>();
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadIkIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadIkIntegrator.cs
@@ -66,8 +66,8 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += info =>
             {
-                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
-                _lookAtIk = info.vrmRoot.GetComponentInChildren<LookAtIK>();
+                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _lookAtIk = info.VrmRoot.GetComponentInChildren<LookAtIK>();
                 _hasModel = true;
             };
             vrmLoadable.VrmDisposing += () =>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadIkIntegrator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadIkIntegrator.cs
@@ -66,7 +66,7 @@ namespace Baku.VMagicMirror
 
             vrmLoadable.VrmLoaded += info =>
             {
-                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _head = info.AvatarBones.Head;
                 _lookAtIk = info.VrmRoot.GetComponentInChildren<LookAtIK>();
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadMotionClipPlayer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadMotionClipPlayer.cs
@@ -120,8 +120,8 @@ namespace Baku.VMagicMirror
             _autoBlink = autoBlink;
             vrmLoadable.VrmLoaded += info =>
             {
-                _neck = info.animator.GetBoneTransform(HumanBodyBones.Neck);
-                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.Animator.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
                 _hasNeck = (_neck != null);
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadMotionClipPlayer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadMotionClipPlayer.cs
@@ -120,8 +120,8 @@ namespace Baku.VMagicMirror
             _autoBlink = autoBlink;
             vrmLoadable.VrmLoaded += info =>
             {
-                _neck = info.Animator.GetBoneTransform(HumanBodyBones.Neck);
-                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.AvatarBones.Neck;
+                _head = info.AvatarBones.Head;
                 _hasNeck = (_neck != null);
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadMotionClipPlayer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/HeadMotionClipPlayer.cs
@@ -120,8 +120,8 @@ namespace Baku.VMagicMirror
             _autoBlink = autoBlink;
             vrmLoadable.VrmLoaded += info =>
             {
-                _neck = info.controlRig.GetBoneTransform(HumanBodyBones.Neck);
-                _head = info.controlRig.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.animator.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
                 _hasNeck = (_neck != null);
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
@@ -58,9 +58,9 @@ namespace Baku.VMagicMirror.IK
             //モデルロード時、身長を参照することで「コントローラの移動オフセットはこんくらいだよね」を初期化
             vrmLoadable.VrmLoaded += info =>
             {
-                var h = info.controlRig.GetBoneTransform(HumanBodyBones.Head);
-                var f = info.controlRig.GetBoneTransform(HumanBodyBones.LeftFoot);
-                CacheHandOffsets(info.controlRig);
+                var h = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                var f = info.animator.GetBoneTransform(HumanBodyBones.LeftFoot);
+                CacheHandOffsets(info.animator);
             };
 
             dependency.Events.MoveLeftGamepadStick += v =>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
@@ -58,9 +58,9 @@ namespace Baku.VMagicMirror.IK
             //モデルロード時、身長を参照することで「コントローラの移動オフセットはこんくらいだよね」を初期化
             vrmLoadable.VrmLoaded += info =>
             {
-                var h = info.animator.GetBoneTransform(HumanBodyBones.Head);
-                var f = info.animator.GetBoneTransform(HumanBodyBones.LeftFoot);
-                CacheHandOffsets(info.animator);
+                var h = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                var f = info.Animator.GetBoneTransform(HumanBodyBones.LeftFoot);
+                CacheHandOffsets(info.Animator);
             };
 
             dependency.Events.MoveLeftGamepadStick += v =>

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
@@ -56,12 +56,7 @@ namespace Baku.VMagicMirror.IK
             _rightHandState = new ArcadeStickHandIkState(this, ReactedHand.Right);
 
             //モデルロード時、身長を参照することで「コントローラの移動オフセットはこんくらいだよね」を初期化
-            vrmLoadable.VrmLoaded += info =>
-            {
-                var h = info.Animator.GetBoneTransform(HumanBodyBones.Head);
-                var f = info.Animator.GetBoneTransform(HumanBodyBones.LeftFoot);
-                CacheHandOffsets(info.Animator);
-            };
+            vrmLoadable.VrmLoaded += info => CacheHandOffsets(info.Animator);
 
             dependency.Events.MoveLeftGamepadStick += v =>
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ArcadeStickHandIKGenerator.cs
@@ -56,7 +56,7 @@ namespace Baku.VMagicMirror.IK
             _rightHandState = new ArcadeStickHandIkState(this, ReactedHand.Right);
 
             //モデルロード時、身長を参照することで「コントローラの移動オフセットはこんくらいだよね」を初期化
-            vrmLoadable.VrmLoaded += info => CacheHandOffsets(info.Animator);
+            vrmLoadable.VrmLoaded += info => CacheHandOffsets(info.AvatarBones);
 
             dependency.Events.MoveLeftGamepadStick += v =>
             {
@@ -206,47 +206,47 @@ namespace Baku.VMagicMirror.IK
             }
         }
 
-        private void CacheHandOffsets(Animator animator)
+        private void CacheHandOffsets(VRMAvatarBones avatarBones)
         {
             //左手 : 手のひら中央の位置を推定するため、中指の付け根を見に行く
-            var leftWrist = animator.GetBoneTransform(HumanBodyBones.LeftHand);
-            var leftMiddle = animator.GetBoneTransform(HumanBodyBones.LeftMiddleProximal);
+            var leftWrist = avatarBones.LeftHand;
+            var leftMiddle = avatarBones.LeftMiddleProximal;
             _leftHandPalmOffset = leftMiddle != null ? 0.5f * (leftMiddle.position - leftWrist.position) : Vector3.zero;
 
             //右手 : 指の位置を一通りチェックする
-            var rightWristPos = animator.GetBoneTransform(HumanBodyBones.RightHand).position;
-            var intermediateBones = new Transform[]
+            var rightWristPos = avatarBones.RightHand.position;
+            var intermediateBones = new[]
             {
                 //NOTE: 指が約30度曲がったとき関節1個ぶんのズレが発生するので、あえてDistalではなくIntermediateを見る
-                animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate),
-                animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate),
-                animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate),
-                animator.GetBoneTransform(HumanBodyBones.RightRingIntermediate),
-                animator.GetBoneTransform(HumanBodyBones.RightLittleIntermediate),
+                avatarBones.RightThumbIntermediate,
+                avatarBones.RightIndexIntermediate,
+                avatarBones.RightMiddleIntermediate,
+                avatarBones.RightRingIntermediate,
+                avatarBones.RightLittleIntermediate,
             };
             
             //NOTE: さらに、指が30度曲がるとだいたい関節2つぶんy方向にオフセットがつくので、その分を計算する
-            var proximalBones = new Transform[]
+            var proximalBones = new[]
             {
-                animator.GetBoneTransform(HumanBodyBones.RightThumbProximal),
-                animator.GetBoneTransform(HumanBodyBones.RightIndexProximal),
-                animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal),
-                animator.GetBoneTransform(HumanBodyBones.RightRingProximal),
-                animator.GetBoneTransform(HumanBodyBones.RightLittleProximal),
+                avatarBones.RightThumbProximal,
+                avatarBones.RightIndexProximal,
+                avatarBones.RightMiddleProximal,
+                avatarBones.RightRingProximal,
+                avatarBones.RightLittleProximal,
             };
             
-            var distalBones = new Transform[]
+            var distalBones = new[]
             {
-                animator.GetBoneTransform(HumanBodyBones.RightThumbDistal),
-                animator.GetBoneTransform(HumanBodyBones.RightIndexDistal),
-                animator.GetBoneTransform(HumanBodyBones.RightMiddleDistal),
-                animator.GetBoneTransform(HumanBodyBones.RightRingDistal),
-                animator.GetBoneTransform(HumanBodyBones.RightLittleDistal),
+                avatarBones.RightThumbDistal,
+                avatarBones.RightIndexDistal,
+                avatarBones.RightMiddleDistal,
+                avatarBones.RightRingDistal,
+                avatarBones.RightLittleDistal,
             };
             
             //NOTE: 指が一部なくてもエラーにはならないが、指の一部だけが欠けていると計算としてはかなり崩れる。
             //指が全部 or 全部あるモデルが大多数派であると考えての実装になっています
-            for (int i = 0; i < intermediateBones.Length; i++)
+            for (var i = 0; i < intermediateBones.Length; i++)
             {
                 if (i == 0)
                 {
@@ -280,9 +280,6 @@ namespace Baku.VMagicMirror.IK
             {
                 _wristToFingerOffsets[0] = Vector3.zero;
             }
-            
-
-
         }
 
         private void EnterState(ReactedHand hand)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
@@ -116,8 +116,8 @@ namespace Baku.VMagicMirror.IK
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _keyPoseCalculator.SetupAvatarBodyParameter(info.controlRig);
-            var headHeight = info.controlRig.GetBoneTransform(HumanBodyBones.Head).position.y;
+            _keyPoseCalculator.SetupAvatarBodyParameter(info.animator);
+            var headHeight = info.animator.GetBoneTransform(HumanBodyBones.Head).position.y;
             //0を入れると0除算になるので一応避けておく
             _timeTableGenerator.HeadHeight = Mathf.Max(headHeight, 0.1f);
             _hasModel = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
@@ -116,8 +116,8 @@ namespace Baku.VMagicMirror.IK
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _keyPoseCalculator.SetupAvatarBodyParameter(info.animator);
-            var headHeight = info.animator.GetBoneTransform(HumanBodyBones.Head).position.y;
+            _keyPoseCalculator.SetupAvatarBodyParameter(info.Animator);
+            var headHeight = info.Animator.GetBoneTransform(HumanBodyBones.Head).position.y;
             //0を入れると0除算になるので一応避けておく
             _timeTableGenerator.HeadHeight = Mathf.Max(headHeight, 0.1f);
             _hasModel = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
@@ -117,7 +117,7 @@ namespace Baku.VMagicMirror.IK
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
             _keyPoseCalculator.SetupAvatarBodyParameter(info.Animator);
-            var headHeight = info.Animator.GetBoneTransform(HumanBodyBones.Head).position.y;
+            var headHeight = info.AvatarBones.Head.position.y;
             //0を入れると0除算になるので一応避けておく
             _timeTableGenerator.HeadHeight = Mathf.Max(headHeight, 0.1f);
             _hasModel = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionHandIKGenerator.cs
@@ -116,7 +116,7 @@ namespace Baku.VMagicMirror.IK
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _keyPoseCalculator.SetupAvatarBodyParameter(info.Animator);
+            _keyPoseCalculator.SetupAvatarBodyParameter(info.AvatarBones);
             var headHeight = info.AvatarBones.Head.position.y;
             //0を入れると0除算になるので一応避けておく
             _timeTableGenerator.HeadHeight = Mathf.Max(headHeight, 0.1f);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionSubroutines/ClapMotionKeyPoseCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/ClapMotionSubroutines/ClapMotionKeyPoseCalculator.cs
@@ -31,31 +31,31 @@ namespace Baku.VMagicMirror.IK
         private float _clapHeight = 1f;
         private float _armLength = 0.5f;
 
-        public void SetupAvatarBodyParameter(Animator animator)
+        public void SetupAvatarBodyParameter(VRMAvatarBones avatarBones)
         {
             //左右の腕長さがあまりに違うケースも無視、難しいので
-            var leftUpperArm = animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-            var leftLowerArm = animator.GetBoneTransform(HumanBodyBones.LeftLowerArm);
-            var leftHand = animator.GetBoneTransform(HumanBodyBones.LeftHand);
+            var leftUpperArm = avatarBones.LeftUpperArm;
+            var leftLowerArm = avatarBones.LeftLowerArm;
+            var leftHand = avatarBones.LeftHand;
             var leftArmLength =
                 Vector3.Distance(leftUpperArm.position, leftLowerArm.position) +
                 Vector3.Distance(leftLowerArm.position, leftHand.position);
 
-            var rightUpperArm = animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
-            var rightLowerArm = animator.GetBoneTransform(HumanBodyBones.RightLowerArm);
-            var rightHand = animator.GetBoneTransform(HumanBodyBones.RightHand);
+            var rightUpperArm = avatarBones.RightUpperArm;
+            var rightLowerArm = avatarBones.RightLowerArm;
+            var rightHand = avatarBones.RightHand;
             var rightArmLength =
                 Vector3.Distance(rightUpperArm.position, rightLowerArm.position) +
                 Vector3.Distance(rightLowerArm.position, rightHand.position);
 
             //chestは必須ボーンではないことに注意
-            var chestBone = animator.GetBoneTransform(HumanBodyBones.Chest);
+            var chestBone = avatarBones.Chest;
             if (chestBone == null)
             {
-                chestBone = animator.GetBoneTransform(HumanBodyBones.Spine);
+                chestBone = avatarBones.Spine;
             }
             var chest = chestBone.position;
-            var head = animator.GetBoneTransform(HumanBodyBones.Head).position;
+            var head = avatarBones.Head.position;
 
             //ClapHeightは手首を持ってく位置を指定することに注意。気持ち低めを狙う。
             _clapHeight = Mathf.Lerp(chest.y, head.y, 0.4f);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -102,9 +102,9 @@ namespace Baku.VMagicMirror
 
             _vrmLoadable.VrmLoaded += info =>
             {
-                _hips = info.animator.GetBoneTransform(HumanBodyBones.Hips);
-                _leftUpperArm = info.animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-                _rightUpperArm = info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+                _hips = info.Animator.GetBoneTransform(HumanBodyBones.Hips);
+                _leftUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
+                _rightUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
                 _leftHandTarget.TargetTransform.SetParent(_hips, false);
                 _rightHandTarget.TargetTransform.SetParent(_hips, false);
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -102,9 +102,9 @@ namespace Baku.VMagicMirror
 
             _vrmLoadable.VrmLoaded += info =>
             {
-                _hips = info.Animator.GetBoneTransform(HumanBodyBones.Hips);
-                _leftUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-                _rightUpperArm = info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+                _hips = info.AvatarBones.Hips;
+                _leftUpperArm = info.AvatarBones.LeftUpperArm;
+                _rightUpperArm = info.AvatarBones.RightUpperArm;
                 _leftHandTarget.TargetTransform.SetParent(_hips, false);
                 _rightHandTarget.TargetTransform.SetParent(_hips, false);
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/FootIkSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/FootIkSetter.cs
@@ -21,8 +21,8 @@ namespace Baku.VMagicMirror.IK
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                var leftFoot = info.animator.GetBoneTransform(HumanBodyBones.LeftFoot);
-                var rightFoot = info.animator.GetBoneTransform(HumanBodyBones.RightFoot);
+                var leftFoot = info.Animator.GetBoneTransform(HumanBodyBones.LeftFoot);
+                var rightFoot = info.Animator.GetBoneTransform(HumanBodyBones.RightFoot);
                 _defaultLeftFootPosition = leftFoot.position;
                 _defaultRightFootPosition = rightFoot.position;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/FootIkSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/FootIkSetter.cs
@@ -21,8 +21,8 @@ namespace Baku.VMagicMirror.IK
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                var leftFoot = info.controlRig.GetBoneTransform(HumanBodyBones.LeftFoot);
-                var rightFoot = info.controlRig.GetBoneTransform(HumanBodyBones.RightFoot);
+                var leftFoot = info.animator.GetBoneTransform(HumanBodyBones.LeftFoot);
+                var rightFoot = info.animator.GetBoneTransform(HumanBodyBones.RightFoot);
                 _defaultLeftFootPosition = leftFoot.position;
                 _defaultRightFootPosition = rightFoot.position;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/FootIkSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/FootIkSetter.cs
@@ -21,8 +21,8 @@ namespace Baku.VMagicMirror.IK
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                var leftFoot = info.Animator.GetBoneTransform(HumanBodyBones.LeftFoot);
-                var rightFoot = info.Animator.GetBoneTransform(HumanBodyBones.RightFoot);
+                var leftFoot = info.AvatarBones.LeftFoot;
+                var rightFoot = info.AvatarBones.RightFoot;
                 _defaultLeftFootPosition = leftFoot.position;
                 _defaultRightFootPosition = rightFoot.position;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
@@ -87,9 +87,9 @@ namespace Baku.VMagicMirror.IK
             //モデルロード時、身長を参照することで「コントローラの移動オフセットはこんくらいだよね」を初期化
             vrmLoadable.VrmLoaded += info =>
             {
-                var h = info.Animator.GetBoneTransform(HumanBodyBones.Head);
-                var f = info.Animator.GetBoneTransform(HumanBodyBones.LeftFoot);
-                float height = h.position.y - f.position.y;
+                var h = info.AvatarBones.Head;
+                var f = info.AvatarBones.LeftFoot;
+                var height = h.position.y - f.position.y;
                 _posOffsetScale = Mathf.Clamp(height / ReferenceHeight, 0.1f, 5f);
             };
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
@@ -87,8 +87,8 @@ namespace Baku.VMagicMirror.IK
             //モデルロード時、身長を参照することで「コントローラの移動オフセットはこんくらいだよね」を初期化
             vrmLoadable.VrmLoaded += info =>
             {
-                var h = info.controlRig.GetBoneTransform(HumanBodyBones.Head);
-                var f = info.controlRig.GetBoneTransform(HumanBodyBones.LeftFoot);
+                var h = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                var f = info.animator.GetBoneTransform(HumanBodyBones.LeftFoot);
                 float height = h.position.y - f.position.y;
                 _posOffsetScale = Mathf.Clamp(height / ReferenceHeight, 0.1f, 5f);
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/GamepadHandIKGenerator.cs
@@ -87,8 +87,8 @@ namespace Baku.VMagicMirror.IK
             //モデルロード時、身長を参照することで「コントローラの移動オフセットはこんくらいだよね」を初期化
             vrmLoadable.VrmLoaded += info =>
             {
-                var h = info.animator.GetBoneTransform(HumanBodyBones.Head);
-                var f = info.animator.GetBoneTransform(HumanBodyBones.LeftFoot);
+                var h = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                var f = info.Animator.GetBoneTransform(HumanBodyBones.LeftFoot);
                 float height = h.position.y - f.position.y;
                 _posOffsetScale = Mathf.Clamp(height / ReferenceHeight, 0.1f, 5f);
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
@@ -60,21 +60,21 @@ namespace Baku.VMagicMirror.IK
 
         void IInitializable.Initialize()
         {
-            _vrmLoadable.VrmLoaded += info => SetupAvatar(info.Animator);
+            _vrmLoadable.VrmLoaded += info => SetupAvatar(info.AvatarBones);
             _vrmLoadable.VrmDisposing += ClearAvatarReference;
             _coroutineSource.StartCoroutine(SetHandPositionsIfHasModel());
         }
 
-        private void SetupAvatar(Animator animator)
+        private void SetupAvatar(VRMAvatarBones avatarBones)
         {
-            _hips = animator.GetBoneTransform(HumanBodyBones.Hips);
-            _rightUpperArm = animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
-            _leftUpperArm = animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
+            _hips = avatarBones.Hips;
+            _rightUpperArm = avatarBones.RightUpperArm;
+            _leftUpperArm = avatarBones.LeftUpperArm;
 
             var rightUpperArmPos = _rightUpperArm.position;
-            var rightWristPos = animator.GetBoneTransform(HumanBodyBones.RightHand).position;
+            var rightWristPos = avatarBones.RightHand.position;
             var leftUpperArmPos = _leftUpperArm.position;
-            var leftWristPos = animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
+            var leftWristPos = avatarBones.LeftHand.position;
             var hipsPos = _hips.position;
 
             _rightArmLength = Vector3.Distance(rightWristPos, rightUpperArmPos);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/HandDownIkCalculator.cs
@@ -60,7 +60,7 @@ namespace Baku.VMagicMirror.IK
 
         void IInitializable.Initialize()
         {
-            _vrmLoadable.VrmLoaded += info => SetupAvatar(info.animator);
+            _vrmLoadable.VrmLoaded += info => SetupAvatar(info.Animator);
             _vrmLoadable.VrmDisposing += ClearAvatarReference;
             _coroutineSource.StartCoroutine(SetHandPositionsIfHasModel());
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PenTabletHandIkGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PenTabletHandIkGenerator.cs
@@ -71,12 +71,12 @@ namespace Baku.VMagicMirror.IK
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var wrist = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
+                var wrist = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
                 var wristPosition = wrist.position;
-                var midProximal = info.animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal);
-                var midInter = info.animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate);
-                var littleDistal = info.animator.GetBoneTransform(HumanBodyBones.RightLittleDistal);
-                var thumbProximal = info.animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate);
+                var midProximal = info.Animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal);
+                var midInter = info.Animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate);
+                var littleDistal = info.Animator.GetBoneTransform(HumanBodyBones.RightLittleDistal);
+                var thumbProximal = info.Animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate);
                 
                 //NOTE: 人差し指の第2-第3関節の横でペンが縦に立つように調節するとこういう式になります
                 _wristToPenBasePosition = (midProximal != null && midInter != null && thumbProximal != null)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PenTabletHandIkGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PenTabletHandIkGenerator.cs
@@ -71,12 +71,12 @@ namespace Baku.VMagicMirror.IK
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var wrist = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
+                var wrist = info.AvatarBones.RightHand;
                 var wristPosition = wrist.position;
-                var midProximal = info.Animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal);
-                var midInter = info.Animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate);
-                var littleDistal = info.Animator.GetBoneTransform(HumanBodyBones.RightLittleDistal);
-                var thumbProximal = info.Animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate);
+                var midProximal = info.AvatarBones.RightMiddleProximal;
+                var midInter = info.AvatarBones.RightMiddleIntermediate;
+                var littleDistal = info.AvatarBones.RightLittleDistal;
+                var thumbProximal = info.AvatarBones.RightThumbIntermediate;
                 
                 //NOTE: 人差し指の第2-第3関節の横でペンが縦に立つように調節するとこういう式になります
                 _wristToPenBasePosition = (midProximal != null && midInter != null && thumbProximal != null)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PenTabletHandIkGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PenTabletHandIkGenerator.cs
@@ -71,12 +71,12 @@ namespace Baku.VMagicMirror.IK
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var wrist = info.controlRig.GetBoneTransform(HumanBodyBones.RightHand);
+                var wrist = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
                 var wristPosition = wrist.position;
-                var midProximal = info.controlRig.GetBoneTransform(HumanBodyBones.RightMiddleProximal);
-                var midInter = info.controlRig.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate);
-                var littleDistal = info.controlRig.GetBoneTransform(HumanBodyBones.RightLittleDistal);
-                var thumbProximal = info.controlRig.GetBoneTransform(HumanBodyBones.RightThumbIntermediate);
+                var midProximal = info.animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal);
+                var midInter = info.animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate);
+                var littleDistal = info.animator.GetBoneTransform(HumanBodyBones.RightLittleDistal);
+                var thumbProximal = info.animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate);
                 
                 //NOTE: 人差し指の第2-第3関節の横でペンが縦に立つように調節するとこういう式になります
                 _wristToPenBasePosition = (midProximal != null && midInter != null && thumbProximal != null)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PresentationHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PresentationHandIKGenerator.cs
@@ -77,10 +77,10 @@ namespace Baku.VMagicMirror.IK
                 //NOTE: Shoulderが必須ボーンでは無い事に注意
                 var bones = new List<Transform>()
                     {
-                        info.controlRig.GetBoneTransform(HumanBodyBones.RightShoulder),
-                        info.controlRig.GetBoneTransform(HumanBodyBones.RightUpperArm),
-                        info.controlRig.GetBoneTransform(HumanBodyBones.RightLowerArm),
-                        info.controlRig.GetBoneTransform(HumanBodyBones.RightHand),
+                        info.animator.GetBoneTransform(HumanBodyBones.RightShoulder),
+                        info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm),
+                        info.animator.GetBoneTransform(HumanBodyBones.RightLowerArm),
+                        info.animator.GetBoneTransform(HumanBodyBones.RightHand),
                     }
                     .Where(t => t != null)
                     .ToArray();
@@ -92,10 +92,10 @@ namespace Baku.VMagicMirror.IK
                 }
                 _lengthFromShoulderToWrist = sum;
                 
-                _head = info.controlRig.GetBoneTransform(HumanBodyBones.Head);
+                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
                 //NOTE: ここも肩ボーンはオプションなことに注意
-                _rightShoulder = info.controlRig.GetBoneTransform(HumanBodyBones.RightShoulder) ??
-                                 info.controlRig.GetBoneTransform(HumanBodyBones.RightUpperArm);
+                _rightShoulder = info.animator.GetBoneTransform(HumanBodyBones.RightShoulder) ??
+                                 info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
                 
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PresentationHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PresentationHandIKGenerator.cs
@@ -77,10 +77,10 @@ namespace Baku.VMagicMirror.IK
                 //NOTE: Shoulderが必須ボーンでは無い事に注意
                 var bones = new List<Transform>()
                     {
-                        info.Animator.GetBoneTransform(HumanBodyBones.RightShoulder),
-                        info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm),
-                        info.Animator.GetBoneTransform(HumanBodyBones.RightLowerArm),
-                        info.Animator.GetBoneTransform(HumanBodyBones.RightHand),
+                        info.AvatarBones.RightShoulder,
+                        info.AvatarBones.RightUpperArm,
+                        info.AvatarBones.RightLowerArm,
+                        info.AvatarBones.RightHand,
                     }
                     .Where(t => t != null)
                     .ToArray();
@@ -92,10 +92,10 @@ namespace Baku.VMagicMirror.IK
                 }
                 _lengthFromShoulderToWrist = sum;
                 
-                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _head = info.AvatarBones.Head;
                 //NOTE: ここも肩ボーンはオプションなことに注意
-                _rightShoulder = info.Animator.GetBoneTransform(HumanBodyBones.RightShoulder) ??
-                                 info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+                _rightShoulder = info.AvatarBones.RightShoulder ??
+                                 info.AvatarBones.RightUpperArm;
                 
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PresentationHandIKGenerator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/PresentationHandIKGenerator.cs
@@ -77,10 +77,10 @@ namespace Baku.VMagicMirror.IK
                 //NOTE: Shoulderが必須ボーンでは無い事に注意
                 var bones = new List<Transform>()
                     {
-                        info.animator.GetBoneTransform(HumanBodyBones.RightShoulder),
-                        info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm),
-                        info.animator.GetBoneTransform(HumanBodyBones.RightLowerArm),
-                        info.animator.GetBoneTransform(HumanBodyBones.RightHand),
+                        info.Animator.GetBoneTransform(HumanBodyBones.RightShoulder),
+                        info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm),
+                        info.Animator.GetBoneTransform(HumanBodyBones.RightLowerArm),
+                        info.Animator.GetBoneTransform(HumanBodyBones.RightHand),
                     }
                     .Where(t => t != null)
                     .ToArray();
@@ -92,10 +92,10 @@ namespace Baku.VMagicMirror.IK
                 }
                 _lengthFromShoulderToWrist = sum;
                 
-                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
                 //NOTE: ここも肩ボーンはオプションなことに注意
-                _rightShoulder = info.animator.GetBoneTransform(HumanBodyBones.RightShoulder) ??
-                                 info.animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+                _rightShoulder = info.Animator.GetBoneTransform(HumanBodyBones.RightShoulder) ??
+                                 info.Animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
                 
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
@@ -59,8 +59,8 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _leftLegIk = info.leftLegIk;
-            _rightLegIk = info.rightLegIk;
+            _leftLegIk = info.LeftLegIk;
+            _rightLegIk = info.RightLegIk;
             _hasModel = true;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
@@ -289,8 +289,8 @@ namespace Baku.VMagicMirror
         {
             vrmLoadable.VrmLoaded += info =>
             {
-                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
-                _neck = info.animator.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.Animator.GetBoneTransform(HumanBodyBones.Neck);
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
@@ -289,8 +289,8 @@ namespace Baku.VMagicMirror
         {
             vrmLoadable.VrmLoaded += info =>
             {
-                _head = info.Animator.GetBoneTransform(HumanBodyBones.Head);
-                _neck = info.Animator.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.AvatarBones.Head;
+                _neck = info.AvatarBones.Neck;
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/NonImageBasedMotion.cs
@@ -289,8 +289,8 @@ namespace Baku.VMagicMirror
         {
             vrmLoadable.VrmLoaded += info =>
             {
-                _head = info.controlRig.GetBoneTransform(HumanBodyBones.Head);
-                _neck = info.controlRig.GetBoneTransform(HumanBodyBones.Neck);
+                _head = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.animator.GetBoneTransform(HumanBodyBones.Neck);
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/VMCP/VMCPSender.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/VMCP/VMCPSender.cs
@@ -132,7 +132,7 @@ namespace Baku.VMagicMirror.VMCP
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _animator = info.animator;
+            _animator = info.Animator;
 
             for (var i = 0; i < (int)HumanBodyBones.LastBone; i++)
             {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/BuiltInMotionPlayer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/BuiltInMotionPlayer.cs
@@ -71,11 +71,11 @@ namespace Baku.VMagicMirror.WordToMotion
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _simpleAnimation = info.vrmRoot.gameObject.AddComponent<SimpleAnimation>();
+            _simpleAnimation = info.VrmRoot.gameObject.AddComponent<SimpleAnimation>();
             _simpleAnimation.playAutomatically = false;
             _simpleAnimation.AddState(_clipData.DefaultStandingAnimation, DefaultStateName);
             _simpleAnimation.Play(DefaultStateName);
-            _animator = info.animator;
+            _animator = info.Animator;
             _hasModel = true;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/CustomMotionPlayer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/CustomMotionPlayer.cs
@@ -83,7 +83,7 @@ namespace Baku.VMagicMirror
                 //TODO: これControlRigと相性が悪すぎるので何か考えて下さい
                 //ビルトインモーションもヤバそう
                 _humanPoseHandler = new HumanPoseHandler(info.animator.avatar, info.vrmRoot);
-                _hips = info.controlRig.GetBoneTransform(HumanBodyBones.Hips);
+                _hips = info.animator.GetBoneTransform(HumanBodyBones.Hips);
                 _originHipsPos = _hips.localPosition;
                 _originHipsRot = _hips.localRotation;
                 _playRoutine = new CustomMotionPlayRoutine(

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/CustomMotionPlayer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/CustomMotionPlayer.cs
@@ -1,5 +1,4 @@
-﻿using Baku.VMagicMirror.GameInput;
-using Baku.VMagicMirror.MotionExporter;
+﻿using Baku.VMagicMirror.MotionExporter;
 using Baku.VMagicMirror.WordToMotion;
 using R3;
 using UnityEngine;
@@ -83,7 +82,7 @@ namespace Baku.VMagicMirror
                 //TODO: これControlRigと相性が悪すぎるので何か考えて下さい
                 //ビルトインモーションもヤバそう
                 _humanPoseHandler = new HumanPoseHandler(info.Animator.avatar, info.VrmRoot);
-                _hips = info.Animator.GetBoneTransform(HumanBodyBones.Hips);
+                _hips = info.AvatarBones.Hips;
                 _originHipsPos = _hips.localPosition;
                 _originHipsRot = _hips.localRotation;
                 _playRoutine = new CustomMotionPlayRoutine(

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/CustomMotionPlayer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/CustomMotionPlayer.cs
@@ -82,8 +82,8 @@ namespace Baku.VMagicMirror
             {
                 //TODO: これControlRigと相性が悪すぎるので何か考えて下さい
                 //ビルトインモーションもヤバそう
-                _humanPoseHandler = new HumanPoseHandler(info.animator.avatar, info.vrmRoot);
-                _hips = info.animator.GetBoneTransform(HumanBodyBones.Hips);
+                _humanPoseHandler = new HumanPoseHandler(info.Animator.avatar, info.VrmRoot);
+                _hips = info.Animator.GetBoneTransform(HumanBodyBones.Hips);
                 _originHipsPos = _hips.localPosition;
                 _originHipsRot = _hips.localRotation;
                 _playRoutine = new CustomMotionPlayRoutine(

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/ExtraBlendShapeClipNamesSender.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/ExtraBlendShapeClipNamesSender.cs
@@ -14,7 +14,7 @@ namespace Baku.VMagicMirror
             vrmLoadable.VrmLoaded += info =>
             {
                 var names = string.Join(",",
-                    info.instance.Vrm.Expression.LoadExpressionMap()
+                    info.Instance.Vrm.Expression.LoadExpressionMap()
                         .Keys
                         .Where(k => k.Preset == ExpressionPreset.custom)
                         .Select(k => k.Name)              

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/TaskBasedIkWeightFader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/TaskBasedIkWeightFader.cs
@@ -147,11 +147,11 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _ik = info.fbbIk;
-            _leftLegIk = info.leftLegIk;
-            _rightLegIk = info.rightLegIk;
-            _leftTwistRelaxer = info.leftArmTwistRelaxer;
-            _rightTwistRelaxer = info.rightArmTwistRelaxer;
+            _ik = info.FbbIk;
+            _leftLegIk = info.LeftLegIk;
+            _rightLegIk = info.RightLegIk;
+            _leftTwistRelaxer = info.LeftArmTwistRelaxer;
+            _rightTwistRelaxer = info.RightArmTwistRelaxer;
 
             var s = _ik.solver;
             _originWeight = new Weights(
@@ -167,7 +167,7 @@ namespace Baku.VMagicMirror
                 LeftTwistRelaxerWeight,
                 RightTwistRelaxerWeight
             );
-            _simpleAnimation = info.vrmRoot.GetComponent<SimpleAnimation>();
+            _simpleAnimation = info.VrmRoot.GetComponent<SimpleAnimation>();
             if (!_simpleAnimationActive)
             {
                 _simpleAnimation.enabled = false;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/V2/WordToMotionRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/V2/WordToMotionRunner.cs
@@ -59,7 +59,7 @@ namespace Baku.VMagicMirror.WordToMotion
             _vrmLoadable.VrmDisposing -= OnVrmUnloaded;
         }
 
-        private void OnVrmLoaded(VrmLoadedInfo info) => _blendShape.Initialize(info.instance.Vrm.Expression);
+        private void OnVrmLoaded(VrmLoadedInfo info) => _blendShape.Initialize(info.Instance.Vrm.Expression);
 
         private void OnVrmUnloaded() => _blendShape.DisposeProxy();
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/VrmaMotionSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/WordToMotion/VrmaMotionSetter.cs
@@ -98,8 +98,8 @@ namespace Baku.VMagicMirror
         
         private void OnModelLoaded(VrmLoadedInfo info)
         {
-            _runtime = info.instance.Runtime;
-            var animator = info.animator;
+            _runtime = info.Instance.Runtime;
+            var animator = info.Animator;
             for (var i = 0; i < BoneMax; i++)
             {
                 var bone = (HumanBodyBones)i;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/ApiImplements/AvatarPoseApiImplement.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/ApiImplements/AvatarPoseApiImplement.cs
@@ -137,7 +137,7 @@ namespace Baku.VMagicMirror.Buddy
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _animator = info.animator;
+            _animator = info.Animator;
             for (var i = 0; i < (int)HumanBodyBones.LastBone - 1; i++)
             {
                 var bone = (HumanBodyBones)i;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyLayoutUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyLayoutUpdater.cs
@@ -104,11 +104,11 @@ namespace Baku.VMagicMirror.Buddy
                     continue;
                 }
 
-                var parentBone = info.animator.GetBoneTransformAscending(layout.ParentBone);
+                var parentBone = info.Animator.GetBoneTransformAscending(layout.ParentBone);
                 transform.SetParent(parentBone);
             }
 
-            _animator = info.animator;
+            _animator = info.Animator;
             _hasModel = true;
         }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyTransform3DBoneAttachUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Buddy/Updater/BuddyTransform3DBoneAttachUpdater.cs
@@ -52,7 +52,7 @@ namespace Baku.VMagicMirror.Buddy
 
         private void OnModelLoaded(VrmLoadedInfo info)
         {
-            _animator = info.animator;
+            _animator = info.Animator;
             _hasModel = true;
             UpdateAllParentBone();
         }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using UnityEngine;
-using UniVRM10;
 using Zenject;
 
 namespace Baku.VMagicMirror
@@ -27,10 +26,10 @@ namespace Baku.VMagicMirror
         private void ReadParams(VrmLoadedInfo info)
         {
             var leftHand = info.AvatarBones.LeftHand.position;
-            var leftPalm = GetLeftHandRaycastReferencePosition(info.Animator, leftHand);
+            var leftPalm = GetLeftHandRaycastReferencePosition(info.AvatarBones, leftHand);
             
             var rightHand = info.AvatarBones.RightHand.position;
-            var rightPalm = GetRightHandRaycastReferencePosition(info.Animator, rightHand);
+            var rightPalm = GetRightHandRaycastReferencePosition(info.AvatarBones, rightHand);
             
             var height = info.AvatarBones.Head.position.y;
 
@@ -67,21 +66,21 @@ namespace Baku.VMagicMirror
         }
 
         //手首ボーンと中指付け根ボーンの中点を取得します。この点はレイキャストの基準として使われます。
-        private Vector3 GetLeftHandRaycastReferencePosition(Animator animator, Vector3 leftHandPosition)
+        private Vector3 GetLeftHandRaycastReferencePosition(VRMAvatarBones avatarBones, Vector3 leftHandPosition)
         {
-            var finger = animator.GetBoneTransform(HumanBodyBones.LeftMiddleIntermediate);
-            if (finger != null)
-            {
-                return finger.position;
-            }
-            
-            finger = animator.GetBoneTransform(HumanBodyBones.LeftMiddleDistal);
+            var finger = avatarBones.LeftMiddleIntermediate;
             if (finger != null)
             {
                 return finger.position;
             }
 
-            finger = animator.GetBoneTransform(HumanBodyBones.LeftMiddleProximal);
+            finger = avatarBones.LeftMiddleDistal;
+            if (finger != null)
+            {
+                return finger.position;
+            }
+
+            finger = avatarBones.LeftMiddleProximal;
             if (finger != null)
             {
                 return finger.position;
@@ -91,21 +90,21 @@ namespace Baku.VMagicMirror
             return leftHandPosition;
         }
 
-        private Vector3 GetRightHandRaycastReferencePosition(Animator animator, Vector3 rightHandPosition)
+        private Vector3 GetRightHandRaycastReferencePosition(VRMAvatarBones avatarBones, Vector3 rightHandPosition)
         {
-            var finger = animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate);
+            var finger = avatarBones.RightMiddleIntermediate;
             if (finger != null)
             {
                 return finger.position;
             }
             
-            finger = animator.GetBoneTransform(HumanBodyBones.RightMiddleDistal);
+            finger = avatarBones.RightMiddleDistal;
             if (finger != null)
             {
                 return finger.position;
             }
 
-            finger = animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal);
+            finger = avatarBones.RightMiddleProximal;
             if (finger != null)
             {
                 return finger.position;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
@@ -26,13 +26,13 @@ namespace Baku.VMagicMirror
 
         private void ReadParams(VrmLoadedInfo info)
         {
-            var leftHand = info.controlRig.GetBoneTransform(HumanBodyBones.LeftHand).position;
-            var leftPalm = GetLeftHandRaycastReferencePosition(info.controlRig, leftHand);
+            var leftHand = info.animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
+            var leftPalm = GetLeftHandRaycastReferencePosition(info.animator, leftHand);
             
-            var rightHand = info.controlRig.GetBoneTransform(HumanBodyBones.RightHand).position;
-            var rightPalm = GetRightHandRaycastReferencePosition(info.controlRig, rightHand);
+            var rightHand = info.animator.GetBoneTransform(HumanBodyBones.RightHand).position;
+            var rightPalm = GetRightHandRaycastReferencePosition(info.animator, rightHand);
             
-            var height = info.controlRig.GetBoneTransform(HumanBodyBones.Head).position.y;
+            var height = info.animator.GetBoneTransform(HumanBodyBones.Head).position.y;
 
             using (var colliders = AvatarColliders.LoadMeshColliders(
                 info.vrmRoot.gameObject, colliderPrefab, transform))

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
@@ -26,13 +26,13 @@ namespace Baku.VMagicMirror
 
         private void ReadParams(VrmLoadedInfo info)
         {
-            var leftHand = info.Animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
+            var leftHand = info.AvatarBones.LeftHand.position;
             var leftPalm = GetLeftHandRaycastReferencePosition(info.Animator, leftHand);
             
-            var rightHand = info.Animator.GetBoneTransform(HumanBodyBones.RightHand).position;
+            var rightHand = info.AvatarBones.RightHand.position;
             var rightPalm = GetRightHandRaycastReferencePosition(info.Animator, rightHand);
             
-            var height = info.Animator.GetBoneTransform(HumanBodyBones.Head).position.y;
+            var height = info.AvatarBones.Head.position.y;
 
             using (var colliders = AvatarColliders.LoadMeshColliders(
                 info.VrmRoot.gameObject, colliderPrefab, transform))

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ColliderBasedFitting/ColliderBasedAvatarParamLoader.cs
@@ -26,16 +26,16 @@ namespace Baku.VMagicMirror
 
         private void ReadParams(VrmLoadedInfo info)
         {
-            var leftHand = info.animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
-            var leftPalm = GetLeftHandRaycastReferencePosition(info.animator, leftHand);
+            var leftHand = info.Animator.GetBoneTransform(HumanBodyBones.LeftHand).position;
+            var leftPalm = GetLeftHandRaycastReferencePosition(info.Animator, leftHand);
             
-            var rightHand = info.animator.GetBoneTransform(HumanBodyBones.RightHand).position;
-            var rightPalm = GetRightHandRaycastReferencePosition(info.animator, rightHand);
+            var rightHand = info.Animator.GetBoneTransform(HumanBodyBones.RightHand).position;
+            var rightPalm = GetRightHandRaycastReferencePosition(info.Animator, rightHand);
             
-            var height = info.animator.GetBoneTransform(HumanBodyBones.Head).position.y;
+            var height = info.Animator.GetBoneTransform(HumanBodyBones.Head).position.y;
 
             using (var colliders = AvatarColliders.LoadMeshColliders(
-                info.vrmRoot.gameObject, colliderPrefab, transform))
+                info.VrmRoot.gameObject, colliderPrefab, transform))
             {
                 var results = new RaycastHit[colliders.Colliders.Length];
                 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/AvatarMaskTextureController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/AvatarMaskTextureController.cs
@@ -43,7 +43,7 @@ namespace Baku.VMagicMirror
 
         public override void Initialize()
         {
-            _vrmLoadable.VrmLoaded += info => AvatarRenderers = info.renderers ?? Array.Empty<Renderer>();
+            _vrmLoadable.VrmLoaded += info => AvatarRenderers = info.Renderers ?? Array.Empty<Renderer>();
             _vrmLoadable.VrmDisposing += () => AvatarRenderers = Array.Empty<Renderer>();
 
             _useAvatarDropShadow

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
@@ -32,7 +32,7 @@ namespace Baku.VMagicMirror
         {
             vrmLoadable.VrmLoaded += info =>
             {
-                _headPosition = info.Animator.GetBoneTransform(HumanBodyBones.Head).position;
+                _headPosition = info.AvatarBones.Head.position;
                 _hasModel = true;
                 AdjustCameraPoseOnVrmLoaded();
                 ApplyReferenceHeadPositionIfAvailable();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/CameraAndLights/CameraController.cs
@@ -32,7 +32,7 @@ namespace Baku.VMagicMirror
         {
             vrmLoadable.VrmLoaded += info =>
             {
-                _headPosition = info.animator.GetBoneTransform(HumanBodyBones.Head).position;
+                _headPosition = info.Animator.GetBoneTransform(HumanBodyBones.Head).position;
                 _hasModel = true;
                 AdjustCameraPoseOnVrmLoaded();
                 ApplyReferenceHeadPositionIfAvailable();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
@@ -53,9 +53,9 @@ namespace Baku.VMagicMirror
             
             vrmLoadable.VrmLoaded += info =>
             {
-                _rightWrist = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
-                _rightIndexProximal = info.Animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate);
-                _rightThumbIntermediate = info.Animator.GetBoneTransform(HumanBodyBones.RightThumbDistal);
+                _rightWrist = info.AvatarBones.RightHand;
+                _rightIndexProximal = info.AvatarBones.RightIndexIntermediate;
+                _rightThumbIntermediate = info.AvatarBones.RightThumbDistal;
                 _hasValidFinger = (_rightIndexProximal != null && _rightThumbIntermediate != null);
                 _hasModel = true;
                 _sender.SendCommand(MessageFactory.SetModelDoesNotSupportPen(!_hasValidFinger));

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
@@ -53,9 +53,9 @@ namespace Baku.VMagicMirror
             
             vrmLoadable.VrmLoaded += info =>
             {
-                _rightWrist = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
-                _rightIndexProximal = info.animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate);
-                _rightThumbIntermediate = info.animator.GetBoneTransform(HumanBodyBones.RightThumbDistal);
+                _rightWrist = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
+                _rightIndexProximal = info.Animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate);
+                _rightThumbIntermediate = info.Animator.GetBoneTransform(HumanBodyBones.RightThumbDistal);
                 _hasValidFinger = (_rightIndexProximal != null && _rightThumbIntermediate != null);
                 _hasModel = true;
                 _sender.SendCommand(MessageFactory.SetModelDoesNotSupportPen(!_hasValidFinger));

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenController.cs
@@ -53,9 +53,9 @@ namespace Baku.VMagicMirror
             
             vrmLoadable.VrmLoaded += info =>
             {
-                _rightWrist = info.controlRig.GetBoneTransform(HumanBodyBones.RightHand);
-                _rightIndexProximal = info.controlRig.GetBoneTransform(HumanBodyBones.RightIndexIntermediate);
-                _rightThumbIntermediate = info.controlRig.GetBoneTransform(HumanBodyBones.RightThumbDistal);
+                _rightWrist = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
+                _rightIndexProximal = info.animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate);
+                _rightThumbIntermediate = info.animator.GetBoneTransform(HumanBodyBones.RightThumbDistal);
                 _hasValidFinger = (_rightIndexProximal != null && _rightThumbIntermediate != null);
                 _hasModel = true;
                 _sender.SendCommand(MessageFactory.SetModelDoesNotSupportPen(!_hasValidFinger));

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/Wind/VRMWind.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/Wind/VRMWind.cs
@@ -197,9 +197,9 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _modelRoot = info.vrmRoot;
-            _instance = info.instance;
-            _springBones = info.instance.SpringBone.Springs.SelectMany(spring => spring.Joints).ToArray();
+            _modelRoot = info.VrmRoot;
+            _instance = info.Instance;
+            _springBones = info.Instance.SpringBone.Springs.SelectMany(spring => spring.Joints).ToArray();
             _originalGravityDirections = _springBones.Select(b => b.m_gravityDir).ToArray();
             _originalGravityFactors = _springBones.Select(b => b.m_gravityPower).ToArray();
             _hasModel = true;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/AvatarBoneInitialLocalOffsets.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/AvatarBoneInitialLocalOffsets.cs
@@ -39,7 +39,7 @@ namespace Baku.VMagicMirror.VMCP
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                SetLocalOffsets(info.animator);
+                SetLocalOffsets(info.Animator);
                 _hasModel.Value = true;
             };
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBasedFingerSetter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPBasedFingerSetter.cs
@@ -22,7 +22,7 @@ namespace Baku.VMagicMirror.VMCP
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                var a = info.animator;
+                var a = info.Animator;
                 for (var i = FingerIndexStart; i < FingerIndexEnd; i++)
                 {
                     var bone = (HumanBodyBones)i;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPHeadPose.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPHeadPose.cs
@@ -35,8 +35,8 @@ namespace Baku.VMagicMirror.VMCP
             {
                 //NOTE: ロードした瞬間はyaw=0で立ってるはず
                 _defaultHeadOffsetOnHips =
-                    info.animator.GetBoneTransform(HumanBodyBones.Head).position -
-                    info.animator.GetBoneTransform(HumanBodyBones.Hips).position;
+                    info.Animator.GetBoneTransform(HumanBodyBones.Head).position -
+                    info.Animator.GetBoneTransform(HumanBodyBones.Hips).position;
                 _hasModel = true;
             };
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPHeadPose.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPHeadPose.cs
@@ -34,9 +34,7 @@ namespace Baku.VMagicMirror.VMCP
             _vrmLoadable.VrmLoaded += info =>
             {
                 //NOTE: ロードした瞬間はyaw=0で立ってるはず
-                _defaultHeadOffsetOnHips =
-                    info.Animator.GetBoneTransform(HumanBodyBones.Head).position -
-                    info.Animator.GetBoneTransform(HumanBodyBones.Hips).position;
+                _defaultHeadOffsetOnHips = info.AvatarBones.Head.position - info.AvatarBones.Hips.position;
                 _hasModel = true;
             };
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPNaiveBoneTransfer.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/VMCP/VMCPNaiveBoneTransfer.cs
@@ -129,7 +129,7 @@ namespace Baku.VMagicMirror.VMCP
             
             _vrmLoadable.VrmLoaded += info =>
             {
-                var a = info.animator;
+                var a = info.Animator;
                 
                 foreach (var bone in UpperBodyBones)
                 {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/AvatarControl/MediaPipeFaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/AvatarControl/MediaPipeFaceAttitudeController.cs
@@ -67,7 +67,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var animator = info.animator;
+                var animator = info.Animator;
                 _neck = animator.GetBoneTransform(HumanBodyBones.Neck);
                 _head = animator.GetBoneTransform(HumanBodyBones.Head);
                 _hasNeck = _neck != null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/AvatarControl/MediaPipeFaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/AvatarControl/MediaPipeFaceAttitudeController.cs
@@ -67,9 +67,8 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var animator = info.Animator;
-                _neck = animator.GetBoneTransform(HumanBodyBones.Neck);
-                _head = animator.GetBoneTransform(HumanBodyBones.Head);
+                _neck = info.AvatarBones.Neck;
+                _head = info.AvatarBones.Head;
                 _hasNeck = _neck != null;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/AvatarControl/MediaPipeFaceAttitudeController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/AvatarControl/MediaPipeFaceAttitudeController.cs
@@ -67,7 +67,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
 
             vrmLoadable.VrmLoaded += info =>
             {
-                var animator = info.controlRig;
+                var animator = info.animator;
                 _neck = animator.GetBoneTransform(HumanBodyBones.Neck);
                 _head = animator.GetBoneTransform(HumanBodyBones.Head);
                 _hasNeck = _neck != null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/BodyScaleCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/BodyScaleCalculator.cs
@@ -43,12 +43,12 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             
             var rootPosition = target.transform.position;
 
-            var head = target.GetBoneTransform(HumanBodyBones.Head);
-            var leftUpperArm = target.GetBoneTransform(HumanBodyBones.LeftUpperArm);
-            var leftWrist = target.GetBoneTransform(HumanBodyBones.LeftHand);
+            var head = info.AvatarBones.Head;
+            var leftUpperArm = info.AvatarBones.LeftUpperArm;
+            var leftWrist = info.AvatarBones.LeftHand;
             
-            var rightUpperArm = target.GetBoneTransform(HumanBodyBones.RightUpperArm);
-            var rightWrist = target.GetBoneTransform(HumanBodyBones.RightHand);
+            var rightUpperArm = info.AvatarBones.RightUpperArm;
+            var rightWrist = info.AvatarBones.RightHand;
 
             var bodyHeight = head.position.y - rootPosition.y;
             var leftArmLength = Vector3.Distance(leftWrist.position, leftUpperArm.position);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/BodyScaleCalculator.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/BodyScaleCalculator.cs
@@ -39,7 +39,7 @@ namespace Baku.VMagicMirror.MediaPipeTracker
         // TODO: 体型計算してるコード、統一したい…
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            var target = info.animator;
+            var target = info.Animator;
             
             var rootPosition = target.transform.position;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
@@ -108,9 +108,9 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             _vrmLoadable.VrmLoaded += info =>
             {
                 _vrmRoot = info.VrmRoot;
-                _leftHandBone = info.Animator.GetBoneTransform(HumanBodyBones.LeftHand);
-                _rightHandBone = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
-                _headBone = info.Animator.GetBoneTransform(HumanBodyBones.Head);
+                _leftHandBone = info.AvatarBones.LeftHand;
+                _rightHandBone = info.AvatarBones.RightHand;
+                _headBone = info.AvatarBones.Head;
                 _initialHeadPosition = _headBone.position;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHand.cs
@@ -107,10 +107,10 @@ namespace Baku.VMagicMirror.MediaPipeTracker
             
             _vrmLoadable.VrmLoaded += info =>
             {
-                _vrmRoot = info.vrmRoot;
-                _leftHandBone = info.animator.GetBoneTransform(HumanBodyBones.LeftHand);
-                _rightHandBone = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
-                _headBone = info.animator.GetBoneTransform(HumanBodyBones.Head);
+                _vrmRoot = info.VrmRoot;
+                _leftHandBone = info.Animator.GetBoneTransform(HumanBodyBones.LeftHand);
+                _rightHandBone = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
+                _headBone = info.Animator.GetBoneTransform(HumanBodyBones.Head);
                 _initialHeadPosition = _headBone.position;
                 _hasModel = true;
             };

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
@@ -45,8 +45,8 @@ namespace Baku.VMagicMirror
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                _leftHandBone = info.animator.GetBoneTransform(HumanBodyBones.LeftHand);
-                _rightHandBone = info.animator.GetBoneTransform(HumanBodyBones.RightHand);
+                _leftHandBone = info.Animator.GetBoneTransform(HumanBodyBones.LeftHand);
+                _rightHandBone = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
                 _hasModel = true;
             };
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/MediaPipeTracker/MediaPipeHandLocalRotLimiter.cs
@@ -45,8 +45,8 @@ namespace Baku.VMagicMirror
         {
             _vrmLoadable.VrmLoaded += info =>
             {
-                _leftHandBone = info.Animator.GetBoneTransform(HumanBodyBones.LeftHand);
-                _rightHandBone = info.Animator.GetBoneTransform(HumanBodyBones.RightHand);
+                _leftHandBone = info.AvatarBones.LeftHand;
+                _rightHandBone = info.AvatarBones.RightHand;
                 _hasModel = true;
             };
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/SettingAdjust/SettingAutoAdjuster.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/SettingAdjust/SettingAutoAdjuster.cs
@@ -34,7 +34,7 @@ namespace Baku.VMagicMirror
                 _ => AutoAdjust()
                 );
 
-            vrmLoadable.PreVrmLoaded += info => _vrmRoot = info.vrmRoot;
+            vrmLoadable.PreVrmLoaded += info => _vrmRoot = info.VrmRoot;
             vrmLoadable.VrmDisposing += () => _vrmRoot = null;
         }
         

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/SettingAdjust/SettingAutoAdjuster.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/SettingAdjust/SettingAutoAdjuster.cs
@@ -34,15 +34,24 @@ namespace Baku.VMagicMirror
                 _ => AutoAdjust()
                 );
 
-            vrmLoadable.PreVrmLoaded += info => _vrmRoot = info.VrmRoot;
-            vrmLoadable.VrmDisposing += () => _vrmRoot = null;
+            vrmLoadable.PreVrmLoaded += info =>
+            {
+                _avatarBones = info.AvatarBones;
+                _hasModel = true;
+            };
+            vrmLoadable.VrmDisposing += () =>
+            {
+                _hasModel = false;
+                _avatarBones = null;
+            };
         }
         
         private readonly IMessageSender _sender;
         private readonly IMessageDispatcher _dispatcher;
         private readonly Transform _mainCam;
-        
-        private Transform _vrmRoot = null;
+
+        private bool _hasModel;
+        private VRMAvatarBones _avatarBones;
 
         /// <summary>
         /// VRMがロード済みの状態で呼び出すと、
@@ -52,28 +61,23 @@ namespace Baku.VMagicMirror
         /// <returns></returns>
         public DeviceLayoutAutoAdjustParameters GetDeviceLayoutParameters()
         {
-            if (_vrmRoot == null)
+            if (!_hasModel)
             {
                 return null;
             }
             
             var result = new DeviceLayoutAutoAdjustParameters();
 
-            var animator = _vrmRoot.GetComponent<Animator>();
-            
-            Transform chest = animator.GetBoneTransform(HumanBodyBones.Chest);
+            var chest = _avatarBones.Chest;
             result.HeightFactor = 
                 (chest != null) ? 
                     chest.position.y / ReferenceChestHeight :
-                    animator.GetBoneTransform(HumanBodyBones.Spine).position.y / ReferenceSpineHeight;
+                    _avatarBones.Spine.position.y / ReferenceSpineHeight;
             
-            var upperArm = animator.GetBoneTransform(HumanBodyBones.RightUpperArm).position;
-            var lowerArm = animator.GetBoneTransform(HumanBodyBones.RightLowerArm).position;
-            var wrist = animator.GetBoneTransform(HumanBodyBones.RightHand).position;
-            float armLength =
-                Vector3.Distance(upperArm, lowerArm) +
-                Vector3.Distance(lowerArm, wrist);
-
+            var upperArm = _avatarBones.RightUpperArm.position;
+            var lowerArm = _avatarBones.RightLowerArm.position;
+            var wrist = _avatarBones.RightHand.position;
+            var armLength = Vector3.Distance(upperArm, lowerArm) + Vector3.Distance(lowerArm, wrist);
             result.ArmLengthFactor = armLength / ReferenceArmLength;
 
             return result;
@@ -81,7 +85,10 @@ namespace Baku.VMagicMirror
     
         private void AutoAdjust()
         {
-            if (_vrmRoot == null) { return; }
+            if (!_hasModel)
+            {
+                return;
+            }
 
             var parameters = new AutoAdjustParameters();
             //やること: 
@@ -91,11 +98,10 @@ namespace Baku.VMagicMirror
 
             try
             {
-                var animator = _vrmRoot.GetComponent<Animator>();
-
-                //3つのサブルーチンではanimatorのHumanoidBoneを使うが、部位である程度分けられるので分けておく
-                SetHandSizeRelatedParameters(animator, parameters);
-                AdjustCameraPosition(animator);
+                // Adjust対象の部位である程度分けられるので分けておく
+                SetHandSizeRelatedParameters(_avatarBones, parameters);
+                AdjustCameraPosition(_avatarBones);
+                
                 //デバイスレイアウト調整: これは別途調整が終わるとメッセージが飛ぶ
                 _dispatcher.ReceiveCommand(new ReceivedCommand(
                     MessageSerializer.None((ushort) VmmCommands.ResetDeviceLayout)
@@ -110,22 +116,22 @@ namespace Baku.VMagicMirror
             }
         }
         
-        private void AdjustCameraPosition(Animator animator)
+        private void AdjustCameraPosition(VRMAvatarBones avatarBones)
         {
-            var head = animator.GetBoneTransform(HumanBodyBones.Neck);
+            var head = avatarBones.Head;
             _mainCam.position = new Vector3(0, head.position.y, 1.3f);
             _mainCam.rotation = Quaternion.Euler(0, 180, 0);
         }
         
-        private void SetHandSizeRelatedParameters(Animator animator, AutoAdjustParameters parameters)
+        private void SetHandSizeRelatedParameters(VRMAvatarBones avatarBones, AutoAdjustParameters parameters)
         {
-            var tip = animator.GetBoneTransform(HumanBodyBones.RightMiddleDistal);
+            var tip = avatarBones.RightMiddleDistal;
             if (tip == null) { return; }
 
-            var wrist = animator.GetBoneTransform(HumanBodyBones.RightHand);
-            float distance = Vector3.Distance(tip.position, wrist.position);
+            var wrist = avatarBones.RightHand;
+            var distance = Vector3.Distance(tip.position, wrist.position);
 
-            float factor = distance / ReferenceHandLength;
+            var factor = distance / ReferenceHandLength;
             parameters.LengthFromWristToTip = (int)(parameters.LengthFromWristToTip * factor);
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10InstanceUpdater.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10InstanceUpdater.cs
@@ -25,7 +25,7 @@ namespace Baku.VMagicMirror
         {
             vrmLoadable.VrmLoaded += info =>
             {
-                _instance = info.instance;
+                _instance = info.Instance;
                 _hasModel = true;
             };
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -337,27 +337,6 @@ namespace Baku.VMagicMirror
             PostVrmLoaded?.Invoke(info);
         }
 
-        private static Dictionary<HumanBodyBones, Transform> GetBones(Animator animator)
-        {
-            var result = new Dictionary<HumanBodyBones, Transform>();
-            for (var i = (int)HumanBodyBones.Hips; i < (int)HumanBodyBones.LastBone; i++)
-            {
-                var bone = (HumanBodyBones)i;
-                if (bone == HumanBodyBones.Jaw)
-                {
-                    continue;
-                }
-
-                var boneTransform = animator.GetBoneTransform(bone);
-                if (boneTransform != null)
-                {
-                    result[bone] = boneTransform;
-                }
-            }
-
-            return result;
-        }
-        
         private void HandleLoadError(Exception ex)
         {
             string logContent =

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -331,7 +331,7 @@ namespace Baku.VMagicMirror
                 leftArmTwistRelaxer = setupResult.LeftArmTwistRelaxer,
                 rightArmTwistRelaxer = setupResult.RightArmTwistRelaxer,
                 renderers = renderers,
-                bones = GetBones(animator),
+                AvatarBones = new VRMAvatarBones(animator),
             };
             
             PreVrmLoaded?.Invoke(info);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -318,22 +318,20 @@ namespace Baku.VMagicMirror
                 // NOTE: セルフシャドウを一応切っているが、URPではこのプロパティにあまり意味はない
                 r.receiveShadows = false;
             }
-            
-            var info = new VrmLoadedInfo()
-            {
-                modelVersion = _modelVersion.Value,
-                vrmRoot = go.transform,
-                animator = animator,
-                instance = instance,
-                fbbIk = setupResult.Fbbik,
-                leftLegIk = setupResult.LeftLegIk,
-                rightLegIk = setupResult.RightLegIk,
-                leftArmTwistRelaxer = setupResult.LeftArmTwistRelaxer,
-                rightArmTwistRelaxer = setupResult.RightArmTwistRelaxer,
-                renderers = renderers,
-                AvatarBones = new VRMAvatarBones(animator),
-            };
-            
+
+            var info = new VrmLoadedInfo(
+                _modelVersion.Value,
+                go.transform,
+                animator,
+                instance,
+                setupResult.Fbbik,
+                setupResult.LeftLegIk,
+                setupResult.RightLegIk,
+                setupResult.LeftArmTwistRelaxer,
+                setupResult.RightArmTwistRelaxer,
+                renderers
+            );
+
             PreVrmLoaded?.Invoke(info);
             VrmLoaded?.Invoke(info);
             PostVrmLoaded?.Invoke(info);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Baku.VMagicMirror.IK;
@@ -314,7 +315,7 @@ namespace Baku.VMagicMirror
             var renderers = go.GetComponentsInChildren<Renderer>();
             foreach (var r in renderers)
             {
-                //セルフシャドウは明示的に切る: ちょっとでも軽量化したい
+                // NOTE: セルフシャドウを一応切っているが、URPではこのプロパティにあまり意味はない
                 r.receiveShadows = false;
             }
             
@@ -329,9 +330,8 @@ namespace Baku.VMagicMirror
                 rightLegIk = setupResult.RightLegIk,
                 leftArmTwistRelaxer = setupResult.LeftArmTwistRelaxer,
                 rightArmTwistRelaxer = setupResult.RightArmTwistRelaxer,
-                //NOTE: このbsがないことでエラーが起こるのはイベント購読側が悪い。
-                //blendShape = blendShapeProxy,
                 renderers = renderers,
+                bones = GetBones(animator),
             };
             
             PreVrmLoaded?.Invoke(info);
@@ -339,6 +339,27 @@ namespace Baku.VMagicMirror
             PostVrmLoaded?.Invoke(info);
         }
 
+        private static Dictionary<HumanBodyBones, Transform> GetBones(Animator animator)
+        {
+            var result = new Dictionary<HumanBodyBones, Transform>();
+            for (var i = (int)HumanBodyBones.Hips; i < (int)HumanBodyBones.LastBone; i++)
+            {
+                var bone = (HumanBodyBones)i;
+                if (bone == HumanBodyBones.Jaw)
+                {
+                    continue;
+                }
+
+                var boneTransform = animator.GetBoneTransform(bone);
+                if (boneTransform != null)
+                {
+                    result[bone] = boneTransform;
+                }
+            }
+
+            return result;
+        }
+        
         private void HandleLoadError(Exception ex)
         {
             string logContent =

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRM10LoadController.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Baku.VMagicMirror.IK;
 using Cysharp.Threading.Tasks;
-using RootMotion.FinalIK;
 using UniGLTF.Extensions.VRMC_vrm;
 using R3;
 using UnityEngine;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMAvatarBones.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMAvatarBones.cs
@@ -1,0 +1,123 @@
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    /// <summary>
+    /// アバターのHumanoidボーンをプロパティベースで取得出来るクラス。
+    /// 必須ボーンじゃないプロパティはnullになる可能性があることに注意。
+    /// </summary>
+    public sealed class VRMAvatarBones
+    {
+        public VRMAvatarBones(Animator animator)
+        {
+            Hips = animator.GetBoneTransform(HumanBodyBones.Hips);
+            LeftUpperLeg = animator.GetBoneTransform(HumanBodyBones.LeftUpperLeg);
+            RightUpperLeg = animator.GetBoneTransform(HumanBodyBones.RightUpperLeg);
+            LeftLowerLeg = animator.GetBoneTransform(HumanBodyBones.LeftLowerLeg);
+            RightLowerLeg = animator.GetBoneTransform(HumanBodyBones.RightLowerLeg);
+            LeftFoot = animator.GetBoneTransform(HumanBodyBones.LeftFoot);
+            RightFoot = animator.GetBoneTransform(HumanBodyBones.RightFoot);
+            Spine = animator.GetBoneTransform(HumanBodyBones.Spine);
+            Chest = animator.GetBoneTransform(HumanBodyBones.Chest);
+            Neck = animator.GetBoneTransform(HumanBodyBones.Neck);
+            Head = animator.GetBoneTransform(HumanBodyBones.Head);
+            LeftShoulder = animator.GetBoneTransform(HumanBodyBones.LeftShoulder);
+            RightShoulder = animator.GetBoneTransform(HumanBodyBones.RightShoulder);
+            LeftUpperArm = animator.GetBoneTransform(HumanBodyBones.LeftUpperArm);
+            RightUpperArm = animator.GetBoneTransform(HumanBodyBones.RightUpperArm);
+            LeftLowerArm = animator.GetBoneTransform(HumanBodyBones.LeftLowerArm);
+            RightLowerArm = animator.GetBoneTransform(HumanBodyBones.RightLowerArm);
+            LeftHand = animator.GetBoneTransform(HumanBodyBones.LeftHand);
+            RightHand = animator.GetBoneTransform(HumanBodyBones.RightHand);
+            LeftToes = animator.GetBoneTransform(HumanBodyBones.LeftToes);
+            RightToes = animator.GetBoneTransform(HumanBodyBones.RightToes);
+            LeftEye = animator.GetBoneTransform(HumanBodyBones.LeftEye);
+            RightEye = animator.GetBoneTransform(HumanBodyBones.RightEye);
+            LeftThumbProximal = animator.GetBoneTransform(HumanBodyBones.LeftThumbProximal);
+            LeftThumbIntermediate = animator.GetBoneTransform(HumanBodyBones.LeftThumbIntermediate);
+            LeftThumbDistal = animator.GetBoneTransform(HumanBodyBones.LeftThumbDistal);
+            LeftIndexProximal = animator.GetBoneTransform(HumanBodyBones.LeftIndexProximal);
+            LeftIndexIntermediate = animator.GetBoneTransform(HumanBodyBones.LeftIndexIntermediate);
+            LeftIndexDistal = animator.GetBoneTransform(HumanBodyBones.LeftIndexDistal);
+            LeftMiddleProximal = animator.GetBoneTransform(HumanBodyBones.LeftMiddleProximal);
+            LeftMiddleIntermediate = animator.GetBoneTransform(HumanBodyBones.LeftMiddleIntermediate);
+            LeftMiddleDistal = animator.GetBoneTransform(HumanBodyBones.LeftMiddleDistal);
+            LeftRingProximal = animator.GetBoneTransform(HumanBodyBones.LeftRingProximal);
+            LeftRingIntermediate = animator.GetBoneTransform(HumanBodyBones.LeftRingIntermediate);
+            LeftRingDistal = animator.GetBoneTransform(HumanBodyBones.LeftRingDistal);
+            LeftLittleProximal = animator.GetBoneTransform(HumanBodyBones.LeftLittleProximal);
+            LeftLittleIntermediate = animator.GetBoneTransform(HumanBodyBones.LeftLittleIntermediate);
+            LeftLittleDistal = animator.GetBoneTransform(HumanBodyBones.LeftLittleDistal);
+            RightThumbProximal = animator.GetBoneTransform(HumanBodyBones.RightThumbProximal);
+            RightThumbIntermediate = animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate);
+            RightThumbDistal = animator.GetBoneTransform(HumanBodyBones.RightThumbDistal);
+            RightIndexProximal = animator.GetBoneTransform(HumanBodyBones.RightIndexProximal);
+            RightIndexIntermediate = animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate);
+            RightIndexDistal = animator.GetBoneTransform(HumanBodyBones.RightIndexDistal);
+            RightMiddleProximal = animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal);
+            RightMiddleIntermediate = animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate);
+            RightMiddleDistal = animator.GetBoneTransform(HumanBodyBones.RightMiddleDistal);
+            RightRingProximal = animator.GetBoneTransform(HumanBodyBones.RightRingProximal);
+            RightRingIntermediate = animator.GetBoneTransform(HumanBodyBones.RightRingIntermediate);
+            RightRingDistal = animator.GetBoneTransform(HumanBodyBones.RightRingDistal);
+            RightLittleProximal = animator.GetBoneTransform(HumanBodyBones.RightLittleProximal);
+            RightLittleIntermediate = animator.GetBoneTransform(HumanBodyBones.RightLittleIntermediate);
+            RightLittleDistal = animator.GetBoneTransform(HumanBodyBones.RightLittleDistal);
+            UpperChest = animator.GetBoneTransform(HumanBodyBones.UpperChest);
+        }
+        public Transform Hips { get; }
+        public Transform LeftUpperLeg { get; }
+        public Transform RightUpperLeg { get; }
+        public Transform LeftLowerLeg { get; }
+        public Transform RightLowerLeg { get; }
+        public Transform LeftFoot { get; }
+        public Transform RightFoot { get; }
+        public Transform Spine { get; }
+        public Transform Chest { get; }
+        public Transform Neck { get; }
+        public Transform Head { get; }
+        public Transform LeftShoulder { get; }
+        public Transform RightShoulder { get; }
+        public Transform LeftUpperArm { get; }
+        public Transform RightUpperArm { get; }
+        public Transform LeftLowerArm { get; }
+        public Transform RightLowerArm { get; }
+        public Transform LeftHand { get; }
+        public Transform RightHand { get; }
+        public Transform LeftToes { get; }
+        public Transform RightToes { get; }
+        public Transform LeftEye { get; }
+        public Transform RightEye { get; }
+        public Transform LeftThumbProximal { get; }
+        public Transform LeftThumbIntermediate { get; }
+        public Transform LeftThumbDistal { get; }
+        public Transform LeftIndexProximal { get; }
+        public Transform LeftIndexIntermediate { get; }
+        public Transform LeftIndexDistal { get; }
+        public Transform LeftMiddleProximal { get; }
+        public Transform LeftMiddleIntermediate { get; }
+        public Transform LeftMiddleDistal { get; }
+        public Transform LeftRingProximal { get; }
+        public Transform LeftRingIntermediate { get; }
+        public Transform LeftRingDistal { get; }
+        public Transform LeftLittleProximal { get; }
+        public Transform LeftLittleIntermediate { get; }
+        public Transform LeftLittleDistal { get; }
+        public Transform RightThumbProximal { get; }
+        public Transform RightThumbIntermediate { get; }
+        public Transform RightThumbDistal { get; }
+        public Transform RightIndexProximal { get; }
+        public Transform RightIndexIntermediate { get; }
+        public Transform RightIndexDistal { get; }
+        public Transform RightMiddleProximal { get; }
+        public Transform RightMiddleIntermediate { get; }
+        public Transform RightMiddleDistal { get; }
+        public Transform RightRingProximal { get; }
+        public Transform RightRingIntermediate { get; }
+        public Transform RightRingDistal { get; }
+        public Transform RightLittleProximal { get; }
+        public Transform RightLittleIntermediate { get; }
+        public Transform RightLittleDistal { get; }
+        public Transform UpperChest { get; }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMAvatarBones.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMAvatarBones.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b21f3efd603eab489ed016f2c9124d6

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using RootMotion.FinalIK;
+﻿using RootMotion.FinalIK;
 using UnityEngine;
 using UniVRM10;
 
@@ -17,37 +16,34 @@ namespace Baku.VMagicMirror
             LimbIK rightLegIk,
             TwistRelaxer leftArmTwistRelaxer,
             TwistRelaxer rightArmTwistRelaxer,
-            Renderer[] renderers,
-            VRMAvatarBones avatarBones
+            Renderer[] renderers
         )
         {
-            this.modelVersion = modelVersion;
-            this.vrmRoot = vrmRoot;
-            this.animator = animator;
-            this.instance = instance;
-            this.fbbIk = fbbIk;
-            this.leftLegIk = leftLegIk;
-            this.rightLegIk = rightLegIk;
-            this.leftArmTwistRelaxer = leftArmTwistRelaxer;
-            this.rightArmTwistRelaxer = rightArmTwistRelaxer;
-            this.renderers = renderers;
-            AvatarBones = avatarBones;
+            ModelVersion = modelVersion;
+            VrmRoot = vrmRoot;
+            Animator = animator;
+            Instance = instance;
+            FbbIk = fbbIk;
+            LeftLegIk = leftLegIk;
+            RightLegIk = rightLegIk;
+            LeftArmTwistRelaxer = leftArmTwistRelaxer;
+            RightArmTwistRelaxer = rightArmTwistRelaxer;
+            Renderers = renderers;
+            AvatarBones = new VRMAvatarBones(animator);
         }
         
-        public Vrm10RuntimeExpression RuntimeFacialExpression => instance.Runtime.Expression;
-        public CurrentModelVersion modelVersion { get; }
-        public Transform vrmRoot { get; }
-        public Animator animator { get; }
-        //NOTE: property細分化してトレーサビリティとってもいいかも、ExpressionSettingsとか
-        public Vrm10Instance instance { get; }
-        public FullBodyBipedIK fbbIk { get; }
-        public LimbIK leftLegIk { get; }
-        public LimbIK rightLegIk { get; }
-
-        public TwistRelaxer leftArmTwistRelaxer { get; }
-        public TwistRelaxer rightArmTwistRelaxer { get; }
-        public Renderer[] renderers { get; }
-
+        public Vrm10RuntimeExpression RuntimeFacialExpression => Instance.Runtime.Expression;
+        public CurrentModelVersion ModelVersion { get; }
+        public Transform VrmRoot { get; }
+        public Animator Animator { get; }
         public VRMAvatarBones AvatarBones { get; }
+        //NOTE: property細分化してトレーサビリティとってもいいかも、ExpressionSettingsとか
+        public Vrm10Instance Instance { get; }
+        public FullBodyBipedIK FbbIk { get; }
+        public LimbIK LeftLegIk { get; }
+        public LimbIK RightLegIk { get; }
+        public TwistRelaxer LeftArmTwistRelaxer { get; }
+        public TwistRelaxer RightArmTwistRelaxer { get; }
+        public Renderer[] Renderers { get; }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using RootMotion.FinalIK;
 using UnityEngine;
 using UniVRM10;
@@ -24,5 +25,7 @@ namespace Baku.VMagicMirror
         //[Obsolete("use `FacialExpression` instead")]
         //public VRMBlendShapeProxy blendShape;
         public Renderer[] renderers;
+
+        public Dictionary<HumanBodyBones, Transform> bones;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
@@ -11,7 +11,6 @@ namespace Baku.VMagicMirror
         public CurrentModelVersion modelVersion;
         public Transform vrmRoot;
         public Animator animator;
-        public Animator controlRig => animator;
         //NOTE: property細分化してトレーサビリティとってもいいかも、ExpressionSettingsとか
         public Vrm10Instance instance;
         public Vrm10RuntimeExpression RuntimeFacialExpression => instance.Runtime.Expression;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
@@ -32,7 +32,6 @@ namespace Baku.VMagicMirror
             AvatarBones = new VRMAvatarBones(animator);
         }
         
-        public Vrm10RuntimeExpression RuntimeFacialExpression => Instance.Runtime.Expression;
         public CurrentModelVersion ModelVersion { get; }
         public Transform VrmRoot { get; }
         public Animator Animator { get; }
@@ -45,5 +44,7 @@ namespace Baku.VMagicMirror
         public TwistRelaxer LeftArmTwistRelaxer { get; }
         public TwistRelaxer RightArmTwistRelaxer { get; }
         public Renderer[] Renderers { get; }
+
+        public Vrm10RuntimeExpression RuntimeFacialExpression => Instance.Runtime.Expression;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
@@ -5,26 +5,49 @@ using UniVRM10;
 
 namespace Baku.VMagicMirror
 {
-    [Serializable]
-    public struct VrmLoadedInfo
+    public readonly struct VrmLoadedInfo
     {
-        public CurrentModelVersion modelVersion;
-        public Transform vrmRoot;
-        public Animator animator;
-        //NOTE: property細分化してトレーサビリティとってもいいかも、ExpressionSettingsとか
-        public Vrm10Instance instance;
-        public Vrm10RuntimeExpression RuntimeFacialExpression => instance.Runtime.Expression;
-        public FullBodyBipedIK fbbIk;
-        public LimbIK leftLegIk;
-        public LimbIK rightLegIk;
-
-        public TwistRelaxer leftArmTwistRelaxer;
-        public TwistRelaxer rightArmTwistRelaxer;
+        public VrmLoadedInfo(
+            CurrentModelVersion modelVersion,
+            Transform vrmRoot,
+            Animator animator,
+            Vrm10Instance instance,
+            FullBodyBipedIK fbbIk,
+            LimbIK leftLegIk,
+            LimbIK rightLegIk,
+            TwistRelaxer leftArmTwistRelaxer,
+            TwistRelaxer rightArmTwistRelaxer,
+            Renderer[] renderers,
+            VRMAvatarBones avatarBones
+        )
+        {
+            this.modelVersion = modelVersion;
+            this.vrmRoot = vrmRoot;
+            this.animator = animator;
+            this.instance = instance;
+            this.fbbIk = fbbIk;
+            this.leftLegIk = leftLegIk;
+            this.rightLegIk = rightLegIk;
+            this.leftArmTwistRelaxer = leftArmTwistRelaxer;
+            this.rightArmTwistRelaxer = rightArmTwistRelaxer;
+            this.renderers = renderers;
+            AvatarBones = avatarBones;
+        }
         
-        //[Obsolete("use `FacialExpression` instead")]
-        //public VRMBlendShapeProxy blendShape;
-        public Renderer[] renderers;
+        public Vrm10RuntimeExpression RuntimeFacialExpression => instance.Runtime.Expression;
+        public CurrentModelVersion modelVersion { get; }
+        public Transform vrmRoot { get; }
+        public Animator animator { get; }
+        //NOTE: property細分化してトレーサビリティとってもいいかも、ExpressionSettingsとか
+        public Vrm10Instance instance { get; }
+        public FullBodyBipedIK fbbIk { get; }
+        public LimbIK leftLegIk { get; }
+        public LimbIK rightLegIk { get; }
 
-        public VRMAvatarBones AvatarBones;
+        public TwistRelaxer leftArmTwistRelaxer { get; }
+        public TwistRelaxer rightArmTwistRelaxer { get; }
+        public Renderer[] renderers { get; }
+
+        public VRMAvatarBones AvatarBones { get; }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/ModelLoad/VRMLoad/VRMLoadedInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using RootMotion.FinalIK;
 using UnityEngine;
 using UniVRM10;
@@ -26,6 +25,6 @@ namespace Baku.VMagicMirror
         //public VRMBlendShapeProxy blendShape;
         public Renderer[] renderers;
 
-        public Dictionary<HumanBodyBones, Transform> bones;
+        public VRMAvatarBones AvatarBones;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/NativeWindow/WindowStyleController.cs
@@ -146,7 +146,7 @@ namespace Baku.VMagicMirror
                 }
             });
             
-            vrmLoadable.PreVrmLoaded += info => _renderers = info.renderers;
+            vrmLoadable.PreVrmLoaded += info => _renderers = info.Renderers;
             vrmLoadable.VrmDisposing += () => _renderers = Array.Empty<Renderer>();
         }
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Refactor (e.g. typo fix)

## What the PR does

- `VRMLoadedInfo` の内訳を生成処理を見直す
- `animator.GetBoneTransform` の呼び出しコードのうち取得ボーンが決め打ちのものは都度取らないでいいように改修
- その他trivialなリファクタが出来るとこは適用

追加でやれそうだがやってないこと

- `_hasModel` + `_xBone` みたいなフィールドを持つこと自体の廃止
    - たぶん出来るが、観点がだいぶ変わるのでPRを分ける

## How to confirm

- [ ] Editor + WPF Buildで基本動作が変わっていないこと