### PR TITLE
背骨ボーンの曲がり具合を調整する機能を追加

### DIFF
--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
@@ -7,7 +7,7 @@ namespace Baku.VMagicMirror
 {
     public class SpineBoneModifier : PresenterBase
     {
-        private const float PositiveAngleFactor = 0.3f;
+        private const float PositiveAngleFactor = 0.4f;
         private const float NegativeAngleFactor = 0.2f;
         private readonly IMessageReceiver _receiver;
         private readonly IVRMLoadable _vrmLoadable;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
@@ -1,28 +1,26 @@
+using System.Collections.Generic;
 using R3;
+using RootMotion.FinalIK;
 using UnityEngine;
-using Zenject;
 
 namespace Baku.VMagicMirror
 {
     public class SpineBoneModifier : PresenterBase
     {
+        private const float PositiveAngleFactor = 0.3f;
+        private const float NegativeAngleFactor = 0.2f;
         private readonly IMessageReceiver _receiver;
         private readonly IVRMLoadable _vrmLoadable;
 
         private bool _hasModel;
-        private static readonly float[] SpineBoneAngleWeights = { 0.4f, 0.4f, 0.2f };
-        private readonly Transform[] _spineBones = new Transform[3];
+        private readonly List<Transform> _spineBones = new(3);
         // neckがない場合はhead
         private Transform _neckBone;
-        // shoulderがない場合はupperArm
-        private Transform _leftShoulder;
-        private Transform _rightShoulder;
+        private FullBodyBipedIK _fbbik;
         
         private readonly ReactiveProperty<int> _spineAngleOffset = new(0);
         
-        public SpineBoneModifier(
-            IMessageReceiver receiver,
-            IVRMLoadable vrmLoadable)
+        public SpineBoneModifier(IMessageReceiver receiver, IVRMLoadable vrmLoadable)
         {
             _receiver = receiver;
             _vrmLoadable = vrmLoadable;
@@ -38,20 +36,15 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _spineBones[0] = info.AvatarBones.Spine;
-            _spineBones[1] = info.AvatarBones.Chest;
-            _spineBones[2] = info.AvatarBones.UpperChest;
-            if (_spineBones[1] == null) _spineBones[1] = _spineBones[0];
-            if (_spineBones[2] == null) _spineBones[2] = _spineBones[1];
+            if (info.AvatarBones.Spine != null) _spineBones.Add(info.AvatarBones.Spine);
+            if (info.AvatarBones.Chest != null) _spineBones.Add(info.AvatarBones.Chest);
+            if (info.AvatarBones.UpperChest != null) _spineBones.Add(info.AvatarBones.UpperChest);
 
             _neckBone = info.AvatarBones.Neck;
             if (_neckBone == null) _neckBone = info.AvatarBones.Head;
-            
-            _leftShoulder = info.AvatarBones.LeftShoulder;
-            if (_leftShoulder == null) _leftShoulder = info.AvatarBones.LeftUpperArm;
 
-            _rightShoulder = info.AvatarBones.RightShoulder;
-            if (_rightShoulder == null) _rightShoulder = info.AvatarBones.RightUpperArm;
+            _fbbik = info.FbbIk;
+            _fbbik.solver.OnPreRead += Apply;
             
             _hasModel = true;
         }
@@ -59,32 +52,33 @@ namespace Baku.VMagicMirror
         private void OnVrmUnloaded()
         {
             _hasModel = false;
-            _spineBones[0] = null;
-            _spineBones[1] = null;
-            _spineBones[2] = null;
+            
+            if (_fbbik != null)
+            {
+                _fbbik.solver.OnPreRead -= Apply;
+            }
+            _fbbik = null;
+            _spineBones.Clear();
             _neckBone = null;
-            _leftShoulder = null;
-            _rightShoulder = null;
         }
 
-        public void Apply()
+        private void Apply()
         {
-            if (!_hasModel)
+            if (!_hasModel || _spineAngleOffset.CurrentValue == 0)
             {
                 return;
             }
 
-            var angle = (float) _spineAngleOffset.CurrentValue;
-            for (var i = 0; i < _spineBones.Length; i++)
+            var angleFactor = _spineAngleOffset.CurrentValue > 0 ? PositiveAngleFactor : NegativeAngleFactor;
+            var angle = _spineAngleOffset.CurrentValue * angleFactor;
+            var dividedAngle = angle / _spineBones.Count;
+            foreach (var spineBone in _spineBones)
             {
-                var spineBone = _spineBones[i];
-                spineBone.localRotation *= Quaternion.Euler(angle * SpineBoneAngleWeights[i], 0, 0);
+                spineBone.localRotation *= Quaternion.Euler(dividedAngle, 0, 0);
             }
 
-            // 肩ボーンも逆回転させないと腕が後ろ向きになっちゃうので少し打ち消す。多少腰より後ろに行くようにする
+            // 腰を曲げたぶんが頭の向きに影響しないように打ち消す
             _neckBone.localRotation *= Quaternion.Euler(-angle, 0, 0);
-            _leftShoulder.localRotation *= Quaternion.Euler(-angle * .4f, 0, 0);
-            _rightShoulder.localRotation *= Quaternion.Euler(-angle * .4f, 0, 0);
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
@@ -4,7 +4,7 @@ using Zenject;
 
 namespace Baku.VMagicMirror
 {
-    public class SpineBoneModifier : PresenterBase, ITickable
+    public class SpineBoneModifier : PresenterBase
     {
         private readonly IMessageReceiver _receiver;
         private readonly IVRMLoadable _vrmLoadable;
@@ -67,8 +67,6 @@ namespace Baku.VMagicMirror
             _rightShoulder = null;
         }
 
-        void ITickable.Tick() => Apply();
-        
         public void Apply()
         {
             if (!_hasModel)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
@@ -1,18 +1,23 @@
-using System.Collections.Generic;
 using R3;
 using UnityEngine;
+using Zenject;
 
 namespace Baku.VMagicMirror
 {
-    public class SpineBoneModifier : PresenterBase
+    public class SpineBoneModifier : PresenterBase, ITickable
     {
         private readonly IMessageReceiver _receiver;
         private readonly IVRMLoadable _vrmLoadable;
 
         private bool _hasModel;
-        private readonly List<Transform> _spineBones = new();
-        // NOTE: neckがない場合はheadが入る
+        private static readonly float[] SpineBoneAngleWeights = { 0.4f, 0.4f, 0.2f };
+        private readonly Transform[] _spineBones = new Transform[3];
+        // neckがない場合はhead
         private Transform _neckBone;
+        // shoulderがない場合はupperArm
+        private Transform _leftShoulder;
+        private Transform _rightShoulder;
+        
         private readonly ReactiveProperty<int> _spineAngleOffset = new(0);
         
         public SpineBoneModifier(
@@ -33,16 +38,20 @@ namespace Baku.VMagicMirror
 
         private void OnVrmLoaded(VrmLoadedInfo info)
         {
-            _spineBones.Clear();
-            if (info.AvatarBones.Spine != null) _spineBones.Add(info.AvatarBones.Spine);
-            if (info.AvatarBones.Chest != null) _spineBones.Add(info.AvatarBones.Chest);
-            if (info.AvatarBones.UpperChest != null) _spineBones.Add(info.AvatarBones.UpperChest);
+            _spineBones[0] = info.AvatarBones.Spine;
+            _spineBones[1] = info.AvatarBones.Chest;
+            _spineBones[2] = info.AvatarBones.UpperChest;
+            if (_spineBones[1] == null) _spineBones[1] = _spineBones[0];
+            if (_spineBones[2] == null) _spineBones[2] = _spineBones[1];
 
             _neckBone = info.AvatarBones.Neck;
-            if (_neckBone == null)
-            {
-                _neckBone = info.AvatarBones.Head;
-            }
+            if (_neckBone == null) _neckBone = info.AvatarBones.Head;
+            
+            _leftShoulder = info.AvatarBones.LeftShoulder;
+            if (_leftShoulder == null) _leftShoulder = info.AvatarBones.LeftUpperArm;
+
+            _rightShoulder = info.AvatarBones.RightShoulder;
+            if (_rightShoulder == null) _rightShoulder = info.AvatarBones.RightUpperArm;
             
             _hasModel = true;
         }
@@ -50,10 +59,16 @@ namespace Baku.VMagicMirror
         private void OnVrmUnloaded()
         {
             _hasModel = false;
-            _spineBones.Clear();
+            _spineBones[0] = null;
+            _spineBones[1] = null;
+            _spineBones[2] = null;
             _neckBone = null;
+            _leftShoulder = null;
+            _rightShoulder = null;
         }
 
+        void ITickable.Tick() => Apply();
+        
         public void Apply()
         {
             if (!_hasModel)
@@ -61,7 +76,17 @@ namespace Baku.VMagicMirror
                 return;
             }
 
-            // TODO: なんかする
+            var angle = (float) _spineAngleOffset.CurrentValue;
+            for (var i = 0; i < _spineBones.Length; i++)
+            {
+                var spineBone = _spineBones[i];
+                spineBone.localRotation *= Quaternion.Euler(angle * SpineBoneAngleWeights[i], 0, 0);
+            }
+
+            // 肩ボーンも逆回転させないと腕が後ろ向きになっちゃうので少し打ち消す。多少腰より後ろに行くようにする
+            _neckBone.localRotation *= Quaternion.Euler(-angle, 0, 0);
+            _leftShoulder.localRotation *= Quaternion.Euler(-angle * .4f, 0, 0);
+            _rightShoulder.localRotation *= Quaternion.Euler(-angle * .4f, 0, 0);
         }
     }
 }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using R3;
+using UnityEngine;
+
+namespace Baku.VMagicMirror
+{
+    public class SpineBoneModifier : PresenterBase
+    {
+        private readonly IMessageReceiver _receiver;
+        private readonly IVRMLoadable _vrmLoadable;
+
+        private bool _hasModel;
+        private readonly List<Transform> _spineBones = new();
+        // NOTE: neckがない場合はheadが入る
+        private Transform _neckBone;
+        private readonly ReactiveProperty<int> _spineAngleOffset = new(0);
+        
+        public SpineBoneModifier(
+            IMessageReceiver receiver,
+            IVRMLoadable vrmLoadable)
+        {
+            _receiver = receiver;
+            _vrmLoadable = vrmLoadable;
+        }
+        
+        public override void Initialize()
+        {
+            _receiver.BindIntProperty(VmmCommands.SetSpineAngleOffset, _spineAngleOffset);
+
+            _vrmLoadable.VrmLoaded += OnVrmLoaded;
+            _vrmLoadable.VrmDisposing += OnVrmUnloaded;
+        }
+
+        private void OnVrmLoaded(VrmLoadedInfo info)
+        {
+            _spineBones.Clear();
+            if (info.AvatarBones.Spine != null) _spineBones.Add(info.AvatarBones.Spine);
+            if (info.AvatarBones.Chest != null) _spineBones.Add(info.AvatarBones.Chest);
+            if (info.AvatarBones.UpperChest != null) _spineBones.Add(info.AvatarBones.UpperChest);
+
+            _neckBone = info.AvatarBones.Neck;
+            if (_neckBone == null)
+            {
+                _neckBone = info.AvatarBones.Head;
+            }
+            
+            _hasModel = true;
+        }
+
+        private void OnVrmUnloaded()
+        {
+            _hasModel = false;
+            _spineBones.Clear();
+            _neckBone = null;
+        }
+
+        public void Apply()
+        {
+            if (!_hasModel)
+            {
+                return;
+            }
+
+            // TODO: なんかする
+        }
+    }
+}

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs.meta
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/Body/SpineBoneModifier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e5a418cbad37b447a3b8e0cac716322

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
@@ -55,10 +55,10 @@ namespace Baku.VMagicMirror
                 _rightLegIk.solver.Update();
             }
 
+            _spineBoneModifier.Apply();
             _mediaPipeHandLocalRotLimiter.LateUpdate();
             _vrmaMotionSetter.ApplyUpdate();
             _armMuscleInterpolator.Update();
-            _spineBoneModifier.Apply();
         }
 
         private void OnVrmLoaded(VrmLoadedInfo info)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
@@ -13,7 +13,6 @@ namespace Baku.VMagicMirror
         private readonly MediaPipeHandLocalRotLimiter _mediaPipeHandLocalRotLimiter;
         private readonly VrmaMotionSetter _vrmaMotionSetter;
         private readonly ArmMuscleInterpolator _armMuscleInterpolator;
-        private readonly SpineBoneModifier _spineBoneModifier;
         private LimbIK _leftLegIk;
         private LimbIK _rightLegIk;
         private bool _hasModel;
@@ -33,7 +32,6 @@ namespace Baku.VMagicMirror
             _mediaPipeHandLocalRotLimiter = mediaPipeHandLocalRotLimiter;
             _vrmaMotionSetter = vrmaMotionSetter;
             _armMuscleInterpolator = armMuscleInterpolator;
-            _spineBoneModifier = spineBoneModifier;
         }
         
         public override void Initialize()
@@ -55,7 +53,6 @@ namespace Baku.VMagicMirror
                 _rightLegIk.solver.Update();
             }
 
-            _spineBoneModifier.Apply();
             _mediaPipeHandLocalRotLimiter.LateUpdate();
             _vrmaMotionSetter.ApplyUpdate();
             _armMuscleInterpolator.Update();

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
@@ -23,8 +23,7 @@ namespace Baku.VMagicMirror
             IVRMLoadable vrmLoadable,
             MediaPipeHandLocalRotLimiter mediaPipeHandLocalRotLimiter,
             VrmaMotionSetter vrmaMotionSetter,
-            ArmMuscleInterpolator armMuscleInterpolator,
-            SpineBoneModifier spineBoneModifier
+            ArmMuscleInterpolator armMuscleInterpolator
             )
         {
             _source = source;

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/AvatarControl/Motion/LateUpdateAfterFinalIKRunner.cs
@@ -13,6 +13,7 @@ namespace Baku.VMagicMirror
         private readonly MediaPipeHandLocalRotLimiter _mediaPipeHandLocalRotLimiter;
         private readonly VrmaMotionSetter _vrmaMotionSetter;
         private readonly ArmMuscleInterpolator _armMuscleInterpolator;
+        private readonly SpineBoneModifier _spineBoneModifier;
         private LimbIK _leftLegIk;
         private LimbIK _rightLegIk;
         private bool _hasModel;
@@ -23,7 +24,8 @@ namespace Baku.VMagicMirror
             IVRMLoadable vrmLoadable,
             MediaPipeHandLocalRotLimiter mediaPipeHandLocalRotLimiter,
             VrmaMotionSetter vrmaMotionSetter,
-            ArmMuscleInterpolator armMuscleInterpolator
+            ArmMuscleInterpolator armMuscleInterpolator,
+            SpineBoneModifier spineBoneModifier
             )
         {
             _source = source;
@@ -31,6 +33,7 @@ namespace Baku.VMagicMirror
             _mediaPipeHandLocalRotLimiter = mediaPipeHandLocalRotLimiter;
             _vrmaMotionSetter = vrmaMotionSetter;
             _armMuscleInterpolator = armMuscleInterpolator;
+            _spineBoneModifier = spineBoneModifier;
         }
         
         public override void Initialize()
@@ -55,6 +58,7 @@ namespace Baku.VMagicMirror
             _mediaPipeHandLocalRotLimiter.LateUpdate();
             _vrmaMotionSetter.ApplyUpdate();
             _armMuscleInterpolator.Update();
+            _spineBoneModifier.Apply();
         }
 
         private void OnVrmLoaded(VrmLoadedInfo info)

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Installer/MotionCalculationInstaller.cs
@@ -56,6 +56,7 @@ namespace Baku.VMagicMirror.Installer
             container.Bind<LateUpdateSourceAfterFinalIK>().FromNewComponentOnNewGameObject().AsSingle();
 
             container.BindInterfacesAndSelfTo<ArmMuscleInterpolator>().AsSingle();
+            container.BindInterfacesAndSelfTo<SpineBoneModifier>().AsSingle();
             container.BindInterfacesTo<LateUpdateAfterFinalIKRunner>().AsSingle();
         }
     }

--- a/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
+++ b/VMagicMirror/Assets/Baku/VMagicMirror/Scripts/Interprocess/IpcMessage/VmmCommands.cs
@@ -100,6 +100,7 @@
         EnableGameInputLocomotionMode,
         EnableTwistBodyMotion,
         EnableBodyLeanZ,
+        SetSpineAngleOffset, // 1deg刻みの値で、Spine ~ UpperChestに回転が分配される
 
         // Motion, Face
         EnableFaceTracking,

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -205,14 +205,19 @@
             GamepadMotionMode = 0;
 
             EnableHidRandomTyping = false;
-            EnableShoulderMotionModify = true;
-            ShoulderRotationOffset = 0;
             EnableHandDownTimeout = true;
             WaistWidth = 30;
             ElbowCloseStrength = 30;
             EnableFpsAssumedRightHand = false;
             ShowPresentationPointer = false;
             PresentationArmRadiusMin = 20;
+        }
+
+        public void ResetShoulderAndBackSetting()
+        {
+            SpineAngleOffset = 0;
+            EnableShoulderMotionModify = true;
+            ShoulderRotationOffset = 0;
         }
 
         public void ResetHandSetting()
@@ -234,12 +239,12 @@
             EnableNoHandTrackMode = false;
             EnableGameInputLocomotionMode = false;
             EnableTwistBodyMotion = false;
-            SpineAngleOffset = 0;
             EnableCustomHandDownPose = false;
             CustomHandDownPose = "";
             ResetFaceBasicSetting();
             ResetFaceEyeSetting();
             ResetFaceBlendShapeSetting();
+            ResetShoulderAndBackSetting();
             ResetArmSetting();
             ResetHandSetting();
             ResetWaitMotionSetting();

--- a/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
+++ b/WPF/VMagicMirrorConfig/Model/Entity/MotionSetting.cs
@@ -23,6 +23,8 @@
 
         public bool EnableTwistBodyMotion { get; set; } = false;
 
+        public int SpineAngleOffset { get; set; } = 0;
+
         public bool EnableCustomHandDownPose { get; set; } = false;
 
         //NOTE: jsonがUnityから飛んでくるのを保持するだけ
@@ -232,6 +234,7 @@
             EnableNoHandTrackMode = false;
             EnableGameInputLocomotionMode = false;
             EnableTwistBodyMotion = false;
+            SpineAngleOffset = 0;
             EnableCustomHandDownPose = false;
             CustomHandDownPose = "";
             ResetFaceBasicSetting();

--- a/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
+++ b/WPF/VMagicMirrorConfig/Model/InterProcess/Core/MessageFactory.cs
@@ -85,6 +85,7 @@ namespace Baku.VMagicMirrorConfig
         public static Message EnableNoHandTrackMode(bool enable) => BoolContent(VmmCommands.EnableNoHandTrackMode, enable);
         public static Message EnableGameInputLocomotionMode(bool enable) => BoolContent(VmmCommands.EnableGameInputLocomotionMode, enable);
         public static Message EnableTwistBodyMotion(bool enable) => BoolContent(VmmCommands.EnableTwistBodyMotion, enable);
+        public static Message SetSpineAngleOffset(int offset) => IntContent(VmmCommands.SetSpineAngleOffset, offset);
 
         public static Message EnableCustomHandDownPose(bool enable) => BoolContent(VmmCommands.EnableCustomHandDownPose, enable);
         public static Message SetHandDownModeCustomPose(string poseJson) => StringContent(VmmCommands.SetHandDownModeCustomPose, poseJson);

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -38,6 +38,7 @@ namespace Baku.VMagicMirrorConfig
                 setting.EnableGameInputLocomotionMode, v => SendMessage(MessageFactory.EnableGameInputLocomotionMode(v))
                 );
             EnableTwistBodyMotion = new RProperty<bool>(setting.EnableTwistBodyMotion, v => SendMessage(MessageFactory.EnableTwistBodyMotion(v)));
+            SpineAngleOffset = new RProperty<int>(setting.SpineAngleOffset, v => SendMessage(MessageFactory.SetSpineAngleOffset(v)));
             EnableCustomHandDownPose = new RProperty<bool>(setting.EnableCustomHandDownPose, v => SendMessage(MessageFactory.EnableCustomHandDownPose(v)));
             CustomHandDownPose = new RProperty<string>(setting.CustomHandDownPose, v => SendMessage(MessageFactory.SetHandDownModeCustomPose(v)));
 
@@ -191,6 +192,8 @@ namespace Baku.VMagicMirrorConfig
         public RProperty<bool> EnableGameInputLocomotionMode { get; }
 
         public RProperty<bool> EnableTwistBodyMotion { get; }
+
+        public RProperty<int> SpineAngleOffset { get; }
 
         public RProperty<bool> EnableCustomHandDownPose { get; }
 
@@ -398,6 +401,7 @@ namespace Baku.VMagicMirrorConfig
             EnableNoHandTrackMode.Value = setting.EnableNoHandTrackMode;
             EnableGameInputLocomotionMode.Value = setting.EnableGameInputLocomotionMode;
             EnableTwistBodyMotion.Value = setting.EnableTwistBodyMotion;
+            SpineAngleOffset.Value = setting.SpineAngleOffset;
             EnableCustomHandDownPose.Value = setting.EnableCustomHandDownPose;
             ResetFaceBasicSetting();
             ResetFaceEyeSetting();

--- a/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
+++ b/WPF/VMagicMirrorConfig/Model/SettingModel/MotionSettingModel.cs
@@ -369,14 +369,20 @@ namespace Baku.VMagicMirrorConfig
             GamepadMotionMode.Value = setting.GamepadMotionMode;
 
             EnableHidRandomTyping.Value = setting.EnableHidRandomTyping;
-            EnableShoulderMotionModify.Value = setting.EnableShoulderMotionModify;
-            ShoulderRotationOffset.Value = setting.ShoulderRotationOffset;
             EnableHandDownTimeout.Value = setting.EnableHandDownTimeout;
             WaistWidth.Value = setting.WaistWidth;
             ElbowCloseStrength.Value = setting.ElbowCloseStrength;
             EnableFpsAssumedRightHand.Value = setting.EnableFpsAssumedRightHand;
             ShowPresentationPointer.Value = setting.ShowPresentationPointer;
             PresentationArmRadiusMin.Value = setting.PresentationArmRadiusMin;
+        }
+
+        public void ResetShoulderAndBackSetting()
+        {
+            var setting = MotionSetting.Default;
+            SpineAngleOffset.Value = setting.SpineAngleOffset;
+            EnableShoulderMotionModify.Value = setting.EnableShoulderMotionModify;
+            ShoulderRotationOffset.Value = setting.ShoulderRotationOffset;
         }
 
         public void ResetHandSetting()
@@ -401,11 +407,11 @@ namespace Baku.VMagicMirrorConfig
             EnableNoHandTrackMode.Value = setting.EnableNoHandTrackMode;
             EnableGameInputLocomotionMode.Value = setting.EnableGameInputLocomotionMode;
             EnableTwistBodyMotion.Value = setting.EnableTwistBodyMotion;
-            SpineAngleOffset.Value = setting.SpineAngleOffset;
             EnableCustomHandDownPose.Value = setting.EnableCustomHandDownPose;
             ResetFaceBasicSetting();
             ResetFaceEyeSetting();
             ResetFaceBlendShapeSetting();
+            ResetShoulderAndBackSetting();
             ResetArmSetting();
             ResetHandSetting();
             ResetWaitMotionSetting();

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -385,6 +385,7 @@ Restart (turn off and on) the buddy to get more detailed log.</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode">Always-Hands-Down Mode (*Increase body move)</sys:String>    
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">Hands-Down Mode</sys:String>    
     <sys:String x:Key="Motion_FullBody_TwistBodyMotion">Enable Twist Motion</sys:String>    
+    <sys:String x:Key="Motion_FullBody_SpineAngleOffset">Bend Back</sys:String>
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose">Custom Hand Down Pose</sys:String>    
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Notice">*Pose adjuster appears on Free Layout Mode</sys:String>
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_AlwaysDownWarning" xml:space="preserve">To edit hand pose,

--- a/WPF/VMagicMirrorConfig/Resources/English.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/English.xaml
@@ -393,7 +393,9 @@ Restart (turn off and on) the buddy to get more detailed log.</sys:String>
 - Turn on "Free Layout Mode"</sys:String>
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Reset">Reset Hand Down Pose to Default</sys:String>
     <sys:String x:Key="Motion_FullBody_OpenGameInputSetting">Game Locomotion Setting...</sys:String>
-    
+
+    <sys:String x:Key="Motion_ShoulderAndBack">Shoulder / Back</sys:String>
+
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">Arm</sys:String>    
     <sys:String x:Key="Motion_Arm_EnableHidMotion">Enable Typing / Mouse Motion</sys:String>

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -385,6 +385,7 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode">つねに手下げモード (※体の動きが増えます)</sys:String>    
     <sys:String x:Key="Motion_FullBody_NoHandTrackMode_Streaming">つねに手下げモード</sys:String>    
     <sys:String x:Key="Motion_FullBody_TwistBodyMotion">ひねりモーション</sys:String>    
+    <sys:String x:Key="Motion_FullBody_SpineAngleOffset">背中を曲げる</sys:String>
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose">手を下げた位置を手動で調整</sys:String>    
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_AlwaysDownWarning" xml:space="preserve">手の位置を編集するには
 「つねに手下げモード」がオンの状態で

--- a/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
+++ b/WPF/VMagicMirrorConfig/Resources/Japanese.xaml
@@ -392,7 +392,9 @@ png画像やglb/gltfモデルが利用可能です。</sys:String>
 フリーレイアウトモードを有効にします</sys:String>
     <sys:String x:Key="Motion_FullBody_EnableCustomHandDownPose_Reset">手の位置をデフォルトにリセット</sys:String>
     <sys:String x:Key="Motion_FullBody_OpenGameInputSetting">ゲーム入力の詳細設定…</sys:String>
-    
+
+    <sys:String x:Key="Motion_ShoulderAndBack">肩・背中</sys:String>
+
     <!-- Motion : Arm -->
     <sys:String x:Key="Motion_Arm">腕・ひじ</sys:String>
     <sys:String x:Key="Motion_Arm_EnableHidMotion">タイピング / マウス動作を反映</sys:String>

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -135,8 +135,8 @@
                                        Text="{DynamicResource Motion_FullBody_SpineAngleOffset}"/>
                             <Slider Grid.Column="1"
                                     x:Name="sliderSpineAngleOffset"
-                                    Minimum="-30"
-                                    Maximum="30"
+                                    Minimum="-100"
+                                    Maximum="100"
                                     SmallChange="1"
                                     LargeChange="10"
                                     TickFrequency="1"

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -55,6 +55,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -121,17 +122,43 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
 
-                        <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                        <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
+                              Margin="5,5,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="3*" />
+                                <ColumnDefinition Width="1*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0"
+                                       VerticalAlignment="Center"
+                                       Text="{DynamicResource Motion_FullBody_SpineAngleOffset}"/>
+                            <Slider Grid.Column="1"
+                                    x:Name="sliderSpineAngleOffset"
+                                    Minimum="-30"
+                                    Maximum="30"
+                                    SmallChange="1"
+                                    LargeChange="10"
+                                    TickFrequency="1"
+                                    IsSnapToTickEnabled="True"
+                                    Value="{Binding SpineAngleOffset.Value, Mode=TwoWay}"
+                                    />
+                            <TextBox Grid.Column="2"
+                                     Text="{Binding Value, ElementName=sliderSpineAngleOffset}"
+                                     />
+                        </Grid>
+
+                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                                   Margin="5,15,5,0"
                                   IsChecked="{Binding EnableCustomHandDownPose.Value}"
                                   Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose}"/>
-                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                        <CheckBox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
                                   Margin="20,2,15,5"
                                   Visibility="{Binding EnableCustomHandDownPose.Value,
                                                       Converter={StaticResource BooleanToVisibilityConverter}}"
                                   IsChecked="{Binding EnableDeviceFreeLayout.Value}"
                                   Content="{DynamicResource Layout_DeviceFreeLayout}"/>
-                        <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
+                        <Button Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
                                 Width="NaN"
                                 HorizontalAlignment="Left"
                                 Margin="20,5"
@@ -140,7 +167,7 @@
                                 Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose_Reset}"
                                 Command="{Binding ResetCustomHandDownPoseCommand}"
                                 />
-                        <Border Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
+                        <Border Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
                                 Style="{StaticResource SideMarginSectionBorder}"
                                 HorizontalAlignment="Left"
                                 Margin="20,5,10,5"
@@ -160,7 +187,7 @@
                             </StackPanel>
                         </Border>
 
-                        <Button Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
+                        <Button Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2"
                                 Width="NaN"
                                 HorizontalAlignment="Left"
                                 Margin="20,5"

--- a/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
+++ b/WPF/VMagicMirrorConfig/View/SettingWindowTabs/MotionSettingPanel.xaml
@@ -35,9 +35,6 @@
                     <StackPanel Orientation="Horizontal"
                                 Margin="5"
                                 >
-                        <md:PackIcon Kind="HumanHandsdown"
-                                     Style="{StaticResource SettingHeaderPackIcon}"
-                                     />
                         <TextBlock Text="{DynamicResource Motion_FullBody}"
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
@@ -46,7 +43,6 @@
 
                     <Grid Margin="10,5">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
@@ -122,43 +118,17 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
 
-                        <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
-                              Margin="5,5,0,0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="3*" />
-                                <ColumnDefinition Width="1*"/>
-                            </Grid.ColumnDefinitions>
-
-                            <TextBlock Grid.Column="0"
-                                       VerticalAlignment="Center"
-                                       Text="{DynamicResource Motion_FullBody_SpineAngleOffset}"/>
-                            <Slider Grid.Column="1"
-                                    x:Name="sliderSpineAngleOffset"
-                                    Minimum="-100"
-                                    Maximum="100"
-                                    SmallChange="1"
-                                    LargeChange="10"
-                                    TickFrequency="1"
-                                    IsSnapToTickEnabled="True"
-                                    Value="{Binding SpineAngleOffset.Value, Mode=TwoWay}"
-                                    />
-                            <TextBox Grid.Column="2"
-                                     Text="{Binding Value, ElementName=sliderSpineAngleOffset}"
-                                     />
-                        </Grid>
-
-                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+                        <CheckBox Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                                   Margin="5,15,5,0"
                                   IsChecked="{Binding EnableCustomHandDownPose.Value}"
                                   Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose}"/>
-                        <CheckBox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
+                        <CheckBox Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                                   Margin="20,2,15,5"
                                   Visibility="{Binding EnableCustomHandDownPose.Value,
                                                       Converter={StaticResource BooleanToVisibilityConverter}}"
                                   IsChecked="{Binding EnableDeviceFreeLayout.Value}"
                                   Content="{DynamicResource Layout_DeviceFreeLayout}"/>
-                        <Button Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
+                        <Button Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
                                 Width="NaN"
                                 HorizontalAlignment="Left"
                                 Margin="20,5"
@@ -167,7 +137,7 @@
                                 Content="{DynamicResource Motion_FullBody_EnableCustomHandDownPose_Reset}"
                                 Command="{Binding ResetCustomHandDownPoseCommand}"
                                 />
-                        <Border Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
+                        <Border Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
                                 Style="{StaticResource SideMarginSectionBorder}"
                                 HorizontalAlignment="Left"
                                 Margin="20,5,10,5"
@@ -187,7 +157,7 @@
                             </StackPanel>
                         </Border>
 
-                        <Button Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2"
+                        <Button Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
                                 Width="NaN"
                                 HorizontalAlignment="Left"
                                 Margin="20,5"
@@ -208,32 +178,22 @@
                     <StackPanel Orientation="Horizontal"
                                 Margin="5"
                                 >
-
-                        <md:PackIcon Kind="HumanGreeting"
-                                     Style="{StaticResource SettingHeaderPackIcon}"
-                                     />
-
-                        <TextBlock Text="{DynamicResource Motion_Arm}"
+                        <TextBlock Text="{DynamicResource Motion_ShoulderAndBack}"
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"
                                    />
-
                         <Button Style="{StaticResource CategorySettingResetButton}"
-                                Command="{Binding ResetArmMotionSettingCommand}"
+                                Command="{Binding ResetShoulderAndBackMotionSettingCommand}"
                                 />
                     </StackPanel>
-
 
                     <CheckBox Margin="15,0" 
                               Content="{DynamicResource Motion_Arm_EnableShoulderModify}"
                               IsChecked="{Binding EnableShoulderMotionModify.Value}"
                               />
 
-
                     <Grid Margin="5,0,0,10">
                         <Grid.RowDefinitions>
-                            <RowDefinition/>
-                            <RowDefinition/>
                             <RowDefinition/>
                             <RowDefinition/>
                         </Grid.RowDefinitions>
@@ -264,30 +224,79 @@
                                  />
 
                         <TextBlock Grid.Row="1" Grid.Column="0"
-                                       Text="{DynamicResource Motion_Arm_WaistWidth}"/>
+                                   Text="{DynamicResource Motion_FullBody_SpineAngleOffset}"/>
                         <Slider Grid.Row="1" Grid.Column="1"
+                                x:Name="sliderSpineAngleOffset"
+                                Minimum="-100"
+                                Maximum="100"
+                                SmallChange="1"
+                                LargeChange="10"
+                                TickFrequency="1"
+                                IsSnapToTickEnabled="True"
+                                Value="{Binding SpineAngleOffset.Value, Mode=TwoWay}"
+                                />
+                        <TextBox Grid.Row="1" Grid.Column="2"
+                                 Text="{Binding Value, ElementName=sliderSpineAngleOffset}"
+                                 />
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <Border Style="{StaticResource SideMarginSectionBorder}">
+                <StackPanel>
+
+                    <StackPanel Orientation="Horizontal"
+                                Margin="5"
+                                >
+
+                        <TextBlock Text="{DynamicResource Motion_Arm}"
+                                   Style="{StaticResource HeaderText}"
+                                   Margin="5"
+                                   />
+
+                        <Button Style="{StaticResource CategorySettingResetButton}"
+                                Command="{Binding ResetArmMotionSettingCommand}"
+                                />
+                    </StackPanel>
+
+
+                    <Grid Margin="5,0,0,10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="3*" />
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Row="0" Grid.Column="0"
+                                       Text="{DynamicResource Motion_Arm_WaistWidth}"/>
+                        <Slider Grid.Row="0" Grid.Column="1"
                                 x:Name="sliderSpineWaistWidth"
                                 Minimum="1"
                                 Maximum="100"
                                 Value="{Binding WaistWidth.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="1" Grid.Column="2"
+                        <TextBox Grid.Row="0" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderSpineWaistWidth}"
                                  />
 
-                        <TextBlock Grid.Row="2" Grid.Column="0"
+                        <TextBlock Grid.Row="1" Grid.Column="0"
                                        Text="{DynamicResource Motion_Arm_ElbowCloseStrength}"/>
-                        <Slider Grid.Row="2" Grid.Column="1"
+                        <Slider Grid.Row="1" Grid.Column="1"
                                 x:Name="sliderElbowCloseStrength"
                                 Minimum="0"
                                 Maximum="100"
                                 Value="{Binding ElbowCloseStrength.Value, Mode=TwoWay}"
                                 />
-                        <TextBox Grid.Row="2" Grid.Column="2"
+                        <TextBox Grid.Row="1" Grid.Column="2"
                                  Text="{Binding Value, ElementName=sliderElbowCloseStrength}"
                                  />
 
-                        <CheckBox Grid.Row="3" Grid.Column="0"
+                        <CheckBox Grid.Row="2" Grid.Column="0"
                                   Grid.ColumnSpan="3"
                                   Margin="5" 
                                   Content="{DynamicResource Motion_Arm_FpsAssumedRightHand}"
@@ -373,9 +382,6 @@
                     <StackPanel Orientation="Horizontal"
                                 Margin="5"
                                 >
-                        <md:PackIcon Kind="Hand"
-                                     Style="{StaticResource SettingHeaderPackIcon}"
-                                     />
                         <TextBlock Text="{DynamicResource Motion_Hand}"
                                    Margin="5"
                                    Style="{StaticResource HeaderText}"
@@ -443,9 +449,6 @@
                     <StackPanel Orientation="Horizontal"
                                 Margin="5">
 
-                        <md:PackIcon Kind="TimerSand" 
-                                     Style="{StaticResource SettingHeaderPackIcon}"
-                                     />
                         <TextBlock Text="{DynamicResource Motion_Wait}"
                                    Style="{StaticResource HeaderText}"
                                    Margin="5"

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
@@ -26,6 +26,9 @@ namespace Baku.VMagicMirrorConfig.ViewModel
             ResetArmMotionSettingCommand = new ActionCommand(
                  () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetArmSetting)
                  );
+            ResetShoulderAndBackMotionSettingCommand = new ActionCommand(
+                 () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetShoulderAndBackSetting)
+                 );
             ResetHandMotionSettingCommand = new ActionCommand(
                 () => SettingResetUtils.ResetSingleCategoryAsync(_model.ResetHandSetting)
                 );
@@ -186,6 +189,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         public ActionCommand OpenGameInputSettingWindowCommand { get; }
         public ActionCommand ResetCustomHandDownPoseCommand { get; }
         public ActionCommand ResetArmMotionSettingCommand { get; }
+        public ActionCommand ResetShoulderAndBackMotionSettingCommand { get; }
         public ActionCommand ResetHandMotionSettingCommand { get; }
         public ActionCommand ResetWaitMotionSettingCommand { get; }
     }

--- a/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
+++ b/WPF/VMagicMirrorConfig/ViewModel/SettingWindowTab/MotionSettingViewModel.cs
@@ -158,6 +158,7 @@ namespace Baku.VMagicMirrorConfig.ViewModel
         }
 
         public RProperty<bool> EnableTwistBodyMotion => _model.EnableTwistBodyMotion;
+        public RProperty<int> SpineAngleOffset => _model.SpineAngleOffset;
         public RProperty<bool> EnableCustomHandDownPose => _model.EnableCustomHandDownPose;
         public RProperty<bool> EnableDeviceFreeLayout => _layoutModel.EnableDeviceFreeLayout;
 


### PR DESCRIPTION
## PR category

PR type: 

- [x] Add new feature

## What the PR does

fixes #1277 

- Spine ~ UpperChestに曲げ角度を配分する
- NeckとかShoulderは逆方向に曲げて打ち消す(Shoulderは完全に打ち消すとやりすぎなので部分的に戻す)
- #1276 と同じで既定値が0であり、既定値であれば振る舞いが変化しない

## How to confirm

- [x] Unity Editor + WPF Buildで、値に応じて背中の曲がり度合いが変化すること
- [x] 手のIK結果に悪影響がないこと。例えばハンドトラッキングの位置が上がったり下がったりしすぎないこと
- [x] `.vrma` を再生した場合はこの調整が切れてVRMAのモーションが優先されること
- [x] VMC Protocol受信 + 背骨・頭ボーン動作を同時適用するモードのとき、この背骨曲げ補正も適用されること