### PR TITLE
ギズモのオブジェクトについてフリーレイアウトじゃない間は表示しないようにする

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Accessory/AccessoryItem.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Accessory/AccessoryItem.prefab
@@ -23,12 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8732823132694731684}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8732823133005825145}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8732823132901955326
 GameObject:
@@ -55,12 +56,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8732823132901955326}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.15, y: 0.15, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8732823133005825145}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!33 &8732823132901955314
 MeshFilter:
@@ -81,11 +83,17 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -107,9 +115,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8732823133005825094
 GameObject:
@@ -121,7 +131,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8732823133005825145}
   - component: {fileID: 8732823133005825144}
-  - component: {fileID: 8732823133005825147}
   m_Layer: 0
   m_Name: AccessoryItem
   m_TagString: Untagged
@@ -136,14 +145,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8732823133005825094}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8732823132901955313}
   - {fileID: 8732823132694731687}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8732823133005825144
 MonoBehaviour:
@@ -159,21 +169,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   imageRenderer: {fileID: 8732823132901955315}
   modelParent: {fileID: 8732823132694731687}
-  transformControl: {fileID: 8732823133005825147}
---- !u!114 &8732823133005825147
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8732823133005825094}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/IK Targets.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/AvatarControl/IK Targets.prefab
@@ -23,12 +23,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 37285441425996432}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 303702880965066003}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1009745881067083495
 GameObject:
@@ -39,7 +40,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 303702880965066003}
-  - component: {fileID: 5879314087457661568}
   - component: {fileID: 3998390410401398488}
   m_Layer: 0
   m_Name: LeftHandDownPoseTarget
@@ -55,31 +55,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1009745881067083495}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.2, y: 1, z: 0.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3629974543253739537}
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5879314087457661568
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1009745881067083495}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &3998390410401398488
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -93,7 +77,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   handImageGizmo: {fileID: 37285441425996432}
-  transformControl: {fileID: 5879314087457661568}
 --- !u!1 &2026465566758330141
 GameObject:
   m_ObjectHideFlags: 0
@@ -117,12 +100,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2026465566758330141}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.1, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6179000882620333244
 GameObject:
@@ -133,7 +117,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4519926354364588533}
-  - component: {fileID: 6424636812989539530}
   - component: {fileID: 1771108102995737168}
   m_Layer: 0
   m_Name: RightHandDownPoseTarget
@@ -149,31 +132,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6179000882620333244}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.2, y: 1, z: 0.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3736577104217786014}
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6424636812989539530
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6179000882620333244}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &1771108102995737168
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -187,7 +154,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   handImageGizmo: {fileID: 8523932535829481958}
-  transformControl: {fileID: 6424636812989539530}
 --- !u!1 &6437777465248540157
 GameObject:
   m_ObjectHideFlags: 0
@@ -211,12 +177,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6437777465248540157}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.1, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7220499516820559162
 GameObject:
@@ -241,12 +208,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7220499516820559162}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.8, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7220499517351026419
 GameObject:
@@ -273,9 +241,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7220499517351026419}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7220499516820559165}
   - {fileID: 7220499518389840108}
@@ -287,7 +257,6 @@ Transform:
   - {fileID: 4519926354364588533}
   - {fileID: 303702880965066003}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5762340297962685063
 MonoBehaviour:
@@ -346,12 +315,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7220499517585180709}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.2, y: 1, z: 0.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7220499518389840109
 GameObject:
@@ -376,12 +346,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7220499518389840109}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.2, y: 1, z: 0.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7220499518504390856
 GameObject:
@@ -406,12 +377,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7220499518504390856}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.5, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7220499518765536736
 GameObject:
@@ -436,12 +408,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7220499518765536736}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.2, y: 1, z: 0.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7220499517351026418}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8523932535829481958
 GameObject:
@@ -466,10 +439,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8523932535829481958}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4519926354364588533}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/ArcadeStick.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/ArcadeStick.prefab
@@ -91,6 +91,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -112,9 +117,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &6637181315389140622
 MonoBehaviour:
@@ -205,6 +212,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -226,9 +238,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &1298392476832728951
 MonoBehaviour:
@@ -543,6 +557,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -564,9 +583,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &5686501444301236346
 MonoBehaviour:
@@ -609,7 +630,6 @@ GameObject:
   - component: {fileID: 1929893641757598267}
   - component: {fileID: 6167114964147250039}
   - component: {fileID: 5697564078635650873}
-  - component: {fileID: 7297205259961872122}
   - component: {fileID: 4470397378458318839}
   - component: {fileID: 7745898941940334511}
   - component: {fileID: 8083138301532420417}
@@ -671,7 +691,6 @@ MonoBehaviour:
   handTiltDeg: 15
   basePosition: {x: 0, y: 0.93, z: 0.3}
   baseRotation: {x: -20, y: 0, z: 0}
-  transformControl: {fileID: 7297205259961872122}
 --- !u!114 &5697564078635650873
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -684,23 +703,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 55cd3c12a99482a44b8beed7dd18c5f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &7297205259961872122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1929893641757598266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &4470397378458318839
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -746,6 +748,7 @@ MonoBehaviour:
   _monoInstallers:
   - {fileID: 7745898941940334511}
   _installerPrefabs: []
+  _findSiblingMonoInstallers: 0
   _autoRun: 1
   _kernel: {fileID: 0}
 --- !u!1 &1929893642170050632
@@ -807,6 +810,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -828,9 +836,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &5390053601945650630
 MonoBehaviour:
@@ -921,6 +931,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -942,9 +957,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &7531484246715446212
 MonoBehaviour:
@@ -1035,6 +1052,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1056,9 +1078,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &2918992650328940474
 MonoBehaviour:
@@ -1149,6 +1173,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1170,9 +1199,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &3406479640668980037
 MonoBehaviour:
@@ -1263,6 +1294,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1284,9 +1320,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &4117753365661144237
 MonoBehaviour:
@@ -1377,6 +1415,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -1398,9 +1441,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &4926468303222890704
 MonoBehaviour:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/CarHandle.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/CarHandle.prefab
@@ -59,6 +59,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -80,9 +85,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &8941411347322145325
 MonoBehaviour:
@@ -126,7 +133,6 @@ GameObject:
   - component: {fileID: 1795383079595422825}
   - component: {fileID: 2065479404992935130}
   - component: {fileID: 4230855241644607740}
-  - component: {fileID: 21559323284940690}
   - component: {fileID: 627030824324925011}
   - component: {fileID: 7400727536925904230}
   - component: {fileID: 5887662914163986934}
@@ -209,7 +215,6 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  transformControl: {fileID: 21559323284940690}
 --- !u!114 &4230855241644607740
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -222,23 +227,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0764e93bf2166748a4c5cc646bb3d40, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &21559323284940690
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2457249424336435430}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &627030824324925011
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -271,6 +259,7 @@ MonoBehaviour:
   _monoInstallers:
   - {fileID: 5887662914163986934}
   _installerPrefabs: []
+  _findSiblingMonoInstallers: 0
   _autoRun: 1
   _kernel: {fileID: 0}
 --- !u!114 &5887662914163986934
@@ -345,6 +334,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -366,9 +360,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &8763232601968147042
 MonoBehaviour:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/GamePad.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/GamePad.prefab
@@ -76,7 +76,6 @@ GameObject:
   - component: {fileID: 5253142755745637109}
   - component: {fileID: 2197838250286941368}
   - component: {fileID: 9160035658810551669}
-  - component: {fileID: 6460605521299412919}
   - component: {fileID: 5626418132133974600}
   - component: {fileID: 3938523069641137890}
   - component: {fileID: 4019206306232422492}
@@ -120,6 +119,7 @@ MonoBehaviour:
   _monoInstallers:
   - {fileID: 4019206306232422492}
   _installerPrefabs: []
+  _findSiblingMonoInstallers: 0
   _autoRun: 1
   _kernel: {fileID: 0}
 --- !u!114 &9160035658810551669
@@ -144,25 +144,7 @@ MonoBehaviour:
   baseRotation: {x: -15, y: 0, z: 0}
   baseScale: 0.8
   bodyRenderer: {fileID: 2569459266424081521}
-  transformControl: {fileID: 6460605521299412919}
   modelScaleTarget: {fileID: 3335174451244510248}
---- !u!114 &6460605521299412919
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5253142755745637110}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &5626418132133974600
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -410,7 +392,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -7511558181221131132, guid: 0c17954af6b183e40a098f208aaa4fbe,
         type: 3}
-      propertyPath: m_Materials.Array.data[0]
+      propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: ae5b4c35aa6275f43831630af1d4e5ea, type: 2}
     - target: {fileID: -5754084199372789682, guid: 0c17954af6b183e40a098f208aaa4fbe,

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/Keyboard.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/Keyboard.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 1224206899735044980}
   - component: {fileID: 1224206899735044981}
   - component: {fileID: 1224206899735044971}
-  - component: {fileID: 7959860528724925214}
   - component: {fileID: 3905114142533524313}
   - component: {fileID: 8336005670953532689}
   - component: {fileID: 7421822548321400570}
@@ -66,6 +65,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -87,9 +91,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &1224206899735044971
 MonoBehaviour:
@@ -130,24 +136,6 @@ MonoBehaviour:
   - 4
   - 3
   - 3
-  transformControl: {fileID: 7959860528724925214}
---- !u!114 &7959860528724925214
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1224206899735044969}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &3905114142533524313
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -224,6 +212,7 @@ MonoBehaviour:
   _monoInstallers:
   - {fileID: 3367904344915396024}
   _installerPrefabs: []
+  _findSiblingMonoInstallers: 0
   _autoRun: 1
   _kernel: {fileID: 0}
 --- !u!114 &3367904344915396024
@@ -299,6 +288,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -320,9 +314,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &7101327344086615180
 MonoBehaviour:

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/MidiController.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/MidiController.prefab
@@ -14,7 +14,6 @@ GameObject:
   - component: {fileID: 2586501903739760161}
   - component: {fileID: 4156540200492103377}
   - component: {fileID: 1188981740233513778}
-  - component: {fileID: 435494030810225623}
   - component: {fileID: 3297202513737065057}
   - component: {fileID: 7281621472733091659}
   m_Layer: 0
@@ -31,12 +30,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4038568870611727366}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6837477534495436142
 MeshFilter:
@@ -57,11 +57,17 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -83,9 +89,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &2586501903739760161
 MonoBehaviour:
@@ -124,7 +132,6 @@ MonoBehaviour:
   initPos: {x: 0, y: 0.85, z: 0.3}
   initRot: {x: 0, y: 0, z: 0}
   initScale: {x: 0.35, y: 0.35, z: 0.35}
-  _transformControl: {fileID: 435494030810225623}
 --- !u!114 &1188981740233513778
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -137,23 +144,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b6424102d6128eb4fb79da7e55b4ac60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &435494030810225623
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4038568870611727366}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &3297202513737065057
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/PenTablet.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/PenTablet.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 8074230364789003340}
   - component: {fileID: 7229973214667890943}
   - component: {fileID: 2328085201131745261}
-  - component: {fileID: 8783273216763519342}
   - component: {fileID: 2191938032076595646}
   - component: {fileID: 6206299127056181281}
   - component: {fileID: 4026868618588972530}
@@ -66,6 +65,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -87,9 +91,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &7229973214667890943
 MonoBehaviour:
@@ -103,7 +109,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: edad0c30ff88f594e9a27a39d073fe04, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  transformControl: {fileID: 8783273216763519342}
   basePosition: {x: 0.2, y: 1, z: 0.35}
   baseRotation: {x: 30, y: 25, z: 0}
   baseScale: {x: 0.2, y: 0.15, z: 1}
@@ -119,23 +124,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 44704bcb8c152ba4b9a166ccc1f08801, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &8783273216763519342
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8074230364789003343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &2191938032076595646
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -219,6 +207,7 @@ MonoBehaviour:
   _monoInstallers:
   - {fileID: 5713233431942751890}
   _installerPrefabs: []
+  _findSiblingMonoInstallers: 0
   _autoRun: 1
   _kernel: {fileID: 0}
 --- !u!114 &5713233431942751890

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/TouchPad.prefab
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Prefabs/Devices/TouchPad.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 8074230364789003339}
   - component: {fileID: 8074230364789003340}
   - component: {fileID: 8074230364789003341}
-  - component: {fileID: 8783273216763519342}
   - component: {fileID: 2191938032076595646}
   - component: {fileID: 6206299127056181281}
   - component: {fileID: 5176997793618571541}
@@ -65,6 +64,11 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -86,9 +90,11 @@ MeshRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &8074230364789003341
 MonoBehaviour:
@@ -102,24 +108,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a9f0f1f180ccd042b4da57caba696d9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  transformControl: {fileID: 8783273216763519342}
---- !u!114 &8783273216763519342
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8074230364789003343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: acc6365877f8440a2933de30abb074cf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  global: 0
-  useDistance: 1
-  distance: 12
-  xyPlaneMode: 0
-  gizmoRenderer: {fileID: 0}
 --- !u!114 &2191938032076595646
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -207,5 +195,6 @@ MonoBehaviour:
   _monoInstallers:
   - {fileID: 2247828533555177146}
   _installerPrefabs: []
+  _findSiblingMonoInstallers: 0
   _autoRun: 1
   _kernel: {fileID: 0}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItem.cs
@@ -22,7 +22,6 @@ namespace Baku.VMagicMirror
         
         [SerializeField] private Renderer imageRenderer;
         [SerializeField] private Transform modelParent;
-        [SerializeField] private TransformControl transformControl;
         
         public AccessoryItemLayout ItemLayout { get; private set; }
         public string FileId => _file?.FileId ?? "";
@@ -30,6 +29,8 @@ namespace Baku.VMagicMirror
         private AccessoryFile _file = null;
         private IAccessoryFileActions _fileActions = null;
         private Camera _cam = null;
+        private RuntimeTransformControlFactory _transformControlFactory = null;
+        private RuntimeTransformControlHandle _transformControl = null;
 
         private VRMAvatarBones _avatarBones;
         private readonly Dictionary<AccessoryAttachTarget, Transform> _attachBones = new();
@@ -158,10 +159,12 @@ namespace Baku.VMagicMirror
         /// </summary>
         /// <param name="cam"></param>
         /// <param name="file"></param>
-        public void Initialize(Camera cam, AccessoryFile file)
+        public void Initialize(Camera cam, AccessoryFile file, RuntimeTransformControlFactory transformControlFactory)
         {
             _cam = cam;
             _file = file;
+            _transformControlFactory = transformControlFactory;
+            _transformControlFactory.DisableExisting(transform);
 
             SetVisibility(false);
         }
@@ -169,6 +172,7 @@ namespace Baku.VMagicMirror
         //ファイル等から動的ロードしたものも含めて、アクセサリのリソースを解放し、ゲームオブジェクトを破棄します。
         public void Dispose()
         {
+            ReleaseTransformControl();
             _fileActions?.Dispose();
             Destroy(gameObject);
         }
@@ -204,11 +208,6 @@ namespace Baku.VMagicMirror
             _fileActions?.SetClampEndEnable(false);
         }
 
-        private void Start()
-        {
-            transformControl.DragEnded += UpdateLayout;
-        }
-
         private void Update()
         {
             if (ShouldBeVisible)
@@ -230,9 +229,9 @@ namespace Baku.VMagicMirror
         private void LateUpdate()
         {
             UpdateIfBillboard();
-            if (ShouldAdjustBillboard)
+            if (ShouldAdjustBillboard && _transformControl?.Control != null)
             {
-                transformControl.RequestUpdateGizmo();
+                _transformControl.Control.RequestUpdateGizmo();
             }
         }
 
@@ -241,10 +240,7 @@ namespace Baku.VMagicMirror
             _blinkCts.Cancel();
             _blinkCts.Dispose();
 
-            if (transformControl != null)
-            {
-                transformControl.DragEnded -= UpdateLayout;
-            }
+            ReleaseTransformControl();
         }
 
         private void InitializeImage(AccessoryFile file)
@@ -296,7 +292,7 @@ namespace Baku.VMagicMirror
             {
                 imageRenderer.gameObject.SetActive(false);
                 modelParent.gameObject.SetActive(false);
-                transformControl.mode = TransformControl.TransformMode.None;
+                ReleaseTransformControl();
                 return;
             }
 
@@ -342,8 +338,7 @@ namespace Baku.VMagicMirror
                 ItemLayout.UseBillboardMode = false;
             }
             //ビルボードモードではLateUpdateでアイテムを動かすときがGizmoの更新タイミングになるので、手動更新にする
-            transformControl.AutoUpdateGizmo = !ItemLayout.UseBillboardMode;
-            transformControl.XyPlaneMode = ItemLayout.UseBillboardMode;
+            ApplyTransformControlSettings();
             
             SetVisibility(ShouldBeVisible);
             
@@ -431,7 +426,7 @@ namespace Baku.VMagicMirror
             transform.SetParent(null);
             _avatarBones = null;
             _attachBones.Clear();
-            transformControl.mode = TransformControl.TransformMode.None;
+            ReleaseTransformControl();
             SetVisibility(false);
         }
 
@@ -441,21 +436,22 @@ namespace Baku.VMagicMirror
         /// <param name="request"></param>
         public void ControlItemTransform(TransformControlRequest request)
         {
-            if (_avatarBones == null && ItemLayout == null)
+            if (_avatarBones == null || ItemLayout == null)
             {
                 return;
             }
 
-            transformControl.global = request.WorldCoordinate;
             //NOTE: 表情やモーションに付随して一瞬表示されるような状態に対しては位置編集UIは出さない
             var visible = ItemLayout.IsVisible;
-            transformControl.mode = visible ? request.Mode : TransformControl.TransformMode.None;
-
             if (!visible)
             {
+                ReleaseTransformControl();
                 return;
             }
 
+            var transformControl = EnsureTransformControl();
+            transformControl.global = request.WorldCoordinate;
+            transformControl.mode = request.Mode;
             transformControl.Control();
 
             //スケールについては1軸だけいじったとき、残りの2軸を追従させる
@@ -486,7 +482,7 @@ namespace Baku.VMagicMirror
         /// <summary> フリーレイアウトモードを終了するとき呼び出すことで、TransformControlを非表示にします。 </summary>
         public void EndControlItemTransform()
         {
-            transformControl.mode = TransformControl.TransformMode.None;
+            ReleaseTransformControl();
         }
         
         //Unity上でTransformControlによって改変したPosition/Rotation/Scaleがある場合に呼び出すことで、layoutを更新します。
@@ -593,7 +589,7 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            if (transformControl.IsDragging)
+            if (_transformControl?.Control != null && _transformControl.Control.IsDragging)
             {
                 //NOTE: ここをガードすると一時的にrotationとかz軸方向の移動がヘンになる事があるが、それは許容する
                 return;
@@ -644,6 +640,44 @@ namespace Baku.VMagicMirror
                 camTransform.rotation *
                 //NOTE: 180度ひっくり返すのは、カメラに対して正面向きにする必要があるため
                 Quaternion.Euler(0, 180, ItemLayout.Rotation.z);
+        }
+
+        private TransformControl EnsureTransformControl()
+        {
+            if (_transformControl?.Control != null)
+            {
+                return _transformControl.Control;
+            }
+
+            _transformControl = _transformControlFactory.Create(transform);
+            _transformControl.Control.DragEnded += UpdateLayout;
+            ApplyTransformControlSettings();
+            return _transformControl.Control;
+        }
+
+        private void ReleaseTransformControl()
+        {
+            if (_transformControl?.Control == null)
+            {
+                _transformControl = null;
+                return;
+            }
+
+            _transformControl.Control.DragEnded -= UpdateLayout;
+            _transformControl.Dispose();
+            _transformControl = null;
+        }
+
+        private void ApplyTransformControlSettings()
+        {
+            if (_transformControl?.Control == null || ItemLayout == null)
+            {
+                return;
+            }
+
+            //ビルボードモードではLateUpdateでアイテムを動かすときがGizmoの更新タイミングになるので、手動更新にする
+            _transformControl.Control.AutoUpdateGizmo = !ItemLayout.UseBillboardMode;
+            _transformControl.Control.XyPlaneMode = ItemLayout.UseBillboardMode;
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Accessory/AccessoryItemController.cs
@@ -23,6 +23,7 @@ namespace Baku.VMagicMirror
         [SerializeField] private AccessoryItem itemPrefab = null;
 
         private Camera _cam;
+        private RuntimeTransformControlFactory _transformControlFactory;
         private IMessageSender _sender;
         private readonly List<AccessoryItem> _items = new List<AccessoryItem>();
         private IDisposable _layoutSender = null;
@@ -35,6 +36,7 @@ namespace Baku.VMagicMirror
             IVRMLoadable vrmLoader,
             IMessageReceiver receiver,
             IMessageSender sender, 
+            RuntimeTransformControlFactory transformControlFactory,
             FaceSwitchUpdater faceSwitchUpdater,
             DeviceTransformController deviceTransformController,
             WordToMotionAccessoryRequest accessoryRequest,
@@ -43,6 +45,7 @@ namespace Baku.VMagicMirror
             )
         {
             _cam = cam;
+            _transformControlFactory = transformControlFactory;
             _sender = sender;
 
             vrmLoader.VrmLoaded += info =>
@@ -170,7 +173,7 @@ namespace Baku.VMagicMirror
             foreach (var file in files)
             {
                 var item = Instantiate(itemPrefab);
-                item.Initialize(_cam, file);
+                item.Initialize(_cam, file, _transformControlFactory);
                 item.FirstEnabled += OnItemFirstEnabled;
                 if (_hasModel)
                 {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/CustomizableHandIkTarget.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/CustomizableHandIkTarget.cs
@@ -1,4 +1,3 @@
-using mattatz.TransformControl;
 using UnityEngine;
 
 namespace Baku.VMagicMirror.IK
@@ -6,10 +5,8 @@ namespace Baku.VMagicMirror.IK
     public class CustomizableHandIkTarget : MonoBehaviour
     {
         [SerializeField] private GameObject handImageGizmo;
-        [SerializeField] private TransformControl transformControl;
 
         public void SetGizmoImageActiveness(bool active) => handImageGizmo.SetActive(active);
-        public TransformControl TransformControl => transformControl;
         public Transform TargetTransform => transform;
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/IK/CustomizedDownHandIk.cs
@@ -19,23 +19,26 @@ namespace Baku.VMagicMirror
 
         private readonly HandDownIkCalculator _handDownIkCalculator;
         private readonly DeviceTransformController _deviceTransformController;
+        private readonly RuntimeTransformControlFactory _transformControlFactory;
         private readonly IMessageReceiver _receiver;
         private readonly IMessageSender _sender;
         private readonly IVRMLoadable _vrmLoadable;
         private readonly ICoroutineSource _coroutineSource;
         private readonly BodyMotionModeController _bodyMotionModeController;
 
-        private readonly ReactiveProperty<bool> _enableAlwaysHandDownMode = new ReactiveProperty<bool>(false);
-        private readonly ReactiveProperty<bool> _enableFreeLayoutMode = new ReactiveProperty<bool>(false);
-        private readonly ReactiveProperty<bool> _enableCustomHandDownPose = new ReactiveProperty<bool>(false);
+        private readonly ReactiveProperty<bool> _enableAlwaysHandDownMode = new(false);
+        private readonly ReactiveProperty<bool> _enableFreeLayoutMode = new(false);
+        private readonly ReactiveProperty<bool> _enableCustomHandDownPose = new(false);
         public ReadOnlyReactiveProperty<bool> EnableCustomHandDownPose => _enableCustomHandDownPose;
 
-        private readonly IKDataRecord _leftHand = new IKDataRecord();
+        private readonly IKDataRecord _leftHand = new();
         public IIKData LeftHand => _leftHand;
-        private readonly IKDataRecord _rightHand = new IKDataRecord();
+        private readonly IKDataRecord _rightHand = new();
         public IIKData RightHand => _rightHand;
 
-        private readonly ReactiveProperty<bool> _showGizmo = new ReactiveProperty<bool>(false);
+        private readonly ReactiveProperty<bool> _showGizmo = new(false);
+        private RuntimeTransformControlHandle _leftHandControl;
+        private RuntimeTransformControlHandle _rightHandControl;
         private bool _hasModel;
         private Transform _hips;
         private Transform _leftUpperArm;
@@ -47,7 +50,7 @@ namespace Baku.VMagicMirror
         private Vector3 _leftUpperArmPosOffset;
         private Vector3 _rightUpperArmPosOffset;
 
-        private readonly HandDownRestPose _currentPose = new HandDownRestPose();
+        private readonly HandDownRestPose _currentPose = new();
 
         public CustomizedDownHandIk(
             IKTargetTransforms ikTargetTransforms, 
@@ -56,6 +59,7 @@ namespace Baku.VMagicMirror
             IMessageReceiver receiver,
             IMessageSender sender,
             DeviceTransformController deviceTransformController,
+            RuntimeTransformControlFactory transformControlFactory,
             ICoroutineSource coroutineSource,
             BodyMotionModeController bodyMotionModeController
             )
@@ -67,12 +71,16 @@ namespace Baku.VMagicMirror
             _vrmLoadable = vrmLoadable;
             _handDownIkCalculator = handDownIkCalculator;
             _deviceTransformController = deviceTransformController;
+            _transformControlFactory = transformControlFactory;
             _coroutineSource = coroutineSource;
             _bodyMotionModeController = bodyMotionModeController;
         }
 
         public override void Initialize()
         {
+            _transformControlFactory.DisableExisting(_leftHandTarget.TargetTransform);
+            _transformControlFactory.DisableExisting(_rightHandTarget.TargetTransform);
+
             _receiver.AssignCommandHandler(
                 VmmCommands.EnableCustomHandDownPose,
                 command => _enableCustomHandDownPose.Value = command.ToBoolean()
@@ -127,6 +135,7 @@ namespace Baku.VMagicMirror
                 _rightUpperArmPosOffset = Vector3.zero;
                 _leftHandTarget.TargetTransform.SetParent(null);
                 _rightHandTarget.TargetTransform.SetParent(null);
+                ReleaseTransformControls();
             };
 
             _deviceTransformController.ControlRequested
@@ -146,8 +155,7 @@ namespace Baku.VMagicMirror
                     _rightHandTarget.SetGizmoImageActiveness(gizmoVisible);
                     if (!gizmoVisible)
                     {
-                        _leftHandTarget.TransformControl.mode = TransformControl.TransformMode.None;
-                        _rightHandTarget.TransformControl.mode = TransformControl.TransformMode.None;
+                        ReleaseTransformControls();
                     }
                 })
                 .AddTo(this);
@@ -162,28 +170,11 @@ namespace Baku.VMagicMirror
                     }
                 });
             
-            //gizmoの操作が確定するとWPF側にも姿勢が送られる: ドラッグ操作の途中では内部的にのみ反映する
-            _leftHandTarget.TransformControl.DragEnded += mode =>
-            {
-                if (mode == TransformControl.TransformMode.None) return;
-                var pose = GetPoseFromTransform(_leftHandTarget.TargetTransform, true);
-                SetPose(pose);
-                SendPose();
-            };
-
-            _rightHandTarget.TransformControl.DragEnded += mode =>
-            {
-                if (mode == TransformControl.TransformMode.None) return;
-                var pose = GetPoseFromTransform(_rightHandTarget.TargetTransform, false);
-                SetPose(pose);
-                SendPose();
-            };
-            
             _coroutineSource.StartCoroutine(UpdateOnEndOfFrame());
         }
 
         //片方の手の位置を調整
-        IEnumerator UpdateOnEndOfFrame()
+        private IEnumerator UpdateOnEndOfFrame()
         {
             var eof = new WaitForEndOfFrame();
             while (true)
@@ -201,13 +192,13 @@ namespace Baku.VMagicMirror
                 }
 
                 //操作中のgizmoは逐一見てIKに反映
-                if (_leftHandTarget.TransformControl.IsDragging)
+                if (_leftHandControl?.Control != null && _leftHandControl.Control.IsDragging)
                 {
                     var pose = GetPoseFromTransform(_leftHandTarget.TargetTransform, true);
                     SetPose(pose);
                 }
 
-                if (_rightHandTarget.TransformControl.IsDragging)
+                if (_rightHandControl?.Control != null && _rightHandControl.Control.IsDragging)
                 {
                     var pose = GetPoseFromTransform(_rightHandTarget.TargetTransform, false);
                     SetPose(pose);
@@ -224,13 +215,17 @@ namespace Baku.VMagicMirror
 
         private void OnGizmoControlRequested(TransformControlRequest request)
         {
-            if (!_showGizmo.Value)
+            if (!_showGizmo.Value || !_hasModel)
             {
                 return;
             }
 
-            _leftHandTarget.TransformControl.global = request.WorldCoordinate;
-            _rightHandTarget.TransformControl.global = request.WorldCoordinate;
+            EnsureTransformControls();
+            var leftControl = _leftHandControl.Control;
+            var rightControl = _rightHandControl.Control;
+
+            leftControl.global = request.WorldCoordinate;
+            rightControl.global = request.WorldCoordinate;
 
             var rawMode = request.Mode;
             var useMode =
@@ -239,10 +234,10 @@ namespace Baku.VMagicMirror
             var mode = useMode ? rawMode : TransformControl.TransformMode.None;
             
             //scaleは許可されてないことに注意
-            _leftHandTarget.TransformControl.mode = mode;
-            _rightHandTarget.TransformControl.mode = mode;
-            _leftHandTarget.TransformControl.Control();
-            _rightHandTarget.TransformControl.Control();
+            leftControl.mode = mode;
+            rightControl.mode = mode;
+            leftControl.Control();
+            rightControl.Control();
         }
 
         private void ApplyHandDownPose(string poseJson)
@@ -362,6 +357,69 @@ namespace Baku.VMagicMirror
                 LeftRotation = ik.Rotation.eulerAngles,
             };
             SetPose(pose);
+        }
+
+        public override void Dispose()
+        {
+            ReleaseTransformControls();
+            base.Dispose();
+        }
+
+        private void EnsureTransformControls()
+        {
+            if (_leftHandControl?.Control == null)
+            {
+                _leftHandControl = _transformControlFactory.Create(_leftHandTarget.TargetTransform);
+                _leftHandControl.Control.DragEnded += OnLeftHandDragEnded;
+            }
+
+            if (_rightHandControl?.Control == null)
+            {
+                _rightHandControl = _transformControlFactory.Create(_rightHandTarget.TargetTransform);
+                _rightHandControl.Control.DragEnded += OnRightHandDragEnded;
+            }
+        }
+
+        private void ReleaseTransformControls()
+        {
+            if (_leftHandControl?.Control != null)
+            {
+                _leftHandControl.Control.DragEnded -= OnLeftHandDragEnded;
+                _leftHandControl.Dispose();
+            }
+
+            if (_rightHandControl?.Control != null)
+            {
+                _rightHandControl.Control.DragEnded -= OnRightHandDragEnded;
+                _rightHandControl.Dispose();
+            }
+
+            _leftHandControl = null;
+            _rightHandControl = null;
+        }
+
+        private void OnLeftHandDragEnded(TransformControl.TransformMode mode)
+        {
+            if (mode == TransformControl.TransformMode.None)
+            {
+                return;
+            }
+
+            var pose = GetPoseFromTransform(_leftHandTarget.TargetTransform, true);
+            SetPose(pose);
+            SendPose();
+        }
+
+        private void OnRightHandDragEnded(TransformControl.TransformMode mode)
+        {
+            if (mode == TransformControl.TransformMode.None)
+            {
+                return;
+            }
+
+            var pose = GetPoseFromTransform(_rightHandTarget.TargetTransform, false);
+            SetPose(pose);
+            SendPose();
         }
     }
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/ArcadeStickProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/ArcadeStickProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using mattatz.TransformControl;
 using UnityEngine;
 
 namespace Baku.VMagicMirror
@@ -34,9 +33,6 @@ namespace Baku.VMagicMirror
 
         [SerializeField] private Vector3 basePosition = new Vector3(0f, .93f, 0.3f);
         [SerializeField] private Vector3 baseRotation = new Vector3(-20f, 0f, 0f);
-
-        [SerializeField] private TransformControl transformControl = default;
-        public TransformControl TransformControl => transformControl;
 
         private void Awake()
         {

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/CarHandleProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/CarHandleProvider.cs
@@ -1,4 +1,3 @@
-using mattatz.TransformControl;
 using UnityEngine;
 
 namespace Baku.VMagicMirror
@@ -17,9 +16,6 @@ namespace Baku.VMagicMirror
         [SerializeField] private Transform steering;
         [SerializeField] private AnimationCurve angleToHeadYawRateCurve;
 
-        [SerializeField] private TransformControl transformControl = default;
-        public TransformControl TransformControl => transformControl;
-        
         public Transform RootTransform => transform;
         public Transform OffsetAddedTransform => offset;
         //NOTE: 実際はこの値が更にフリーレイアウトモードでスケールする…はず

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceTransformController.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/DeviceTransformController.cs
@@ -41,26 +41,35 @@ namespace Baku.VMagicMirror
         private float _gamepadModelScale = 1.0f;
         
         private SettingAutoAdjuster _settingAutoAdjuster;
+        private RuntimeTransformControlFactory _transformControlFactory;
         private HidTransformController _hidTransformController;
         private GamepadProvider _gamepad;
         private ArcadeStickProvider _arcadeStick;
         private CarHandleProvider _carHandle;
         private PenTabletProvider _penTable;
 
-        private TransformControl _keyboardControl;
-        private TransformControl _touchPadControl;
-        private TransformControl _midiControl;
-        private TransformControl _gamepadControl;
-        private TransformControl _arcadeStickControl;
-        private TransformControl _carHandleControl;
-        private TransformControl _penTabletControl;
+        private Transform _keyboardTransform;
+        private Transform _touchPadTransform;
+        private Transform _midiTransform;
+        private Transform _gamepadTransform;
+        private Transform _arcadeStickTransform;
+        private Transform _carHandleTransform;
+        private Transform _penTabletTransform;
+
+        private RuntimeTransformControlHandle _keyboardControl;
+        private RuntimeTransformControlHandle _touchPadControl;
+        private RuntimeTransformControlHandle _midiControl;
+        private RuntimeTransformControlHandle _gamepadControl;
+        private RuntimeTransformControlHandle _arcadeStickControl;
+        private RuntimeTransformControlHandle _carHandleControl;
+        private RuntimeTransformControlHandle _penTabletControl;
         private Transform _gamepadModelScaleTarget;
         
         private bool _preferWorldCoordinate;
         private TransformControl.TransformMode _mode = TransformControl.TransformMode.Translate;
 
-        private TransformControl[] _transformControls;
-        private TransformControl[] TransformControls => _transformControls ??= new[]
+        private RuntimeTransformControlHandle[] _transformControls;
+        private RuntimeTransformControlHandle[] TransformControls => _transformControls ??= new[]
         {
             _keyboardControl,
             _touchPadControl,
@@ -110,6 +119,7 @@ namespace Baku.VMagicMirror
             IMessageReceiver receiver,
             IMessageSender sender,
             SettingAutoAdjuster settingAutoAdjuster,
+            RuntimeTransformControlFactory transformControlFactory,
             HidTransformController hidTransformController,
             KeyboardProvider keyboard,
             TouchPadProvider touchPad,
@@ -122,6 +132,7 @@ namespace Baku.VMagicMirror
         {
             _sender = sender;
             _settingAutoAdjuster = settingAutoAdjuster;
+            _transformControlFactory = transformControlFactory;
 
             _hidTransformController = hidTransformController;
             _gamepad = gamepad;
@@ -129,22 +140,30 @@ namespace Baku.VMagicMirror
             _carHandle = carHandle;
             _penTable = penTablet;
 
-            _keyboardControl = keyboard.TransformControl;
-            _touchPadControl = touchPad.TransformControl;
-            _midiControl = midiController.TransformControl;
-            _gamepadControl = gamepad.TransformControl;
-            _arcadeStickControl = arcadeStick.TransformControl;
-            _carHandleControl = carHandle.TransformControl;
-            _penTabletControl = penTablet.TransformControl;
+            _keyboardTransform = keyboard.transform;
+            _touchPadTransform = touchPad.transform;
+            _midiTransform = midiController.transform;
+            _gamepadTransform = gamepad.transform;
+            _arcadeStickTransform = arcadeStick.transform;
+            _carHandleTransform = carHandle.transform;
+            _penTabletTransform = penTablet.transform;
             _gamepadModelScaleTarget = gamepad.ModelScaleTarget;
+
+            _transformControlFactory.DisableExisting(_keyboardTransform);
+            _transformControlFactory.DisableExisting(_touchPadTransform);
+            _transformControlFactory.DisableExisting(_midiTransform);
+            _transformControlFactory.DisableExisting(_gamepadTransform);
+            _transformControlFactory.DisableExisting(_arcadeStickTransform);
+            _transformControlFactory.DisableExisting(_carHandleTransform);
+            _transformControlFactory.DisableExisting(_penTabletTransform);
             
-            _keyboardVisibility = _keyboardControl.GetComponent<KeyboardVisibilityView>();
-            _touchPadVisibility =  _touchPadControl.GetComponent<TouchpadVisibilityView>();
-            _gamepadVisibility = _gamepadControl.GetComponent<GamepadVisibilityView>();
-            _arcadeStickVisibility = _arcadeStickControl.GetComponent<ArcadeStickVisibilityView>();
-            _carHandleVisibility = _carHandleControl.GetComponent<CarHandleVisibilityView>();
-            _midiControllerVisibility = _midiControl.GetComponent<MidiControllerVisibility>();
-            _penTabletVisibility = _penTabletControl.GetComponent<PenTabletVisibilityView>();
+            _keyboardVisibility = keyboard.GetComponent<KeyboardVisibilityView>();
+            _touchPadVisibility =  touchPad.GetComponent<TouchpadVisibilityView>();
+            _gamepadVisibility = gamepad.GetComponent<GamepadVisibilityView>();
+            _arcadeStickVisibility = arcadeStick.GetComponent<ArcadeStickVisibilityView>();
+            _carHandleVisibility = carHandle.GetComponent<CarHandleVisibilityView>();
+            _midiControllerVisibility = midiController.GetComponent<MidiControllerVisibility>();
+            _penTabletVisibility = penTablet.GetComponent<PenTabletVisibilityView>();
             
             receiver.AssignCommandHandler(
                 VmmCommands.EnableDeviceFreeLayout,
@@ -167,22 +186,24 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            _keyboardControl.mode = _keyboardVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
-            _touchPadControl.mode = _touchPadVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
-            _gamepadControl.mode = _gamepadVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
+            EnsureTransformControls();
+
+            _keyboardControl.Control.mode = _keyboardVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
+            _touchPadControl.Control.mode = _touchPadVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
+            _gamepadControl.Control.mode = _gamepadVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
             //NOTE:
             // アケコンは実機スケールを重んじるため、スケール変化は認めない
             // 車のハンドルも物理ベースで同様に考えうるが、ハンドルについてはスケールがxyzで歪まないことだけ保証している
-            _arcadeStickControl.mode = _arcadeStickVisibility.IsVisible && _mode != TransformControl.TransformMode.Scale 
+            _arcadeStickControl.Control.mode = _arcadeStickVisibility.IsVisible && _mode != TransformControl.TransformMode.Scale
                 ? _mode
                 : TransformControl.TransformMode.None;
-            _carHandleControl.mode = _carHandleVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
-            _midiControl.mode = _midiControllerVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
-            _penTabletControl.mode = _penTabletVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
+            _carHandleControl.Control.mode = _carHandleVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
+            _midiControl.Control.mode = _midiControllerVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
+            _penTabletControl.Control.mode = _penTabletVisibility.IsVisible ? _mode : TransformControl.TransformMode.None;
 
             foreach (var transformControl in TransformControls)
             {
-                transformControl.Control();
+                transformControl.Control.Control();
             }
             
             AdjustCarHandleScale();
@@ -193,7 +214,8 @@ namespace Baku.VMagicMirror
         //CarHandleのscaleのx,y,z成分が等しい状態にする
         private void AdjustCarHandleScale()
         {
-            if (_carHandleControl.mode != TransformControl.TransformMode.Scale)
+            if (_carHandleControl?.Control == null ||
+                _carHandleControl.Control.mode != TransformControl.TransformMode.Scale)
             {
                 return;
             }
@@ -201,7 +223,7 @@ namespace Baku.VMagicMirror
             const float ScaleDiffThreshold = 0.0001f;
 
             //scaleに仲間外れの値がある場合、その値が編集されたと見なして他2つの値を追従させる
-            var t = _carHandleControl.transform;
+            var t = _carHandleTransform;
             
             var scale = t.localScale;
 
@@ -261,10 +283,18 @@ namespace Baku.VMagicMirror
                 RawCanvas.gameObject.SetActive(IsDeviceFreeLayoutEnabled);
             }
 
-            foreach (var transformControl in TransformControls)
+            if (enable)
             {
-                transformControl.enabled = enable;
-                transformControl.mode = enable ? _mode : TransformControl.TransformMode.None;
+                EnsureTransformControls();
+                foreach (var transformControl in TransformControls)
+                {
+                    transformControl.Control.global = _preferWorldCoordinate;
+                    transformControl.Control.mode = _mode;
+                }
+            }
+            else
+            {
+                ReleaseTransformControls();
             }
         }
 
@@ -272,13 +302,13 @@ namespace Baku.VMagicMirror
         {
             var data = new DeviceLayoutsData()
             {
-                keyboard = ToItem(_keyboardControl.transform),
-                touchPad = ToItem(_touchPadControl.transform),
-                midi = ToItem(_midiControl.transform),
-                gamepad = ToItem(_gamepadControl.transform),
-                arcadeStick = ToItem(_arcadeStickControl.transform),
-                carHandle = ToItem(_carHandleControl.transform),
-                penTablet = ToItem(_penTabletControl.transform),
+                keyboard = ToItem(_keyboardTransform),
+                touchPad = ToItem(_touchPadTransform),
+                midi = ToItem(_midiTransform),
+                gamepad = ToItem(_gamepadTransform),
+                arcadeStick = ToItem(_arcadeStickTransform),
+                carHandle = ToItem(_carHandleTransform),
+                penTablet = ToItem(_penTabletTransform),
                 gamepadModelScale = _gamepadModelScaleTarget.localScale.x,
             };
             _sender?.SendCommand(MessageFactory.UpdateDeviceLayout(data));
@@ -308,13 +338,13 @@ namespace Baku.VMagicMirror
                 // TODO: Transform編集に関するコードのトレーサビリティが悪いのを直したい
                 // 具体的には、各ControlなりProviderなりのクラスからSetPosition系のメソッドが生えてると嬉しい
                 var data = JsonUtility.FromJson<DeviceLayoutsData>(content);
-                ApplyItem(data.keyboard, _keyboardControl.transform);
-                ApplyItem(data.touchPad, _touchPadControl.transform);
-                ApplyItem(data.midi, _midiControl.transform);
-                ApplyItem(data.gamepad, _gamepadControl.transform);
-                ApplyItem(data.arcadeStick, _arcadeStickControl.transform);
-                ApplyItem(data.carHandle, _carHandleControl.transform);
-                ApplyItem(data.penTablet, _penTabletControl.transform);
+                ApplyItem(data.keyboard, _keyboardTransform);
+                ApplyItem(data.touchPad, _touchPadTransform);
+                ApplyItem(data.midi, _midiTransform);
+                ApplyItem(data.gamepad, _gamepadTransform);
+                ApplyItem(data.arcadeStick, _arcadeStickTransform);
+                ApplyItem(data.carHandle, _carHandleTransform);
+                ApplyItem(data.penTablet, _penTabletTransform);
 
                 _gamepadModelScale = Mathf.Clamp(
                     data.gamepadModelScale,
@@ -420,12 +450,59 @@ namespace Baku.VMagicMirror
             }
 
             act();
+            if (!IsDeviceFreeLayoutEnabled)
+            {
+                return;
+            }
+
+            EnsureTransformControls();
             foreach (var transformControl in TransformControls)
             {
-                transformControl.global = _preferWorldCoordinate;
-                transformControl.mode = _mode;
+                transformControl.Control.global = _preferWorldCoordinate;
+                transformControl.Control.mode = _mode;
             }
         }
+
+        private void EnsureTransformControls()
+        {
+            _keyboardControl ??= _transformControlFactory.Create(_keyboardTransform);
+            _touchPadControl ??= _transformControlFactory.Create(_touchPadTransform);
+            _midiControl ??= _transformControlFactory.Create(_midiTransform);
+            _gamepadControl ??= _transformControlFactory.Create(_gamepadTransform);
+            _arcadeStickControl ??= _transformControlFactory.Create(_arcadeStickTransform);
+            _carHandleControl ??= _transformControlFactory.Create(_carHandleTransform);
+            _penTabletControl ??= _transformControlFactory.Create(_penTabletTransform);
+
+            _transformControls = new[]
+            {
+                _keyboardControl,
+                _touchPadControl,
+                _midiControl,
+                _gamepadControl,
+                _arcadeStickControl,
+                _carHandleControl,
+                _penTabletControl,
+            };
+        }
+
+        private void ReleaseTransformControls()
+        {
+            foreach (var transformControl in TransformControls)
+            {
+                transformControl?.Dispose();
+            }
+
+            _keyboardControl = null;
+            _touchPadControl = null;
+            _midiControl = null;
+            _gamepadControl = null;
+            _arcadeStickControl = null;
+            _carHandleControl = null;
+            _penTabletControl = null;
+            _transformControls = null;
+        }
+
+        private void OnDestroy() => ReleaseTransformControls();
     }
     
     [Serializable]

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/GamepadProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/GamepadProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Baku.VMagicMirror.Installer;
-using mattatz.TransformControl;
 using UnityEngine;
 using Zenject;
 
@@ -28,9 +27,6 @@ namespace Baku.VMagicMirror
 
         [SerializeField] private MeshRenderer bodyRenderer = null;
         
-        [SerializeField] private TransformControl transformControl = null;
-        public TransformControl TransformControl => transformControl;
-
         [SerializeField] private Transform modelScaleTarget = null;
         public Transform ModelScaleTarget => modelScaleTarget;
 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/KeyboardProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/KeyboardProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Baku.VMagicMirror.Installer;
-using mattatz.TransformControl;
 using UnityEngine;
 using Zenject;
 
@@ -260,9 +259,6 @@ namespace Baku.VMagicMirror
             4.0f,
             3.0f,
         };
-
-        [SerializeField] private TransformControl transformControl = null;
-        public TransformControl TransformControl => transformControl;
 
         private KeyboardVisibilityView _visibilityView = null;
         public KeyboardVisibilityView GetVisibilityView()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenTabletProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/PenTabletProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Baku.VMagicMirror.IK;
 using Baku.VMagicMirror.Installer;
-using mattatz.TransformControl;
 using UnityEngine;
 using Zenject;
 
@@ -16,9 +15,6 @@ namespace Baku.VMagicMirror
     {
         private MousePositionProvider _mousePositionProvider = null;
 
-        [SerializeField] private TransformControl transformControl = null;
-        public TransformControl TransformControl => transformControl;
-        
         [SerializeField] private Vector3 basePosition = new Vector3(.15f, .98f, 0.12f);
         [SerializeField] private Vector3 baseRotation = new Vector3(60f, 0f, 0f);
         [SerializeField] private Vector3 baseScale = new Vector3(.3f, .2f, 1f);

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/TouchPadProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/DeviceTransforms/TouchPadProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Baku.VMagicMirror.Installer;
-using mattatz.TransformControl;
 using UnityEngine;
 using Zenject;
 
@@ -8,9 +7,6 @@ namespace Baku.VMagicMirror
     public class TouchPadProvider : MonoBehaviour
     {
         private MousePositionProvider _mousePositionProvider = null;
-
-        [SerializeField] private TransformControl transformControl = null;
-        public TransformControl TransformControl => transformControl;
 
         private TouchpadVisibilityView _visibilityView = null;
         public TouchpadVisibilityView GetVisibilityView()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/RuntimeLayoutEdit/RuntimeTransformControlFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/RuntimeLayoutEdit/RuntimeTransformControlFactory.cs
@@ -6,13 +6,6 @@ namespace Baku.VMagicMirror
 {
     public sealed class RuntimeTransformControlFactory
     {
-        private readonly Camera _camera;
-
-        public RuntimeTransformControlFactory(Camera camera)
-        {
-            _camera = camera;
-        }
-
         public void DisableExisting(Transform target)
         {
             var control = target.GetComponent<TransformControl>();
@@ -34,7 +27,7 @@ namespace Baku.VMagicMirror
                 control = target.gameObject.AddComponent<TransformControl>();
             }
 
-            control.Initialize(_camera);
+            control.Initialize();
             control.enabled = true;
             control.mode = TransformControl.TransformMode.None;
             control.global = false;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/RuntimeLayoutEdit/RuntimeTransformControlFactory.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/RuntimeLayoutEdit/RuntimeTransformControlFactory.cs
@@ -1,0 +1,76 @@
+using System;
+using mattatz.TransformControl;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public sealed class RuntimeTransformControlFactory
+    {
+        private readonly Camera _camera;
+
+        public RuntimeTransformControlFactory(Camera camera)
+        {
+            _camera = camera;
+        }
+
+        public void DisableExisting(Transform target)
+        {
+            var control = target.GetComponent<TransformControl>();
+            if (control == null)
+            {
+                return;
+            }
+
+            control.mode = TransformControl.TransformMode.None;
+            control.enabled = false;
+        }
+
+        public RuntimeTransformControlHandle Create(Transform target)
+        {
+            var control = target.GetComponent<TransformControl>();
+            var created = control == null;
+            if (created)
+            {
+                control = target.gameObject.AddComponent<TransformControl>();
+            }
+
+            control.Initialize(_camera);
+            control.enabled = true;
+            control.mode = TransformControl.TransformMode.None;
+            control.global = false;
+            control.useDistance = true;
+            control.distance = 12f;
+            return new RuntimeTransformControlHandle(control, created);
+        }
+    }
+
+    public sealed class RuntimeTransformControlHandle : IDisposable
+    {
+        private readonly bool _destroyOnDispose;
+
+        public RuntimeTransformControlHandle(TransformControl control, bool destroyOnDispose)
+        {
+            Control = control;
+            _destroyOnDispose = destroyOnDispose;
+        }
+
+        public TransformControl Control { get; private set; }
+
+        public void Dispose()
+        {
+            if (Control == null)
+            {
+                return;
+            }
+
+            Control.mode = TransformControl.TransformMode.None;
+            Control.enabled = false;
+            if (_destroyOnDispose)
+            {
+                UnityEngine.Object.Destroy(Control);
+            }
+
+            Control = null;
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/RuntimeLayoutEdit/RuntimeTransformControlFactory.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Environment/RuntimeLayoutEdit/RuntimeTransformControlFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 786494d367f09e248af2a6e320521604
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/MidiInput/MidiControllerProvider.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/InputMonitoring/MidiInput/MidiControllerProvider.cs
@@ -1,5 +1,4 @@
 ﻿using Baku.VMagicMirror.Installer;
-using mattatz.TransformControl;
 using UnityEngine;
 using Zenject;
 
@@ -26,9 +25,6 @@ namespace Baku.VMagicMirror
         [SerializeField] private Vector3 initPos = new Vector3(0, 1.0f, 0.3f);
         [SerializeField] private Vector3 initRot = new Vector3(0, 0, 0);
         [SerializeField] private Vector3 initScale = new Vector3(0.7f, 0.7f, 0.7f);
-
-        [SerializeField] private TransformControl _transformControl = null;
-        public TransformControl TransformControl => _transformControl;
 
         private Transform[] _notes = null;
         private MidiKnob[] _knobs = null;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/EnvironmentInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/EnvironmentInstaller.cs
@@ -16,7 +16,7 @@ namespace Baku.VMagicMirror.Installer
             container.Bind<RuntimeTransformControlFactory>().AsSingle();
 
             container.BindInterfacesTo<CameraFovController>().AsSingle();
-            container.Bind<CameraUtilWrapper>().AsSingle();
+            container.BindInterfacesAndSelfTo<CameraUtilWrapper>().AsSingle();
             container.Bind<WindowStateRepository>().AsSingle();
 
             container.BindInterfacesTo<AntiAliasSettingSetter>().AsSingle();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/EnvironmentInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/EnvironmentInstaller.cs
@@ -13,6 +13,7 @@ namespace Baku.VMagicMirror.Installer
         {
             container.BindInstance(mainCamera);
             container.BindInstance(refCameraForRay).WithId("RefCameraForRay");
+            container.Bind<RuntimeTransformControlFactory>().AsSingle();
 
             container.BindInterfacesTo<CameraFovController>().AsSingle();
             container.Bind<CameraUtilWrapper>().AsSingle();

--- a/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/GizmoRenderer.cs
+++ b/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/GizmoRenderer.cs
@@ -81,14 +81,7 @@ namespace mattatz.TransformControl
         {
             if (targetCamera == null)
             {
-                //It is better to avoid to pass this line
-                targetCamera = Camera.main;
-            }
-
-            if (targetCamera == null)
-            {
-                //This line passes only when scene or code setup has some problems
-                Debug.LogError("TransformControl cannot find main camera");
+                Debug.LogError("TransformControl target camera is not initialized");
                 return;
             }
 

--- a/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/TransformControl.cs
+++ b/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/TransformControl.cs
@@ -82,7 +82,7 @@ namespace mattatz.TransformControl
                 //Noneに立ち下がった場合、AutoUpdateがfalseであっても無視してRendererをただちに隠す
                 if (_mode != TransformMode.None && value == TransformMode.None)
                 {
-                    gizmoRenderer.SetMode(TransformMode.None);
+                    gizmoRenderer?.SetMode(TransformMode.None);
                 }
                 _mode = value;
             }
@@ -143,13 +143,15 @@ namespace mattatz.TransformControl
 
         private void Awake() => InitializeCircumferences();
 
-        private void Start()
+        public void Initialize(Camera cam)
         {
-            _cam = TransformControlCameraStore.Get();
+            _cam = cam != null ? cam : TransformControlCameraStore.Get();
             EnsureGizmoRenderer();
             gizmoRenderer.Target = transform;
             gizmoRenderer.TargetCamera = _cam;
         }
+
+        private void Start() => Initialize(TransformControlCameraStore.Get());
 
         private void Update()
         {

--- a/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/TransformControl.cs
+++ b/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/TransformControl.cs
@@ -143,15 +143,15 @@ namespace mattatz.TransformControl
 
         private void Awake() => InitializeCircumferences();
 
-        public void Initialize(Camera cam)
+        public void Initialize()
         {
-            _cam = cam != null ? cam : TransformControlCameraStore.Get();
+            _cam = TransformControlCameraStore.Get();
             EnsureGizmoRenderer();
             gizmoRenderer.Target = transform;
             gizmoRenderer.TargetCamera = _cam;
         }
 
-        private void Start() => Initialize(TransformControlCameraStore.Get());
+        private void Start() => Initialize();
 
         private void Update()
         {

--- a/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/TransformControlCameraGetter.cs
+++ b/VMagicMirror/Assets/Dependencies/Mattatz/TransformControl/Scripts/TransformControlCameraGetter.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace mattatz.TransformControl
@@ -5,8 +6,27 @@ namespace mattatz.TransformControl
     public static class TransformControlCameraStore
     {
         private static Camera _camera;
-        public static Camera Get() => _camera != null ? _camera : Camera.main;
-        public static void Set(Camera camera) => _camera = camera;
+        public static Camera Get()
+        {
+            if (_camera == null)
+            {
+                throw new InvalidOperationException(
+                    "TransformControlCameraStore is not initialized. CameraUtilWrapper.Initialize() must set RefCameraForRay before TransformControl is used."
+                );
+            }
+
+            return _camera;
+        }
+
+        public static void Set(Camera camera)
+        {
+            if (camera == null)
+            {
+                throw new ArgumentNullException(nameof(camera));
+            }
+
+            _camera = camera;
+        }
     }
 }
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Improve existing feature

## What the PR does

fixes #1148 

- issueに書いた通りの方針で対応したので、フリーレイアウト中のギズモの表示のされ方はとくに変更なし

## How to confirm

- Editor + WPF Buildで基本動作すること
- とくにフリーレイアウトモードに入らないうちはHierarchy上にGizmoRendererのオブジェクトが表示されないこと
- アクセサリーやデバイス系のオブジェクトに対してフリーレイアウトになったときに編集操作ができること


