### PR TITLE
unity CLIを活用する前提でpackageを乗り換える

### DIFF
--- a/VMagicMirror/Packages/manifest.json
+++ b/VMagicMirror/Packages/manifest.json
@@ -28,7 +28,6 @@
     "com.vrmc.gltf": "https://github.com/vrm-c/UniVRM.git?path=/Packages/UniGLTF#v0.131.0",
     "com.vrmc.univrm": "https://github.com/vrm-c/UniVRM.git?path=/Packages/VRM#v0.131.0",
     "com.vrmc.vrm": "https://github.com/vrm-c/UniVRM.git?path=/Packages/VRM10#v0.131.0",
-    "io.github.hatayama.uloopmcp": "https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src",
     "jp.keijiro.klak.spout": "2.0.6",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.adaptiveperformance": "1.0.0",
@@ -63,6 +62,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.pipeline": "0.4.0-exp.1"
   }
 }

--- a/VMagicMirror/Packages/packages-lock.json
+++ b/VMagicMirror/Packages/packages-lock.json
@@ -154,6 +154,20 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.pipeline": {
+      "version": "0.4.0-exp.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.33",
+        "com.unity.nuget.mono-cecil": "1.11.6",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.0.2"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.probuilder": {
       "version": "6.0.9",
       "depth": 0,
@@ -294,16 +308,6 @@
         "com.vrmc.gltf": "0.131.0"
       },
       "hash": "3b99078d26b362733ad9bf463f98c83b8a1b4c9f"
-    },
-    "io.github.hatayama.uloopmcp": {
-      "version": "https://github.com/hatayama/unity-cli-loop.git?path=/Packages/src",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0",
-        "com.unity.nuget.newtonsoft-json": "3.2.1"
-      },
-      "hash": "f2f983ade57a33de7650f504671bb24c70bc6e1a"
     },
     "jp.keijiro.klak.spout": {
       "version": "2.0.6",


### PR DESCRIPTION
## PR category

PR type: 

- [x] Other

## What the PR does

- uloop CLIからの変更
- recompile checkの挙動の特性も改善しそう(pj自体にRoslynが入ってる事との相性が悪くなさそう)なので、exp packageであることのデメリットよりメリットが勝っていると見なして乗り換えます