### PR TITLE
肩の上がり具合のオフセットを調整する機能を追加

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using R3;
 using RootMotion.FinalIK;
 using UnityEngine;
 using Zenject;
@@ -107,7 +108,9 @@ namespace Baku.VMagicMirror
         private float _rightHandDiffY = 0f;
 
         #endregion
-        
+
+        private readonly ReactiveProperty<float> _shoulderRotationOffset = new(0f);
+
         [Inject]
         public void Initialize(IVRMLoadable vrmLoadable, IMessageReceiver receiver)
         {
@@ -122,7 +125,12 @@ namespace Baku.VMagicMirror
             receiver.AssignCommandHandler(
                 VmmCommands.EnableWaitMotion,
                 command => EnableWaitMotion = command.ToBoolean()
-                );
+            );
+
+            receiver.AssignCommandHandler(
+                VmmCommands.ShoulderRotationOffset,
+                command => _shoulderRotationOffset.Value = command.ToInt() * 0.1f
+            );
         }
 
         private bool _enableWaitMotion = true;
@@ -249,99 +257,98 @@ namespace Baku.VMagicMirror
                 rotRate * _staticRightShoulderEuler.y,
                 rotRate * (_staticRightShoulderEuler.z + _diffBasedRightRollDeg + _waitMotionBasedRightRollDeg)
             );
-            return;
+        }
 
-            void UpdateStaticRotation()
+        private void UpdateStaticRotation()
+        {
+            _staticLeftShoulderEuler = new Vector3(
+                0, 
+                Mathf.Clamp(
+                    Mathf.Asin(_leftElbowOrientation.z) * Mathf.Rad2Deg * angleScale, 
+                    yawMinDeg,
+                    yawMaxDeg
+                ),
+                Mathf.Clamp(
+                    -Mathf.Asin(_leftElbowOrientation.y) * Mathf.Rad2Deg * angleScale,
+                    -rollMaxDeg, 
+                    -rollMinDeg
+                ) - _shoulderRotationOffset.CurrentValue
+            );
+        
+            _staticRightShoulderEuler = new Vector3(
+                0, 
+                Mathf.Clamp(
+                    -Mathf.Asin(_rightElbowOrientation.z) * Mathf.Rad2Deg * angleScale,
+                    -yawMaxDeg,
+                    -yawMinDeg
+                ),
+                Mathf.Clamp(
+                    Mathf.Asin(_rightElbowOrientation.y) * Mathf.Rad2Deg * angleScale,
+                    rollMinDeg, 
+                    rollMaxDeg
+                ) + _shoulderRotationOffset.CurrentValue
+            );
+        }
+
+        //NOTE: 手のIK自体がキレイな値になっている前提で書かれています
+        private void UpdateDynamicRotation()
+        {
+            //最初のフレームは初期化だけで終わり
+            if (!_hasPrevFrameHandIkPosition)
             {
-                _staticLeftShoulderEuler = new Vector3(
-                    0, 
-                    Mathf.Clamp(
-                        Mathf.Asin(_leftElbowOrientation.z) * Mathf.Rad2Deg * angleScale, 
-                        yawMinDeg,
-                        yawMaxDeg
-                    ),
-                    Mathf.Clamp(
-                        -Mathf.Asin(_leftElbowOrientation.y) * Mathf.Rad2Deg * angleScale,
-                        -rollMaxDeg, 
-                        -rollMinDeg
-                    )
-                );
+                _prevLeftHandY = handIk.LeftHandPosition.y;
+                _prevRightHandY = handIk.RightHandPosition.y;
+
+                _leftHandDiffY = 0f;
+                _rightHandDiffY = 0f;
+                
+                _hasPrevFrameHandIkPosition = true;
+                return;
+            }
+
+            //書いてる手順の通りだが、積分値を角度にしたあとで範囲制限とか減衰をやっていく
             
-                _staticRightShoulderEuler = new Vector3(
-                    0, 
-                    Mathf.Clamp(
-                        -Mathf.Asin(_rightElbowOrientation.z) * Mathf.Rad2Deg * angleScale,
-                        -yawMaxDeg,
-                        -yawMinDeg
-                    ),
-                    Mathf.Clamp(
-                        Mathf.Asin(_rightElbowOrientation.y) * Mathf.Rad2Deg * angleScale,
-                        rollMinDeg, 
-                        rollMaxDeg
-                    )
+            var leftY =  handIk.LeftHandPosition.y;
+            _leftHandDiffY += leftY - _prevLeftHandY;
+            _diffBasedLeftRollDeg =
+                Mathf.Clamp(-_leftHandDiffY / _handDiffMax, -1, 1) * handDiffMaxRollDeg;
+            
+            var rightY =  handIk.RightHandPosition.y;
+            _rightHandDiffY += rightY - _prevRightHandY;
+            _diffBasedRightRollDeg =
+                Mathf.Clamp(_rightHandDiffY / _handDiffMax, -1, 1) * handDiffMaxRollDeg;
+
+            
+            _leftHandDiffY = Mathf.Clamp(
+                _leftHandDiffY,
+                -handDiffIntegrateFactor * _handDiffMax,
+                handDiffIntegrateFactor * _handDiffMax
                 );
-            }
+            _leftHandDiffY = Mathf.Lerp(_leftHandDiffY, 0f, handDiffYDecreaseFactor * Time.deltaTime);
 
-            //NOTE: 手のIK自体がキレイな値になっている前提で書かれています
-            void UpdateDynamicRotation()
-            {
-                //最初のフレームは初期化だけで終わり
-                if (!_hasPrevFrameHandIkPosition)
-                {
-                    _prevLeftHandY = handIk.LeftHandPosition.y;
-                    _prevRightHandY = handIk.RightHandPosition.y;
+            _rightHandDiffY = Mathf.Clamp(
+                _rightHandDiffY,
+                -handDiffIntegrateFactor * _handDiffMax,
+                handDiffIntegrateFactor * _handDiffMax
+            );
+            _rightHandDiffY = Mathf.Lerp(_rightHandDiffY, 0f, handDiffYDecreaseFactor * Time.deltaTime);
 
-                    _leftHandDiffY = 0f;
-                    _rightHandDiffY = 0f;
-                    
-                    _hasPrevFrameHandIkPosition = true;
-                    return;
-                }
+            _prevLeftHandY = leftY;
+            _prevRightHandY = rightY;
+        }
 
-                //書いてる手順の通りだが、積分値を角度にしたあとで範囲制限とか減衰をやっていく
-                
-                var leftY =  handIk.LeftHandPosition.y;
-                _leftHandDiffY += leftY - _prevLeftHandY;
-                _diffBasedLeftRollDeg =
-                    Mathf.Clamp(-_leftHandDiffY / _handDiffMax, -1, 1) * handDiffMaxRollDeg;
-                
-                var rightY =  handIk.RightHandPosition.y;
-                _rightHandDiffY += rightY - _prevRightHandY;
-                _diffBasedRightRollDeg =
-                    Mathf.Clamp(_rightHandDiffY / _handDiffMax, -1, 1) * handDiffMaxRollDeg;
-
-                
-                _leftHandDiffY = Mathf.Clamp(
-                    _leftHandDiffY,
-                    -handDiffIntegrateFactor * _handDiffMax,
-                    handDiffIntegrateFactor * _handDiffMax
-                    );
-                _leftHandDiffY = Mathf.Lerp(_leftHandDiffY, 0f, handDiffYDecreaseFactor * Time.deltaTime);
-
-                _rightHandDiffY = Mathf.Clamp(
-                    _rightHandDiffY,
-                    -handDiffIntegrateFactor * _handDiffMax,
-                    handDiffIntegrateFactor * _handDiffMax
-                );
-                _rightHandDiffY = Mathf.Lerp(_rightHandDiffY, 0f, handDiffYDecreaseFactor * Time.deltaTime);
-
-                _prevLeftHandY = leftY;
-                _prevRightHandY = rightY;
-            }
-
-            void UpdateWaitMotionBasedRotation()
-            {
-                var phase = Mathf.Repeat(
-                    (waitMotion.Phase - waitMotionPhaseDelay) * Mathf.PI * 2.0f,
-                    Mathf.PI * 2.0f
-                );
-                
-                //半角公式みたいな形にする: 肩は落とすと見栄えがわるいので、上げるほうにだけ動かすための式がコレです。
-                // float angle = waitMotionBasedAngleDeg * 0.5f * (1f - Mathf.Cos(phase));
-                var angle = - waitMotionBasedAngleDeg * Mathf.Cos(phase);
-                _waitMotionBasedLeftRollDeg = -angle;
-                _waitMotionBasedRightRollDeg = angle;
-            }
+        private void UpdateWaitMotionBasedRotation()
+        {
+            var phase = Mathf.Repeat(
+                (waitMotion.Phase - waitMotionPhaseDelay) * Mathf.PI * 2.0f,
+                Mathf.PI * 2.0f
+            );
+            
+            //半角公式みたいな形にする: 肩は落とすと見栄えがわるいので、上げるほうにだけ動かすための式がコレです。
+            // float angle = waitMotionBasedAngleDeg * 0.5f * (1f - Mathf.Cos(phase));
+            var angle = - waitMotionBasedAngleDeg * Mathf.Cos(phase);
+            _waitMotionBasedLeftRollDeg = -angle;
+            _waitMotionBasedRightRollDeg = angle;
         }
 
         private IEnumerator CheckElbowPostureOnEndOfFrame()

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/ShoulderRotationModifier.cs
@@ -17,7 +17,7 @@ namespace Baku.VMagicMirror
 
         //基準長はMegumi Baxterさんの体型。(https://hub.vroid.com/characters/9003440353945198963/models/7418874241157618732)
         //Headボーンの高さ. コレ以外の値はSettingAutoAdjusterとかにも載ってます
-        public const float ReferenceHeadHeight = 1.176175f;
+        private const float ReferenceHeadHeight = 1.176175f;
         
         [SerializeField] private HandIKIntegrator handIk = null;
         [SerializeField] private WaitingBodyMotion waitMotion = null;
@@ -236,7 +236,7 @@ namespace Baku.VMagicMirror
             }
 
             //IKが効かない = ビルトインモーションが動いてるはずなので、この場合は肩も止める
-            float rotRate = _rightHandEffector.positionWeight;
+            var rotRate = _rightHandEffector.positionWeight;
 
             _leftShoulder.localRotation = Quaternion.Euler(
                 0,
@@ -249,7 +249,8 @@ namespace Baku.VMagicMirror
                 rotRate * _staticRightShoulderEuler.y,
                 rotRate * (_staticRightShoulderEuler.z + _diffBasedRightRollDeg + _waitMotionBasedRightRollDeg)
             );
-            
+            return;
+
             void UpdateStaticRotation()
             {
                 _staticLeftShoulderEuler = new Vector3(
@@ -299,12 +300,12 @@ namespace Baku.VMagicMirror
 
                 //書いてる手順の通りだが、積分値を角度にしたあとで範囲制限とか減衰をやっていく
                 
-                float leftY =  handIk.LeftHandPosition.y;
+                var leftY =  handIk.LeftHandPosition.y;
                 _leftHandDiffY += leftY - _prevLeftHandY;
                 _diffBasedLeftRollDeg =
                     Mathf.Clamp(-_leftHandDiffY / _handDiffMax, -1, 1) * handDiffMaxRollDeg;
                 
-                float rightY =  handIk.RightHandPosition.y;
+                var rightY =  handIk.RightHandPosition.y;
                 _rightHandDiffY += rightY - _prevRightHandY;
                 _diffBasedRightRollDeg =
                     Mathf.Clamp(_rightHandDiffY / _handDiffMax, -1, 1) * handDiffMaxRollDeg;
@@ -330,14 +331,14 @@ namespace Baku.VMagicMirror
 
             void UpdateWaitMotionBasedRotation()
             {
-                float phase = Mathf.Repeat(
+                var phase = Mathf.Repeat(
                     (waitMotion.Phase - waitMotionPhaseDelay) * Mathf.PI * 2.0f,
                     Mathf.PI * 2.0f
                 );
                 
                 //半角公式みたいな形にする: 肩は落とすと見栄えがわるいので、上げるほうにだけ動かすための式がコレです。
                 // float angle = waitMotionBasedAngleDeg * 0.5f * (1f - Mathf.Cos(phase));
-                float angle = - waitMotionBasedAngleDeg * Mathf.Cos(phase);
+                var angle = - waitMotionBasedAngleDeg * Mathf.Cos(phase);
                 _waitMotionBasedLeftRollDeg = -angle;
                 _waitMotionBasedRightRollDeg = angle;
             }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -77,6 +77,7 @@
         // Motion, Arm
         EnableHidRandomTyping,
         EnableShoulderMotionModify,
+        ShoulderRotationOffset, // 0.1deg刻みを表す整数値を受け取り、プラスで肩が上がってマイナスで下がる
         EnableTypingHandDownTimeout,
         SetWaistWidth,
         SetElbowCloseStrength,

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -117,6 +117,7 @@
 
         public bool EnableHidRandomTyping { get; set; } = false;
         public bool EnableShoulderMotionModify { get; set; } = true;
+        public int ShoulderRotationOffset { get; set; } = 0;
         public bool EnableHandDownTimeout { get; set; } = true;
 
         public int WaistWidth { get; set; } = 30;
@@ -203,6 +204,7 @@
 
             EnableHidRandomTyping = false;
             EnableShoulderMotionModify = true;
+            ShoulderRotationOffset = 0;
             EnableHandDownTimeout = true;
             WaistWidth = 30;
             ElbowCloseStrength = 30;

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -98,6 +98,7 @@ namespace Baku.VMagicMirrorConfig
 
         public static Message EnableHidRandomTyping(bool enable) => BoolContent(VmmCommands.EnableHidRandomTyping, enable);
         public static Message EnableShoulderMotionModify(bool enable) => BoolContent(VmmCommands.EnableShoulderMotionModify, enable);
+        public static Message ShoulderRotationOffset(int offset) => IntContent(VmmCommands.ShoulderRotationOffset, offset);
         public static Message EnableTypingHandDownTimeout(bool enable) => BoolContent(VmmCommands.EnableTypingHandDownTimeout, enable);
         public static Message SetWaistWidth(int waistWidthCentimeter) => IntContent(VmmCommands.SetWaistWidth, waistWidthCentimeter);
         public static Message SetElbowCloseStrength(int strengthPercent) => IntContent(VmmCommands.SetElbowCloseStrength, strengthPercent);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -145,6 +145,7 @@ namespace Baku.VMagicMirrorConfig
 
             EnableHidRandomTyping = new RProperty<bool>(setting.EnableHidRandomTyping, v => SendMessage(MessageFactory.EnableHidRandomTyping(v)));
             EnableShoulderMotionModify = new RProperty<bool>(setting.EnableShoulderMotionModify, v => SendMessage(MessageFactory.EnableShoulderMotionModify(v)));
+            ShoulderRotationOffset = new RProperty<int>(setting.ShoulderRotationOffset, v => SendMessage(MessageFactory.ShoulderRotationOffset(v)));
             EnableHandDownTimeout = new RProperty<bool>(setting.EnableHandDownTimeout, v => SendMessage(MessageFactory.EnableTypingHandDownTimeout(v)));
             WaistWidth = new RProperty<int>(setting.WaistWidth, v => SendMessage(MessageFactory.SetWaistWidth(v)));
             ElbowCloseStrength = new RProperty<int>(setting.ElbowCloseStrength, v => SendMessage(MessageFactory.SetElbowCloseStrength(v)));
@@ -281,6 +282,7 @@ namespace Baku.VMagicMirrorConfig
 
         public RProperty<bool> EnableHidRandomTyping { get; }
         public RProperty<bool> EnableShoulderMotionModify { get; }
+        public RProperty<int> ShoulderRotationOffset { get; }
         public RProperty<bool> EnableHandDownTimeout { get; }
 
         public RProperty<int> WaistWidth { get; }
@@ -365,6 +367,7 @@ namespace Baku.VMagicMirrorConfig
 
             EnableHidRandomTyping.Value = setting.EnableHidRandomTyping;
             EnableShoulderMotionModify.Value = setting.EnableShoulderMotionModify;
+            ShoulderRotationOffset.Value = setting.ShoulderRotationOffset;
             EnableHandDownTimeout.Value = setting.EnableHandDownTimeout;
             WaistWidth.Value = setting.WaistWidth;
             ElbowCloseStrength.Value = setting.ElbowCloseStrength;

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -398,6 +398,7 @@ Restart (turn off and on) the buddy to get more detailed log.</sys:String>
     <sys:String x:Key="Motion_Arm_EnableHidMotion">Enable Typing / Mouse Motion</sys:String>
     <sys:String x:Key="Motion_Arm_EnableRandomTyping">Random typing to hide key input</sys:String>
     <sys:String x:Key="Motion_Arm_EnableShoulderModify">Modify shoulder motion</sys:String>
+    <sys:String x:Key="Motion_Arm_ShoulderRotationOffset">Shoulder lift offset</sys:String>
     <sys:String x:Key="Motion_Arm_EnableTypingAndMouseTimeout">Down hand when no input</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand">Enable mouse motion to FPS assumed mode</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand_Tooltip">When checked right hand motion during playing FPS become more natural, but screen touch or pen tablet operation become become slow</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -397,6 +397,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_Arm_EnableHidMotion">タイピング / マウス動作を反映</sys:String>
     <sys:String x:Key="Motion_Arm_EnableRandomTyping">打鍵をランダム化して入力を隠す</sys:String>
     <sys:String x:Key="Motion_Arm_EnableShoulderModify">肩モーションの補正を有効化</sys:String>
+    <sys:String x:Key="Motion_Arm_ShoulderRotationOffset">肩の上がり具合を調整</sys:String>
     <sys:String x:Key="Motion_Arm_EnableTypingAndMouseTimeout">入力がないとき手をおろす</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand">右手のマウス動作をFPS対策モードにする</sys:String>
     <sys:String x:Key="Motion_Arm_FpsAssumedRightHand_Tooltip">オンにするとPC用のFPSを遊ぶときのマウス動作が自然になりますが、ペンタブ作業や画面タッチへの反応が悪くなります。</sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -208,6 +208,7 @@
                             <RowDefinition/>
                             <RowDefinition/>
                             <RowDefinition/>
+                            <RowDefinition/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -216,30 +217,50 @@
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Row="0" Grid.Column="0"
-                                       Text="{DynamicResource Motion_Arm_WaistWidth}"/>
+                                   Margin="20,0,5,0"
+                                   IsEnabled="{Binding EnableShoulderMotionModify.Value}"
+                                   Text="{DynamicResource Motion_Arm_ShoulderRotationOffset}"/>
                         <Slider Grid.Row="0" Grid.Column="1"
+                                x:Name="sliderShoulderRotationOffset"
+                                Minimum="-200"
+                                Maximum="200"
+                                SmallChange="1"
+                                LargeChange="10"
+                                TickFrequency="1"
+                                IsSnapToTickEnabled="True"
+                                IsEnabled="{Binding EnableShoulderMotionModify.Value}"
+                                Value="{Binding ShoulderRotationOffset.Value, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="0" Grid.Column="2"
+                                 IsEnabled="{Binding EnableShoulderMotionModify.Value}"
+                                 Text="{Binding Value, ElementName=sliderShoulderRotationOffset}"
+                                 />
+
+                        <TextBlock Grid.Row="1" Grid.Column="0"
+                                       Text="{DynamicResource Motion_Arm_WaistWidth}"/>
+                        <Slider Grid.Row="1" Grid.Column="1"
                                 x:Name="sliderSpineWaistWidth"
                                 Minimum="1"
                                 Maximum="100"
                                 Value="{Binding WaistWidth.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="0" Grid.Column="2"
+                        <TextBox Grid.Row="1" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderSpineWaistWidth}"
                                  />
 
-                        <TextBlock Grid.Row="1" Grid.Column="0"
+                        <TextBlock Grid.Row="2" Grid.Column="0"
                                        Text="{DynamicResource Motion_Arm_ElbowCloseStrength}"/>
-                        <Slider Grid.Row="1" Grid.Column="1"
+                        <Slider Grid.Row="2" Grid.Column="1"
                                 x:Name="sliderElbowCloseStrength"
                                 Minimum="0"
                                 Maximum="100"
                                 Value="{Binding ElbowCloseStrength.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="1" Grid.Column="2"
+                        <TextBox Grid.Row="2" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderElbowCloseStrength}"
                                  />
 
-                        <CheckBox Grid.Row="2" Grid.Column="0"
+                        <CheckBox Grid.Row="3" Grid.Column="0"
                                   Grid.ColumnSpan="3"
                                   Margin="5" 
                                   Content="{DynamicResource Motion_Arm_FpsAssumedRightHand}"

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
@@ -163,6 +163,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
 
         public RProperty<bool> EnableHidRandomTyping => _model.EnableHidRandomTyping;
         public RProperty<bool> EnableShoulderMotionModify => _model.EnableShoulderMotionModify;
+        public RProperty<int> ShoulderRotationOffset => _model.ShoulderRotationOffset;
         public RProperty<bool> EnableHandDownTimeout => _model.EnableHandDownTimeout;
         public RProperty<int> WaistWidth => _model.WaistWidth;
         public RProperty<int> ElbowCloseStrength => _model.ElbowCloseStrength;


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature
- [x] Improve existing feature

## What the PR does

fixes #1274 

- issue側にも書いてるが、実用上は主に怒り肩を防ぐ(マイナス値を入れる)ために使うのを期待した機能
- いちおう `[-20deg, +20deg]` の範囲で調整できるようにしてるが、実際そこまで大きい値にするのは想定してないのと、IK計算の影響も受けるから実際にこの値で効いてるわけではないかも
 
## How to confirm

- Unity Editor + WPF Buildで実際に動作すること
- とくにプラス値で肩が上がってマイナスで下がること